### PR TITLE
cleanup: Remove proof expires property

### DIFF
--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -142,7 +142,6 @@ fn sign(
         creator: None,
         created: Some(options.created.unwrap_or(now_ms())),
         domain: options.domain.clone(),
-        expires: None,
         challenge: options.challenge.clone(),
         nonce: None,
         property_set: None,

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -139,8 +139,6 @@ pub struct Proof {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires: Option<DateTime<Utc>>, // ISO 8601
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub nonce: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jws: Option<String>,
@@ -1017,17 +1015,6 @@ impl TryFrom<Proof> for DataSet {
             });
         }
 
-        if let Some(expires) = proof.expires {
-            statements.push(Statement {
-                subject: subject.clone(),
-                predicate: Predicate::IRIRef(IRIRef(
-                    "https://w3id.org/security#expires".to_string(),
-                )),
-                object: Object::Literal(Literal::from(expires)),
-                graph_label: None,
-            });
-        }
-
         if let Some(nonce) = proof.nonce {
             statements.push(Statement {
                 subject: subject.clone(),
@@ -1260,9 +1247,6 @@ macro_rules! assert_local {
 
 impl Proof {
     pub fn matches(&self, options: &LinkedDataProofOptions) -> bool {
-        if let Some(expires) = self.expires {
-            assert_local!(Utc::now() < expires);
-        }
         if let Some(ref verification_method) = options.verification_method {
             assert_local!(self.verification_method.as_ref() == Some(verification_method));
         }


### PR DESCRIPTION
The [expires](https://w3c-ccg.github.io/security-vocab/#expires) property is in the [vc-data-model](https://w3c.github.io/vc-data-model/) base context, but it is not otherwise mentioned in the `vc-data-model` spec, or [ld-proofs](https://w3c-ccg.github.io/ld-proofs/). It also does not appear in [vc-test-suite](https://github.com/w3c/vc-test-suite) or [vc-http-api](https://github.com/w3c-ccg/vc-http-api/). `expires` is rather a property of a key, as mentioned in e.g. [lds-ed25519-2018](https://w3c-ccg.github.io/lds-ed25519-2018/). As such it does not belong in a Proof object. This PR removes it, to reduce the chance for confusion.

The `nonce` proof/signature property is also not used in ssi/DIDKit, `vc-test-suite` or `vc-http-api`, but it is mentioned in `ld-proofs`, so I leave it in.