### PR TITLE
Use current time to millisecond precision

### DIFF
--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -10,6 +10,14 @@ use crate::jwk::{OctetParams as JWKOctetParams, Params as JWKParams, JWK};
 use crate::rdf::DataSet;
 use crate::vc::{base64_encode_json, LinkedDataProofOptions, Proof};
 
+// Get current time to millisecond precision if possible
+pub fn now_ms() -> DateTime<Utc> {
+    let datetime = Utc::now();
+    let ms = datetime.timestamp_subsec_millis();
+    let ns = ms * 1_000_000;
+    datetime.with_nanosecond(ns).unwrap_or(datetime)
+}
+
 pub trait LinkedDataDocument {
     fn to_dataset_for_signing(&self) -> Result<DataSet, Error>;
 }
@@ -132,7 +140,7 @@ fn sign(
         proof_value: None,
         verification_method: options.verification_method.clone(),
         creator: None,
-        created: Some(options.created.unwrap_or(Utc::now())),
+        created: Some(options.created.unwrap_or(now_ms())),
         domain: options.domain.clone(),
         expires: None,
         challenge: options.challenge.clone(),

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use crate::error::Error;
 use crate::jwk::{JWTKeys, JWK};
-use crate::ldp::{LinkedDataDocument, LinkedDataProofs};
+use crate::ldp::{now_ms, LinkedDataDocument, LinkedDataProofs};
 use crate::one_or_many::OneOrMany;
 use crate::rdf::{
     BlankNodeLabel, DataSet, IRIRef, Literal, Object, Predicate, Statement, StringLiteral, Subject,
@@ -341,7 +341,7 @@ impl Default for LinkedDataProofOptions {
         Self {
             verification_method: None,
             proof_purpose: Some(ProofPurpose::default()),
-            created: Some(Utc::now()),
+            created: Some(now_ms()),
             challenge: None,
             domain: None,
             checks: Some(vec![Check::Proof]),
@@ -1267,7 +1267,7 @@ impl Proof {
             assert_local!(self.verification_method.as_ref() == Some(verification_method));
         }
         if let Some(created) = self.created {
-            assert_local!(options.created.unwrap_or(Utc::now()) >= created);
+            assert_local!(options.created.unwrap_or(now_ms()) >= created);
         } else {
             return false;
         }


### PR DESCRIPTION
Following #44, this update is to ensure interoperability. `ssi` uses [Utc::now()](https://docs.rs/chrono/0.4.19/chrono/offset/struct.Utc.html#method.now) as a default timestamp for proof `created` datetimes. `Utc::now()` is to nanosecond precision. The other [vc-http-api test suite](https://github.com/w3c-ccg/vc-http-api/tree/6c7d512060830162d444614bf3e276a1d954e007/packages/plugfest-2020) vendor fixtures only use timestamps up to second or millisecond precision. The spec that defines the `dateTime` type requires that implementors support only at least millisecond precision: <https://www.w3.org/TR/xmlschema11-2/#partial-implementation>.

While I have not seen any verifiers reject our credentials for their nanosecond timestamp precision, I have not tested all the vendors in the `vc-http-api` test suite. (Many of their public verifier/issuer endpoints are no longer working). This PR is to propose that we conservatively default to millisecond precision when creating timestamps new timestamps. (Second precision would also be fine I think). If higher precision is needed, the default can be overridden by passing the `created` proof option during issuance.

Credentials also have dateTime properties `issuanceDate` and `expirationDate`. These properties do not have defaults in `ssi` (or in DIDKit), so it will be up to users of ssi/DIDKit to decide how to handle those.

I hope this is a useful update and not a premature optimization.