### PR TITLE
Make issue/verify async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ring = "0.16"
 multibase = "0.8"
 json-ld = { git = "https://github.com/timothee-haudebourg/json-ld", rev = "448791ead1d4c1a78e4434e91d6f7e77b455b4f1" }
 async-std = { version = "1.5", features = ["attributes"] }
+async-trait = "0.1"
 json = "0.12"
 futures = "0.3"
 iref = "1.1"

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -1,7 +1,8 @@
 // To generate text fixture:
 // cargo run --example issue > examples/vc.jsonld
 
-fn main() {
+#[async_std::main]
+async fn main() {
     let key_str = include_str!("../tests/ed25519-2020-10-18.json");
     let key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     let vc = serde_json::json!({
@@ -17,9 +18,9 @@ fn main() {
     let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
     let verification_method = key.to_verification_method().unwrap();
     proof_options.verification_method = Some(verification_method);
-    let proof = vc.generate_proof(&key, &proof_options).unwrap();
+    let proof = vc.generate_proof(&key, &proof_options).await.unwrap();
     vc.add_proof(proof);
-    let result = vc.verify(None);
+    let result = vc.verify(None).await;
     if result.errors.len() > 0 {
         panic!("verify failed: {:#?}", result);
     }

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -1,7 +1,8 @@
 // To generate text fixture:
 // cargo run --example present < examples/vc.jsonld > examples/vp.jsonld
 
-fn main() {
+#[async_std::main]
+async fn main() {
     let key_str = include_str!("../tests/ed25519-2020-10-18.json");
     let key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     let reader = std::io::BufReader::new(std::io::stdin());
@@ -18,9 +19,9 @@ fn main() {
     proof_options.verification_method = Some(verification_method);
     proof_options.proof_purpose = Some(ssi::vc::ProofPurpose::Authentication);
     proof_options.challenge = Some("example".to_string());
-    let proof = vp.generate_proof(&key, &proof_options).unwrap();
+    let proof = vp.generate_proof(&key, &proof_options).await.unwrap();
     vp.add_proof(proof);
-    let result = vp.verify(Some(proof_options));
+    let result = vp.verify(Some(proof_options)).await;
     if result.errors.len() > 0 {
         panic!("verify failed: {:#?}", result);
     }


### PR DESCRIPTION
This makes linked-data proof generation and verification asynchronous. As discussed in #56, this should enable using `ssi` in WebAssembly with #52.