### PR TITLE
Fix hyperlinks in rust docs

### DIFF
--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -49,7 +49,7 @@ fn did_web_url(did: &str) -> Result<String, ResolutionMetadata> {
     Ok(url)
 }
 
-/// https://w3c-ccg.github.io/did-method-web/#read-resolve
+/// <https://w3c-ccg.github.io/did-method-web/#read-resolve>
 #[async_trait]
 impl DIDResolver for DIDWeb {
     async fn resolve(

--- a/src/did.rs
+++ b/src/did.rs
@@ -162,7 +162,7 @@ pub enum Source<'a> {
 #[async_trait]
 pub trait DIDMethod: DIDResolver {
     /// Get the DID method name.
-    /// https://w3c.github.io/did-core/#method-schemes
+    /// <https://w3c.github.io/did-core/#method-schemes>
     fn name(&self) -> &'static str;
 
     // TODO: allow returning errors

--- a/src/did_resolve.rs
+++ b/src/did_resolve.rs
@@ -46,7 +46,7 @@ pub struct ResolutionInputMetadata {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
-/// https://w3c.github.io/did-core/#did-resolution-metadata-properties
+/// <https://w3c.github.io/did-core/#did-resolution-metadata-properties>
 pub struct ResolutionMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -67,8 +67,8 @@ pub struct DocumentMetadata {
     pub property_set: Option<HashMap<String, Metadata>>,
 }
 
-/// https://w3c.github.io/did-core/#did-url-dereferencing-metadata-properties
-/// https://w3c-ccg.github.io/did-resolution/#dereferencing-input-metadata-properties
+/// <https://w3c.github.io/did-core/#did-url-dereferencing-metadata-properties>
+/// <https://w3c-ccg.github.io/did-resolution/#dereferencing-input-metadata-properties>
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct DereferencingInputMetadata {
@@ -83,7 +83,7 @@ pub struct DereferencingInputMetadata {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
-/// https://w3c.github.io/did-core/#did-url-dereferencing-metadata-properties
+/// <https://w3c.github.io/did-core/#did-url-dereferencing-metadata-properties>
 pub struct DereferencingMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -202,8 +202,8 @@ pub trait DIDResolver {
 
 /// Dereference a DID URL
 ///
-/// https://w3c.github.io/did-core/#did-url-dereferencing
-/// https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm
+/// <https://w3c.github.io/did-core/#did-url-dereferencing>
+/// <https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm>
 pub async fn dereference(
     resolver: &(dyn DIDResolver + Sync),
     did_url_str: &str,

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -19,21 +19,21 @@ pub enum RdfDirection {
     CompoundLiteral,
 }
 
-/// https://w3c.github.io/json-ld-api/#the-jsonldoptions-type
+/// <https://w3c.github.io/json-ld-api/#the-jsonldoptions-type>
 // Options implemented as needed
 #[derive(Debug, Clone)]
 pub struct JsonLdOptions {
-    /// https://w3c.github.io/json-ld-api/#dom-jsonldoptions-base
+    /// <https://w3c.github.io/json-ld-api/#dom-jsonldoptions-base>
     pub base: Option<String>,
-    /// https://w3c.github.io/json-ld-api/#dom-jsonldoptions-expandcontext
+    /// <https://w3c.github.io/json-ld-api/#dom-jsonldoptions-expandcontext>
     pub expand_context: Option<String>,
-    /// https://w3c.github.io/json-ld-api/#dom-jsonldoptions-ordered
+    /// <https://w3c.github.io/json-ld-api/#dom-jsonldoptions-ordered>
     pub ordered: bool,
-    /// https://w3c.github.io/json-ld-api/#dom-jsonldoptions-processingmode
+    /// <https://w3c.github.io/json-ld-api/#dom-jsonldoptions-processingmode>
     pub processing_mode: ProcessingMode,
-    /// https://w3c.github.io/json-ld-api/#dom-jsonldoptions-producegeneralizedrdf
+    /// <https://w3c.github.io/json-ld-api/#dom-jsonldoptions-producegeneralizedrdf>
     pub produce_generalized_rdf: Option<bool>,
-    /// https://w3c.github.io/json-ld-api/#dom-jsonldoptions-rdfdirection
+    /// <https://w3c.github.io/json-ld-api/#dom-jsonldoptions-rdfdirection>
     pub rdf_direction: Option<RdfDirection>,
 }
 
@@ -52,7 +52,7 @@ impl Default for JsonLdOptions {
     }
 }
 
-/// https://www.w3.org/TR/json-ld11/#keywords
+/// <https://www.w3.org/TR/json-ld11/#keywords>
 pub const AT_BASE: &str = "@base";
 pub const AT_CONTAINER: &str = "@container";
 pub const AT_CONTEXT: &str = "@context";
@@ -265,7 +265,7 @@ pub struct BlankNodeIdentifierGenerator {
 }
 
 impl BlankNodeIdentifierGenerator {
-    /// https://w3c.github.io/json-ld-api/#generate-blank-node-identifier
+    /// <https://w3c.github.io/json-ld-api/#generate-blank-node-identifier>
     pub fn generate(&mut self, identifier: &JsonValue) -> Result<JsonValue, Error> {
         let identifier_str = if identifier.is_null() {
             None
@@ -296,7 +296,7 @@ impl BlankNodeIdentifierGenerator {
     }
 }
 
-/// https://w3c.github.io/json-ld-api/#node-map-generation
+/// <https://w3c.github.io/json-ld-api/#node-map-generation>
 pub fn generate_node_map(
     element: JsonValue,
     node_map: &mut NodeMap,
@@ -705,7 +705,7 @@ pub fn generate_node_map(
     Ok(())
 }
 
-/// https://w3c.github.io/json-ld-api/#deserialize-json-ld-to-rdf-algorithm
+/// <https://w3c.github.io/json-ld-api/#deserialize-json-ld-to-rdf-algorithm>
 pub fn json_ld_to_rdf(
     node_map: &NodeMap,
     dataset: &mut DataSet,
@@ -820,14 +820,14 @@ pub enum ItemObject {
     Node(NodeObject),
 }
 
-/// https://www.w3.org/TR/json-ld11/#dfn-value-object
+/// <https://www.w3.org/TR/json-ld11/#dfn-value-object>
 #[derive(Debug, Clone)]
 pub struct NodeObject {
     pub id: Option<String>,
     pub entries: json::object::Object,
 }
 
-/// https://www.w3.org/TR/json-ld11/#dfn-list-object
+/// <https://www.w3.org/TR/json-ld11/#dfn-list-object>
 #[derive(Debug, Clone)]
 pub struct ListObject {
     pub list: JsonValue,
@@ -835,7 +835,7 @@ pub struct ListObject {
     pub more_properties: json::object::Object,
 }
 
-/// https://www.w3.org/TR/json-ld11/#value-objects
+/// <https://www.w3.org/TR/json-ld11/#value-objects>
 #[derive(Debug, Clone)]
 pub struct ValueObject {
     pub value: JsonValue,
@@ -1036,7 +1036,7 @@ impl TryFrom<&JsonValue> for ItemObject {
     }
 }
 
-/// https://w3c.github.io/json-ld-api/#object-to-rdf-conversion
+/// <https://w3c.github.io/json-ld-api/#object-to-rdf-conversion>
 pub fn object_to_rdf(
     item: ItemObject,
     list_triples: &mut Vec<Triple>,
@@ -1255,7 +1255,7 @@ pub fn object_to_rdf(
     Ok(Some(Object::Literal(literal)))
 }
 
-/// https://w3c.github.io/json-ld-api/#dfn-canonical-lexical-form
+/// <https://w3c.github.io/json-ld-api/#dfn-canonical-lexical-form>
 pub fn canonicalize_json(value: &JsonValue) -> String {
     // TODO: make sure it follows RFC 8785 (JCS)
     // Converting to serde Value loses the order of keys, and serde_jcs does not provide from_str
@@ -1301,7 +1301,7 @@ pub fn canonicalize_json(value: &JsonValue) -> String {
     }
 }
 
-/// https://www.w3.org/TR/json-ld11/#the-rdf-json-datatype
+/// <https://www.w3.org/TR/json-ld11/#the-rdf-json-datatype>
 pub fn canonicalize_json_string(string: &str) -> String {
     let mut out = String::with_capacity(string.len() + 6);
     out.push('"');
@@ -1336,7 +1336,7 @@ pub fn canonicalize_json_number(num: &JsonValue) -> String {
     num_str
 }
 
-/// https://w3c.github.io/json-ld-api/#list-to-rdf-conversion
+/// <https://w3c.github.io/json-ld-api/#list-to-rdf-conversion>
 pub fn list_to_rdf(
     list: JsonValue,
     list_triples: &mut Vec<Triple>,
@@ -1411,7 +1411,7 @@ pub fn list_to_rdf(
     Ok(first)
 }
 
-/// https://w3c.github.io/json-ld-api/#dom-jsonldprocessor-tordf
+/// <https://w3c.github.io/json-ld-api/#dom-jsonldprocessor-tordf>
 pub async fn json_to_dataset<T>(
     json: &str,
     more_contexts_json: Option<&String>,
@@ -1568,7 +1568,7 @@ mod tests {
     }
 
     #[async_std::test]
-    /// https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html
+    /// <https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html>
     async fn to_rdf_test_suite() {
         let manifest_str = include_str!("../json-ld-api/tests/toRdf-manifest.jsonld");
         let manifest = json::parse(manifest_str).unwrap();

--- a/src/rdf.rs
+++ b/src/rdf.rs
@@ -13,20 +13,20 @@ use crate::error::Error;
 // https://json-ld.github.io/normalization/spec/
 // https://www.w3.org/TR/n-quads/#terminals
 
-/// https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset
+/// <https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset>
 #[derive(Debug, Clone, Default)]
 pub struct DataSet {
     pub default_graph: Graph,
     pub named_graphs: HashMap<GraphLabel, Graph>,
 }
 
-/// https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph
+/// <https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph>
 #[derive(Debug, Clone, Default)]
 pub struct Graph {
     pub triples: Vec<Triple>,
 }
 
-/// https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple
+/// <https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple>
 #[derive(Debug, Clone)]
 pub struct Triple {
     pub subject: Subject,

--- a/src/urdna2015.rs
+++ b/src/urdna2015.rs
@@ -5,7 +5,7 @@ use crate::error::Error;
 use crate::hash::sha256;
 use crate::rdf::{BlankNodeLabel, DataSet, Predicate, Statement};
 
-/// https://json-ld.github.io/normalization/spec/#normalization-state
+/// <https://json-ld.github.io/normalization/spec/#normalization-state>
 #[derive(Debug, Clone)]
 pub struct NormalizationState<'a> {
     pub blank_node_to_quads: Map<&'a str, Vec<&'a Statement>>,
@@ -13,8 +13,8 @@ pub struct NormalizationState<'a> {
     pub canonical_issuer: IdentifierIssuer,
 }
 
-/// https://json-ld.github.io/normalization/spec/#dfn-identifier-issuer
-/// https://json-ld.github.io/normalization/spec/#blank-node-identifier-issuer-state
+/// <https://json-ld.github.io/normalization/spec/#dfn-identifier-issuer>  
+/// <https://json-ld.github.io/normalization/spec/#blank-node-identifier-issuer-state>
 #[derive(Debug, Clone)]
 pub struct IdentifierIssuer {
     pub identifier_prefix: String,
@@ -52,7 +52,7 @@ fn digest_to_lowerhex(digest: &[u8]) -> String {
         .collect::<String>()
 }
 
-/// https://json-ld.github.io/normalization/spec/#hash-first-degree-quads
+/// <https://json-ld.github.io/normalization/spec/#hash-first-degree-quads>
 pub fn hash_first_degree_quads(
     normalization_state: &mut NormalizationState,
     reference_blank_node_identifier: &str,
@@ -91,7 +91,7 @@ pub fn hash_first_degree_quads(
     Ok(hash_hex)
 }
 
-/// https://json-ld.github.io/normalization/spec/
+/// <https://json-ld.github.io/normalization/spec/>
 pub fn normalize(input_dataset: &DataSet) -> Result<DataSet, Error> {
     // https://json-ld.github.io/normalization/spec/#algorithm
     // 1
@@ -224,7 +224,7 @@ pub fn normalize(input_dataset: &DataSet) -> Result<DataSet, Error> {
     Ok(normalized_dataset)
 }
 
-/// https://json-ld.github.io/normalization/spec/#issue-identifier-algorithm
+/// <https://json-ld.github.io/normalization/spec/#issue-identifier-algorithm>
 pub fn issue_identifier(
     identifier_issuer: &mut IdentifierIssuer,
     existing_identifier: &str,
@@ -248,7 +248,7 @@ pub fn issue_identifier(
     Ok(issued_identifier)
 }
 
-/// https://json-ld.github.io/normalization/spec/#hash-n-degree-quads
+/// <https://json-ld.github.io/normalization/spec/#hash-n-degree-quads>
 pub fn hash_n_degree_quads(
     normalization_state: &mut NormalizationState,
     identifier: &str,
@@ -374,7 +374,7 @@ pub fn hash_n_degree_quads(
     })
 }
 
-/// https://json-ld.github.io/normalization/spec/#hash-related-blank-node
+/// <https://json-ld.github.io/normalization/spec/#hash-related-blank-node>
 pub fn hash_related_blank_node(
     normalization_state: &mut NormalizationState,
     related: &str,
@@ -416,7 +416,7 @@ mod tests {
     use super::*;
 
     #[test]
-    /// https://json-ld.github.io/normalization/tests/
+    /// <https://json-ld.github.io/normalization/tests/>
     fn normalization_test_suite() {
         use std::fs::{self};
         use std::path::PathBuf;


### PR DESCRIPTION
URLs must be wrapped in angle brackets (`<>`) to become clickable links in the docs.

Also, for `IdentifierIssuer`, there are two links that are supposed to be on separate lines. In Rustdoc's CommonMark, two spaces at the end of a line is needed to make a line break.

e.g.: https://rust.didkit.dev/ssi/urdna2015/