### PR TITLE
Include subseconds in datetime serialization

### DIFF
--- a/src/rdf.rs
+++ b/src/rdf.rs
@@ -209,7 +209,7 @@ impl DataSet {
 impl From<DateTime<Utc>> for Literal {
     fn from(date_time: DateTime<Utc>) -> Self {
         Literal::Typed {
-            string: StringLiteral(format!("{}", date_time.format("%Y-%m-%dT%H:%M:%SZ"))),
+            string: StringLiteral(date_time.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)),
             type_: IRIRef("http://www.w3.org/2001/XMLSchema#dateTime".to_string()),
         }
     }


### PR DESCRIPTION
While testing our VCs with https://univerifier.io/ by Danube Tech - one of the other [vc-http-api test suite](https://github.com/w3c-ccg/vc-http-api/tree/6c7d512060830162d444614bf3e276a1d954e007/packages/plugfest-2020) vendors - I found a bug in our credential signing.

Datetimes were serialized for signing with second precision, discarding the subsecond part. But the datetimes are generated with nanosecond precision, using [Utc::now()](https://docs.rs/chrono/0.4.19/chrono/offset/struct.Utc.html#method.now).

This PR changes the serialization of datetimes for signing to include their subsecond part, to the precision that it is in the [DateTime](https://docs.rs/chrono/0.4.19/chrono/struct.DateTime.html) struct. This appears to match how `chrono` has `serde` serialize the datetimes to JSON strings. With this change, VCs from ssi/DIDKit verify in Univerifier.

The fixtures in our `vc-http-api` test suite fork/branch are updated accordingly: https://github.com/spruceid/vc-http-api/commit/fc183e3228da7300f9a0acd0f9cadd81ec2a54d4

Credentials previously issued by ssi/DIDKit will no longer verify as-is, but they can be fixed by removing the subsecond part of their datetime properties, since that is how they were actually signed. Since we are still pre-release, I don't think it is necessary to add special handling for the old credentials.

---

Reference / more info: ssi/DIDKit uses Rust type `DateTime<Utc>` from [chrono](https://github.com/chronotope/chrono) for the following properties of RDF type [xsd:dateTime](http://www.w3.org/TR/xmlschema11-2/#dateTime):
- credential [issuanceDate](https://w3c.github.io/vc-data-model/#issuance-date)
- credential [expirationDate](https://w3c.github.io/vc-data-model/#expiration)
- proof [created](https://w3c-ccg.github.io/ld-proofs/#dfn-created)