### PR TITLE
Rename master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: ci
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
DID Core looks like it is going to use "main": https://github.com/w3c/did-core/issues/332. Should we follow their example?