### PR TITLE
Update did:tz verification method type

### DIFF
--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -126,7 +126,7 @@ fn prefix_to_curve_type(prefix: &str) -> Option<(&'static str, &'static str)> {
     let curve_type = match prefix {
         "tz1" => (
             "Ed25519",
-            "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2020",
+            "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
         ),
         // "tz2" => ("secp256k1", "TODO"),
         // "tz3" => ("P-256", "TODO"),
@@ -208,7 +208,7 @@ mod tests {
               "id": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
               "verificationMethod": [{
                 "id": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
-                "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2020",
+                "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
                 "controller": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
                 "blockchainAccountId": "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8@tezos:mainnet"
               }],


### PR DESCRIPTION
Update year to 2021, corresponding to https://github.com/spruceid/did-tezos/pull/4