### PR TITLE
Avoid ring v0.16.16, for Android armv7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pest_derive = "2.1"
 derive_builder = "0.9"
 base64 = "0.12"
 jsonwebtoken = { path = "jsonwebtoken" }
-ring = "0.16"
+ring = "0.16, < 0.16.16"
 multibase = "0.8"
 
 [workspace]


### PR DESCRIPTION
Prevent build error on Android armv7: https://github.com/briansmith/ring/issues/1106

The error appearing in CI: https://github.com/spruceid/didkit/runs/1443157755#step:18:118
CI passes when building with this commit: https://github.com/spruceid/didkit/runs/1443536224