### PR TITLE
Add copyright notices

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+Copyright 2020-2021 Spruce Systems, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Third Party Notices
+Portions of this software are based in part on the work of the World Wide Web Consortium (W3C). Because Spruce Systems, Inc. has included the work of the W3C in this product, Spruce Systems, Inc. is required to include the following text that accompanied such software:
+
+The Security Vocabulary: https://w3c-ccg.github.io/security-vocab/
+Verifiable Credentials Data Model: https://www.w3.org/TR/vc-data-model/
+Decentralized Identifiers (DIDs): https://www.w3.org/TR/did-core/
+ODRL Vocabulary & Expression: https://www.w3.org/TR/odrl-vocab/
+
+Copyright © 2018-2021 World Wide Web Consortium, (Massachusetts Institute of Technology, European Research Consortium for Informatics and Mathematics, Keio University, Beihang). All Rights Reserved. This work is distributed under the W3C® Software License in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Portions of this software are based in part on the work of schema.org. Because Spruce Systems, Inc. has included the work of schema.org in this product, Spruce Systems, Inc. is providing attribution in the following notice:
+
+Copyright in the schema by the sponsors of schema.org (Google, Inc., Yahoo, Inc., Microsoft Corporation and Yandex) are licensed to website publishers and other third parties under the Creative Commons Attribution-ShareAlike License (version 3.0) according to their Terms of Service, please visit https://schema.org/docs/terms.html. To view a copy of this license, please visit http://creativecommons.org/licenses/by-sa/3.0/.


### PR DESCRIPTION
- Provide attribution for the vendored JSON-LD context files.
- Assert Spruce's copyright.
- Identify the license by its SPDX identifier.

This is copied from the `NOTICE` in DIDKit (https://github.com/spruceid/didkit/pull/35), but with the following changes:
- Flutter notice not included, as the Flutter example is only in DIDKit, not `ssi`
- Change Spruce's copyright year from 2020 to range 2020-2021.
- Consolidate W3C copyright notices