### PR TITLE
Change author to Spruce Systems, Inc. and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ssi"
-version = "0.1.0"
-authors = ["wyc <wyc@fastmail.fm>"]
+version = "0.1.1"
+authors = ["Spruce Systems, Inc."]
 edition = "2018"
 
 [features]


### PR DESCRIPTION
I've bumped the version to 0.1.1 because 0.1.0 was already populated on crates.io