### PR TITLE
Fix proof type: rename Ed25519VerificationKey2018 to Ed25519Signature2018

### DIFF
--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -61,7 +61,7 @@ impl LinkedDataProofs {
                 x509_thumbprint_sha256: _,
             } => match &curve[..] {
                 "Ed25519" => {
-                    return Ed25519VerificationKey2018::sign(document, options, &key);
+                    return Ed25519Signature2018::sign(document, options, &key);
                 }
                 _ => {}
             },
@@ -74,7 +74,8 @@ impl LinkedDataProofs {
     pub fn verify(proof: &Proof, document: &dyn LinkedDataDocument) -> Result<(), Error> {
         match proof.type_.as_str() {
             "RsaSignature2018" => RsaSignature2018::verify(proof, document),
-            "Ed25519VerificationKey2018" => Ed25519VerificationKey2018::verify(proof, document),
+            "Ed25519Signature2018" => Ed25519Signature2018::verify(proof, document),
+            "Ed25519VerificationKey2018" => Ed25519Signature2018::verify(proof, document), // invalid/deprecated
             _ => Err(Error::ProofTypeNotImplemented),
         }
     }
@@ -208,8 +209,8 @@ impl ProofSuite for RsaSignature2018 {
     }
 }
 
-pub struct Ed25519VerificationKey2018 {}
-impl ProofSuite for Ed25519VerificationKey2018 {
+pub struct Ed25519Signature2018 {}
+impl ProofSuite for Ed25519Signature2018 {
     fn sign(
         document: &dyn LinkedDataDocument,
         options: &LinkedDataProofOptions,
@@ -219,7 +220,7 @@ impl ProofSuite for Ed25519VerificationKey2018 {
             document,
             options,
             key,
-            "Ed25519VerificationKey2018",
+            "Ed25519Signature2018",
             Algorithm::EdDSA,
         )
     }


### PR DESCRIPTION
The proof type should be "Ed25519Signature2018". "Ed25519VerificationKey2018" is the type of the public key.

Reference: https://w3c-ccg.github.io/lds-ed25519-2018/

I am leaving in verification of proof type "Ed25519VerificationKey2018" for our existing usage, with the code comment "invalid/deprecated". When we release the libraries I think we should remove this usage.