### PR TITLE
Update DID resolution interface

### DIFF
--- a/did-resolve/Cargo.toml
+++ b/did-resolve/Cargo.toml
@@ -10,7 +10,6 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "0.2", features = ["macros", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-bytes = "0.5"
 hyper = "0.13"
 hyper-tls = "0.4"
 http = "0.2"

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -13,7 +13,6 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "0.2", features = ["macros", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-bytes = "0.5"
 hyper = "0.13"
 async-trait = "0.1"
 anyhow = "1.0.34"


### PR DESCRIPTION
This simplifies DIDKit's DID resolution interface, and brings it more in line with DID Core.

- Rename resolveStream to resolveRepresentation. Fix #50
- Use Vec<u8> instead of Bytes in DID resolution return type
- Use Bytes re-exported by hyper
- Implement resolve_representation in terms of resolve by default