### PR TITLE
Add stub vc-test-suite driver

### DIFF
--- a/src/bin/ssi-vc-test/README.md
+++ b/src/bin/ssi-vc-test/README.md
@@ -1,0 +1,12 @@
+# ssi-vc-test
+
+Test driver for the SSI VC implementation in [vc-test-suite][]
+
+## Usage
+
+- `cargo build` this repo
+- `git clone` and `npm install` [vc-test-suite][]
+- Copy `config.json` from this `ssi-vc-test` directory into `vc-test-suite`
+- `npm run test` in `vc-test-suite`
+
+[vc-test-suite]: https://github.com/w3c/vc-test-suite

--- a/src/bin/ssi-vc-test/config.json
+++ b/src/bin/ssi-vc-test/config.json
@@ -1,0 +1,15 @@
+{
+  "generator": "../ssi/target/debug/ssi-vc-test generate",
+  "presentationGenerator": "../ssi/target/debug/ssi-vc-test generate-presentation",
+  "generatorOptions": "",
+  "sectionsNotSupported": [
+    "schema",
+    "refresh",
+    "evidence",
+    "status",
+    "tou",
+    "ldp",
+    "jwt",
+    "zkp"
+  ]
+}

--- a/src/bin/ssi-vc-test/main.rs
+++ b/src/bin/ssi-vc-test/main.rs
@@ -1,0 +1,64 @@
+fn usage() {
+    eprintln!("Usage: ssi-vc-test <generate|generate-presentation> <file>");
+}
+
+fn generate(data: &String) -> &String {
+    // TODO
+    return data;
+}
+
+fn generate_presentation(data: &String) -> &String {
+    // TODO
+    return data;
+}
+
+fn read_json(filename: &String) -> String {
+    let mut file = match std::fs::File::open(filename) {
+        Err(err) => panic!("Unable to open {}: {}", filename, err),
+        Ok(file) => file,
+    };
+    let mut data = String::new();
+
+    use std::io::Read;
+    let data = match file.read_to_string(&mut data) {
+        Err(err) => panic!("Unable to read {}: {}", filename, err),
+        Ok(_) => data,
+    };
+    // TODO: parse JSON
+    data
+}
+
+fn write_json(data: &String) {
+    use std::io::Write;
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    match handle.write_all(data.as_bytes()) {
+        Err(err) => panic!("Unable to write output: {}", err),
+        Ok(_) => {}
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        return usage();
+    }
+    let cmd = &args[1];
+    let filename = &args[2];
+    match &cmd[..] {
+        "generate" => {
+            let data: String = read_json(&filename);
+            let output: &String = generate(&data);
+            write_json(&output);
+        }
+        "generate-presentation" => {
+            let data: String = read_json(&filename);
+            let output: &String = generate_presentation(&data);
+            write_json(&output);
+        }
+        _ => {
+            eprintln!("Unexpected command '{}'", cmd);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
This adds an executable and config file for use with the [W3C Verifiable Claims Working Group Test Suite](https://github.com/w3c/vc-test-suite). The executable receives test suite inputs and currently just echos them back. Eventually it would validate/verify the input and generate output per the tests.