### PR TITLE
Alternative cryptography libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Test
       run: cargo test --verbose --workspace
 
+    - name: Test with alternative crypto libraries
+      run: cargo test --no-default-features --features rsa,ed25519-compact,sha2
+
     - name: Checkout vc-test-suite
       uses: actions/checkout@v2
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 authors = ["wyc <wyc@fastmail.fm>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["ring"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
@@ -15,7 +16,9 @@ pest = "2.1"
 pest_derive = "2.1"
 derive_builder = "0.9"
 base64 = "0.12"
-ring = "0.16"
+ring = { version = "0.16", optional = true }
+rsa = { version = "0.3", optional = true }
+ed25519-compact = { version = "0.1", optional = true }
 multibase = "0.8"
 simple_asn1 = "0.5"
 num-bigint = "0.3"
@@ -27,6 +30,7 @@ futures = "0.3"
 iref = "1.1"
 lazy_static = "1.4"
 permute = "0.1"
+sha2 = { version = "0.9", optional = true }
 
 [workspace]
 members = [

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,34 @@
+use crate::error::Error;
+
+#[cfg(feature = "sha2")]
+pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(data);
+    let hash = hasher.finalize().into();
+    Ok(hash)
+}
+
+#[cfg(feature = "ring")]
+pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
+    use ring::digest;
+    use std::convert::TryInto;
+    let hash = digest::digest(&digest::SHA256, data).as_ref().try_into()?;
+    Ok(hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_empty() {
+        assert_eq!(
+            sha256(&[]).unwrap(),
+            [
+                227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39,
+                174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85
+            ]
+        );
+    }
+}

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use chrono::prelude::*;
-use ring::digest;
 
 use crate::error::Error;
+use crate::hash::sha256;
 use crate::jwk::{Algorithm, OctetParams as JWKOctetParams, Params as JWKParams, JWK};
 use crate::rdf::DataSet;
 use crate::urdna2015;
@@ -121,8 +121,8 @@ async fn to_jws_payload(
     let sigopts_dataset = proof.to_dataset_for_signing(Some(document)).await?;
     let sigopts_dataset_normalized = urdna2015::normalize(&sigopts_dataset)?;
     let sigopts_normalized = sigopts_dataset_normalized.to_nquads()?;
-    let sigopts_digest = digest::digest(&digest::SHA256, sigopts_normalized.as_bytes());
-    let doc_digest = digest::digest(&digest::SHA256, doc_normalized.as_bytes());
+    let sigopts_digest = sha256(sigopts_normalized.as_bytes())?;
+    let doc_digest = sha256(doc_normalized.as_bytes())?;
     let data = [
         sigopts_digest.as_ref().to_vec(),
         doc_digest.as_ref().to_vec(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod der;
 pub mod did;
 pub mod error;
+pub mod hash;
 pub mod jsonld;
 pub mod jwk;
 pub mod jws;

--- a/src/urdna2015.rs
+++ b/src/urdna2015.rs
@@ -1,8 +1,8 @@
-use ring::digest;
 use std::collections::BTreeMap as Map;
 use std::collections::HashSet;
 
 use crate::error::Error;
+use crate::hash::sha256;
 use crate::rdf::{BlankNodeLabel, DataSet, Predicate, Statement};
 
 /// https://json-ld.github.io/normalization/spec/#normalization-state
@@ -45,9 +45,8 @@ pub struct HashNDegreeQuadsOutput {
     pub issuer: IdentifierIssuer,
 }
 
-fn digest_to_lowerhex(digest: &digest::Digest) -> String {
+fn digest_to_lowerhex(digest: &[u8]) -> String {
     digest
-        .as_ref()
         .iter()
         .map(|byte| format!("{:02x}", byte))
         .collect::<String>()
@@ -87,7 +86,7 @@ pub fn hash_first_degree_quads(
     nquads.sort();
     // 5
     let joined_nquads = nquads.join("");
-    let nquads_digest = digest::digest(&digest::SHA256, joined_nquads.as_bytes());
+    let nquads_digest = sha256(joined_nquads.as_bytes())?;
     let hash_hex = digest_to_lowerhex(&nquads_digest);
     Ok(hash_hex)
 }
@@ -367,7 +366,7 @@ pub fn hash_n_degree_quads(
         issuer = &mut issuer_tmp;
     }
     // 6
-    let digest = digest::digest(&digest::SHA256, data_to_hash.as_bytes());
+    let digest = sha256(data_to_hash.as_bytes())?;
     let hash = digest_to_lowerhex(&digest);
     Ok(HashNDegreeQuadsOutput {
         hash,
@@ -407,7 +406,7 @@ pub fn hash_related_blank_node(
     // 4
     input += &identifier;
     // 5
-    let digest = digest::digest(&digest::SHA256, input.as_bytes());
+    let digest = sha256(input.as_bytes())?;
     let hash_hex = digest_to_lowerhex(&digest);
     Ok(hash_hex)
 }


### PR DESCRIPTION
Progress for https://github.com/spruceid/ssi/issues/52, https://github.com/spruceid/didkit/issues/16

This is an initial implementation of cryptographic agility, adding support for additional crypto libraries.

This makes the `ring` dependency optional and adds alternative optional dependencies to provide cryptographic operations: [rsa](https://github.com/RustCrypto/RSA), [ed25519-compact](https://github.com/jedisct1/rust-ed25519-compact), and [sha2](https://github.com/RustCrypto/hashes/tree/master/sha2). Those libraries are some of the ones used by [jwt-compact](https://github.com/slowli/jwt-compact/). `ring` is left as the default since it is what we have already been using, inherited from [jsonwebtoken](https://github.com/Keats/jsonwebtoken/tree/), and I find it faster when running vc-test-suite (400ms vs. 2s when using `rsa`). The dependencies are enabled with features. All functionality previously dependent on `ring` now uses `ring` only if the `ring` feature is enabled, and otherwise will use one of the other libraries if its corresponding feature is enabled. To test with the non-`ring` dependencies, CI runs this:
```
cargo test --no-default-features --features rsa,ed25519-compact,sha2
```
The same flags can be passed to other `cargo` commands, such as `cargo build`.

If the (default) `ring` feature is not enabled, and the other features `rsa`, `ed25519-compact`, `sha2` are not all enabled, some parts of the library will fail to build, since they depend on functionality from either `ring` or one of the other libraries. If both `ring` and some of the other libraries are enabled, use of `ring` should be expected to take precedence.

These changes should enable use of `ssi` with WebAssembly, since the added libraries are pure Rust and supposed to support WebAssembly. I didn't add CI/testing for this, but it will be tested in `DIDKit` with https://github.com/spruceid/didkit/pull/15.

There should also be added a description of the cryptographic libraries, per https://github.com/spruceid/didkit/issues/16#issuecomment-751743009, but I have not added that yet (I am not sure where it should go).