### PR TITLE
Run CI for PR to any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: ci
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
This should make CI run on pushes to any branch that has a PR from it, not just if the PR is to `main`. The purpose is to enable seeing CI results when opening PRs to branches other than `main`. CI will still not run on pushes to non-PR branches. Edit: this branch name is little confusing; it probably should have been `ci-all-pr-branches`.