### PR TITLE
Depend on ssi without default features

### DIFF
--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ssi = { path = "../" }
+ssi = { path = "../", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.0", features = ["macros", "rt"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"
 
 [dependencies]
-ssi = { path = "../" }
+ssi = { path = "../", default-features = false }
 async-trait = "0.1"
 hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
 hyper-tls = "0.5"


### PR DESCRIPTION
Default features brings in `ring` currently.

Attempt to fix https://github.com/spruceid/didkit/pull/52#issuecomment-774121191