### PR TITLE
Update json-ld

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,11 @@ simple_asn1 = "0.5"
 num-bigint = "0.3"
 async-std = { version = "1.5", features = ["attributes"] }
 async-trait = "0.1"
-json-ld = { git = "https://github.com/timothee-haudebourg/json-ld", rev = "448791ead1d4c1a78e4434e91d6f7e77b455b4f1" }
-json = "0.12"
+json-ld = { git = "https://github.com/timothee-haudebourg/json-ld", rev = "fba5a917638d9f0fc87a450c6dc6de0efdf8ae06" }
+# json = "^0.12"
+json = { git = "https://github.com/timothee-haudebourg/json-rust", branch = "fix#190" }
 futures = "0.3"
-iref = "1.1"
+iref = "1.4"
 lazy_static = "1.4"
 combination = "0.1"
 sha2 = { version = "0.9", optional = true }

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -1434,14 +1434,9 @@ where
         let iri = IriBuf::new(url).unwrap();
         let local_context = loader.load_context(iri.as_iri()).await?.into_context();
         context = local_context
-            .process_with(
-                &context,
-                json_ld::context::ProcessingStack::new(),
-                loader,
-                base,
-                options.into(),
-            )
-            .await?;
+            .process_with(&context, loader, base, options.into())
+            .await?
+            .into_inner();
     }
     let mut doc = json::parse(json)?;
     if let Some(more_contexts_json) = more_contexts_json {


### PR DESCRIPTION
Update to latest [json-ld](https://github.com/timothee-haudebourg/json-ld/) crate development version. Changes in `json-ld` include:
- Updated API
- Updated dependency versions
- Workaround for Rust nightly bug (https://github.com/timothee-haudebourg/json-ld/pull/9)
- Fixed a behavior tested by toRdf tests (https://github.com/timothee-haudebourg/json-ld/pull/7).