### PR TITLE
[WIP] Add GenerateEd25519KeyFromSecret to JWK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ derive_builder = "0.9"
 base64 = "0.12"
 ring = { version = "0.16", optional = true }
 rsa = { version = "0.3", optional = true }
-ed25519-dalek = { version = "1", optional = true }
+ed25519-dalek = { git = "https://github.com/theosirian/ed25519-dalek", branch = "from-secret", optional = true }
 rand = { version = "0.7", optional = true }
 multibase = "0.8"
 simple_asn1 = "0.5"

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -202,10 +202,38 @@ impl JWK {
         })
     }
 
+    #[cfg(feature = "ring")]
+    pub fn generate_ed25519_from_secret(_secret: &str) -> Result<JWK, Error> {
+        // TODO figure out how to give a secret to ring API
+        Self::generate_ed25519()
+    }
+
     #[cfg(feature = "ed25519-dalek")]
     pub fn generate_ed25519() -> Result<JWK, Error> {
         let mut csprng = rand::rngs::OsRng {};
         let keypair = ed25519_dalek::Keypair::generate(&mut csprng);
+        let sk_bytes = keypair.secret.to_bytes();
+        let pk_bytes = keypair.public.to_bytes();
+        Ok(JWK {
+            params: Params::OKP(OctetParams {
+                curve: "Ed25519".to_string(),
+                public_key: Base64urlUInt(pk_bytes.to_vec()),
+                private_key: Some(Base64urlUInt(sk_bytes.to_vec())),
+            }),
+            public_key_use: None,
+            key_operations: None,
+            algorithm: None,
+            key_id: None,
+            x509_url: None,
+            x509_certificate_chain: None,
+            x509_thumbprint_sha1: None,
+            x509_thumbprint_sha256: None,
+        })
+    }
+
+    #[cfg(feature = "ed25519-dalek")]
+    pub fn generate_ed25519_from_secret(secret: &str) -> Result<JWK, Error> {
+        let keypair = ed25519_dalek::Keypair::generate_from_secret(secret)?;
         let sk_bytes = keypair.secret.to_bytes();
         let pk_bytes = keypair.public.to_bytes();
         Ok(JWK {


### PR DESCRIPTION
Currently only implemented on the alternative set of crypto libraries (ed25519-dalek,sha2,rsa,rand).

Depends on changes to `ed25519-dalek` that are currently on `from-secret` branch on `https://github.com/theosirian/ed25519-dalek`