### PR TITLE
Use simple_asn1 for DER

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ base64 = "0.12"
 jsonwebtoken = { path = "jsonwebtoken" }
 ring = "0.16"
 multibase = "0.8"
+simple_asn1 = "0.5"
+num-bigint = "0.3"
 
 [workspace]
 members = [

--- a/src/der.rs
+++ b/src/der.rs
@@ -6,14 +6,10 @@
 // https://tools.ietf.org/html/rfc8017#page-55
 // https://tools.ietf.org/html/rfc8410
 
-use std::convert::From;
+use num_bigint::{BigInt, Sign};
+use simple_asn1::{der_encode, ASN1Block, ASN1Class, ToASN1};
 
-const TAG_INTEGER: u8 = 0x02;
-const TAG_OCTETSTRING: u8 = 0x04;
-const TAG_BITSTRING: u8 = 0x03;
-const TAG_SEQUENCE: u8 = 0x10;
-
-pub type DER = Vec<u8>;
+use crate::error::Error;
 
 #[derive(Debug, Clone)]
 pub struct RSAPrivateKey {
@@ -56,7 +52,7 @@ pub struct OtherPrimeInfo {
 }
 
 #[derive(Debug, Clone)]
-pub struct Integer(pub Vec<u8>);
+pub struct Integer(pub BigInt);
 
 #[derive(Debug, Clone)]
 pub struct OctetString(pub Vec<u8>);
@@ -65,147 +61,137 @@ pub struct OctetString(pub Vec<u8>);
 // TODO: support bitstrings not bytes-aligned
 pub struct BitString(pub Vec<u8>);
 
-fn trim_bytes(bytes: &[u8]) -> Vec<u8> {
-    // Remove leading zeros from an array.
-    match bytes.into_iter().position(|&x| x != 0) {
-        Some(n) => bytes[n..].to_vec(),
-        None => vec![0],
-    }
-}
-
-fn encode(tag: u8, constructed: bool, contents: Vec<u8>) -> Vec<u8> {
-    // prepare an ASN1 tag-length-value
-    let id = tag
-        // set bit for constructed (vs primitive)
-        | match constructed {
-            true => 0x20,
-            false => 0,
-        };
-    let len = contents.len();
-    let len_bytes = trim_bytes(&len.to_be_bytes());
-    if len <= 127 {
-        return [vec![id, len_bytes[0]], contents].concat();
-    }
-    let len_len = len_bytes.len();
-    if len_len >= 127 {
-        // This can't really happen, since to_be_bytes returns an array of length 2, 4, or 8.
-        panic!("Key data too large");
-    }
-    let len_len_bytes = trim_bytes(&len_len.to_be_bytes());
-    [vec![id, 0x80 | len_len_bytes[0]], len_bytes, contents].concat()
-}
-
-impl From<RSAPrivateKey> for DER {
-    fn from(key: RSAPrivateKey) -> Self {
-        let multiprime = key.other_prime_infos.is_some();
-        let version = Integer(vec![if multiprime { 1 } else { 0 }]);
-        encode(
-            TAG_SEQUENCE,
-            true,
+impl ToASN1 for RSAPrivateKey {
+    type Error = Error;
+    fn to_asn1_class(&self, class: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        let multiprime = self.other_prime_infos.is_some();
+        let version = Integer(BigInt::new(
+            Sign::Plus,
+            vec![if multiprime { 1 } else { 0 }],
+        ));
+        Ok(vec![ASN1Block::Sequence(
+            0,
             [
-                DER::from(version),
-                DER::from(key.modulus),
-                DER::from(key.public_exponent),
-                DER::from(key.private_exponent),
-                DER::from(key.prime1),
-                DER::from(key.prime2),
-                DER::from(key.exponent1),
-                DER::from(key.exponent2),
-                DER::from(key.coefficient),
-                match key.other_prime_infos {
-                    Some(infos) => DER::from(infos),
+                version.to_asn1_class(class)?,
+                self.modulus.to_asn1_class(class)?,
+                self.public_exponent.to_asn1_class(class)?,
+                self.private_exponent.to_asn1_class(class)?,
+                self.prime1.to_asn1_class(class)?,
+                self.prime2.to_asn1_class(class)?,
+                self.exponent1.to_asn1_class(class)?,
+                self.exponent2.to_asn1_class(class)?,
+                self.coefficient.to_asn1_class(class)?,
+                match self.other_prime_infos {
+                    Some(ref infos) => infos.to_asn1_class(class)?,
                     None => Vec::new(),
                 },
             ]
             .concat(),
-        )
+        )])
     }
 }
 
-impl From<RSAPublicKey> for DER {
-    fn from(key: RSAPublicKey) -> Self {
-        encode(
-            TAG_SEQUENCE,
-            true,
-            [DER::from(key.modulus), DER::from(key.public_exponent)].concat(),
-        )
+impl ToASN1 for RSAPublicKey {
+    type Error = Error;
+    fn to_asn1_class(&self, class: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        Ok(vec![ASN1Block::Sequence(
+            0,
+            vec![
+                self.modulus.to_asn1_class(class)?,
+                self.public_exponent.to_asn1_class(class)?,
+            ]
+            .concat(),
+        )])
     }
 }
 
 impl Ed25519PrivateKey {
-    fn oid() -> Vec<u8> {
+    fn oid() -> ASN1Block {
+        use simple_asn1::BigUint;
         // id-Ed25519 1.3.101.112
-        return vec![0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70];
+        let oid = simple_asn1::OID::new(vec![
+            BigUint::new(vec![1]),
+            BigUint::new(vec![3]),
+            BigUint::new(vec![101]),
+            BigUint::new(vec![112]),
+        ]);
+        ASN1Block::Sequence(0, vec![ASN1Block::ObjectIdentifier(0, oid)])
     }
 }
 
-impl From<Ed25519PrivateKey> for DER {
-    fn from(key: Ed25519PrivateKey) -> Self {
-        let version = Integer(vec![0]);
+impl ToASN1 for Ed25519PrivateKey {
+    type Error = Error;
+    fn to_asn1_class(&self, _class: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        let version = 0;
         // TODO: include public key
-        encode(
-            TAG_SEQUENCE,
-            true,
-            [
-                DER::from(version),
+        Ok(vec![ASN1Block::Sequence(
+            0,
+            vec![
+                ASN1Block::Integer(0, BigInt::new(Sign::NoSign, vec![version])),
                 Ed25519PrivateKey::oid(),
-                DER::from(key.private_key),
+                ASN1Block::OctetString(0, der_encode(&self.private_key)?),
+            ],
+        )])
+    }
+}
+
+impl ToASN1 for Ed25519PublicKey {
+    type Error = Error;
+    fn to_asn1_class(&self, class: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        Ok(vec![ASN1Block::Sequence(
+            0,
+            self.public_key.to_asn1_class(class)?,
+        )])
+    }
+}
+
+impl ToASN1 for Integer {
+    type Error = Error;
+    fn to_asn1_class(&self, _: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        Ok(vec![ASN1Block::Integer(0, self.0.clone())])
+    }
+}
+
+impl ToASN1 for OctetString {
+    type Error = Error;
+    fn to_asn1_class(&self, _: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        Ok(vec![ASN1Block::OctetString(0, self.0.clone())])
+    }
+}
+
+impl ToASN1 for BitString {
+    type Error = Error;
+    fn to_asn1_class(&self, _: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        Ok(vec![ASN1Block::BitString(0, 0, self.0.clone())])
+    }
+}
+
+impl ToASN1 for OtherPrimeInfos {
+    type Error = Error;
+    fn to_asn1_class(&self, class: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        Ok(vec![ASN1Block::Sequence(
+            0,
+            self.0
+                .iter()
+                .map(|x| x.to_asn1_class(class))
+                .collect::<Result<Vec<Vec<ASN1Block>>, Error>>()?
+                .concat(),
+        )])
+    }
+}
+
+impl ToASN1 for OtherPrimeInfo {
+    type Error = Error;
+    fn to_asn1_class(&self, class: ASN1Class) -> Result<Vec<ASN1Block>, Self::Error> {
+        Ok(vec![ASN1Block::Sequence(
+            0,
+            vec![
+                self.prime.to_asn1_class(class)?,
+                self.exponent.to_asn1_class(class)?,
+                self.coefficient.to_asn1_class(class)?,
             ]
             .concat(),
-        )
-    }
-}
-
-impl From<Ed25519PublicKey> for DER {
-    fn from(key: Ed25519PublicKey) -> Self {
-        DER::from(key.public_key)
-    }
-}
-
-impl From<Integer> for DER {
-    fn from(key: Integer) -> Self {
-        encode(TAG_INTEGER, false, key.0)
-    }
-}
-
-impl From<OctetString> for DER {
-    fn from(octets: OctetString) -> Self {
-        encode(
-            TAG_OCTETSTRING,
-            false,
-            encode(TAG_OCTETSTRING, false, octets.0),
-        )
-    }
-}
-
-impl From<BitString> for DER {
-    fn from(data: BitString) -> Self {
-        encode(TAG_BITSTRING, false, [vec![0], data.0].concat())
-    }
-}
-
-impl From<OtherPrimeInfos> for DER {
-    fn from(infos: OtherPrimeInfos) -> Self {
-        encode(
-            TAG_SEQUENCE,
-            true,
-            infos.0.into_iter().flat_map(DER::from).collect(),
-        )
-    }
-}
-
-impl From<OtherPrimeInfo> for DER {
-    fn from(info: OtherPrimeInfo) -> Self {
-        encode(
-            TAG_SEQUENCE,
-            true,
-            [
-                DER::from(info.prime),
-                DER::from(info.exponent),
-                DER::from(info.coefficient),
-            ]
-            .concat(),
-        )
+        )])
     }
 }
 
@@ -214,13 +200,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn encode_oid() {
+        let expected = vec![0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70];
+        let asn1 = Ed25519PrivateKey::oid();
+        let der = simple_asn1::to_der(&asn1).unwrap();
+        assert_eq!(der, expected);
+    }
+
+    #[test]
     fn encode_integer() {
-        let integer = Integer(vec![5]);
+        let integer = Integer(BigInt::new(Sign::Plus, vec![5]));
         // 0x02: Integer type
         // 0x01: Content length of one byte
         // 0x05: The integer 5
         let expected = vec![0x02, 0x01, 0x05];
-        assert_eq!(DER::from(integer), expected);
+        let der = der_encode(&integer).unwrap();
+        assert_eq!(der, expected);
     }
 
     #[test]
@@ -235,6 +230,7 @@ mod tests {
         };
         let expected_b64 = "MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC";
         let expected_key = base64::decode(expected_b64).unwrap();
-        assert_eq!(DER::from(key), expected_key);
+        let key_der = der_encode(&key).unwrap();
+        assert_eq!(key_der, expected_key);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use multibase::Error as MultibaseError;
 use ring::error::KeyRejected as KeyRejectedError;
 use ring::error::Unspecified as RingUnspecified;
 use serde_json::Error as JSONError;
+use simple_asn1::ASN1EncodeErr as ASN1EncodeError;
 use std::fmt;
 
 #[derive(Debug)]
@@ -55,6 +56,7 @@ pub enum Error {
     RingError,
     KeyRejected(KeyRejectedError),
     JWT(JWTError),
+    ASN1Encode(ASN1EncodeError),
     Base64(Base64Error),
     Multibase(MultibaseError),
     JSON(JSONError),
@@ -119,6 +121,7 @@ impl fmt::Display for Error {
             Error::Base64(e) => e.fmt(f),
             Error::Multibase(e) => e.fmt(f),
             Error::JWT(e) => e.fmt(f),
+            Error::ASN1Encode(e) => e.fmt(f),
             Error::JSON(e) => e.fmt(f),
             _ => unreachable!(),
         }
@@ -140,6 +143,12 @@ impl From<Base64Error> for Error {
 impl From<MultibaseError> for Error {
     fn from(err: MultibaseError) -> Error {
         Error::Multibase(err)
+    }
+}
+
+impl From<ASN1EncodeError> for Error {
+    fn from(err: ASN1EncodeError) -> Error {
+        Error::ASN1Encode(err)
     }
 }
 

--- a/tests/jwk-rsa-rfc7515.rs
+++ b/tests/jwk-rsa-rfc7515.rs
@@ -1,0 +1,26 @@
+use std::convert::TryFrom;
+
+use jsonwebtoken::{Algorithm, EncodingKey};
+use ssi::jwk::JWK;
+
+#[test]
+fn rsa_rfc7515() {
+    let signing_input: &[u8] = b"eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+    use serde_json::json;
+    // https://tools.ietf.org/html/rfc7515#page-41
+    let key: JWK = serde_json::from_value(json!({"kty":"RSA",
+          "n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",
+          "e":"AQAB",
+          "d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97IjlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYTCBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLhBOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",
+          "p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdiYrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPGBY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",
+          "q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxaewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",
+          "dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3QCLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",
+          "dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-kyNlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",
+          "qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2oy26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLUW0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"
+        }))
+        .unwrap();
+    let encoding_key = EncodingKey::try_from(&key).unwrap();
+    let sig_b64 =
+        jsonwebtoken::crypto::sign_bytes(&signing_input, &encoding_key, Algorithm::RS256).unwrap();
+    assert_eq!(sig_b64, "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw");
+}


### PR DESCRIPTION
I was getting an error when using this JWK RSA key from RFC 7515:
https://tools.ietf.org/html/rfc7515#page-41

I traced it to what looks like a bug in our DER encoding implementation in `src/der.rs`. We are using DER encoding for passing private keys to `jsonwebtoken`/`ring` for signing.

This PR changes our DER encoding to use [simple_asn1](https://github.com/acw/simple_asn1). That is a crate that is also used by the [rsa](https://github.com/RustCrypto/RSA) crate and others.

With this change, the error I was seeing goes away. I added a test case for it at `tests/jwk-rsa-rfc7515.rs`, to prevent regression, and to assist verifying this bug fix.

The `src/der.rs` file remains, for representing X.509 keys in ASN1 types for DER, but the encoding is now done by `simple_asn1`.