### PR TITLE
Fix linked data proofs using tz1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ http = { version = "0.2", optional = true }
 serde_urlencoded = "0.7"
 percent-encoding = { version = "2.1", optional = true }
 tokio = { version = "1.0", optional = true, features = ["macros"] }
+blake2b_simd = "0.5"
+bs58 = { version = "0.4", features = ["check"] }
 
 [workspace]
 members = [

--- a/contexts/tz-2021-v1.jsonld
+++ b/contexts/tz-2021-v1.jsonld
@@ -1,0 +1,51 @@
+{
+  "Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021": {
+    "@id": "https://w3id.org/security#Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "id": "@id",
+      "type": "@type",
+      "challenge": "https://w3id.org/security#challenge",
+      "created": {
+        "@id": "http://purl.org/dc/terms/created",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "domain": "https://w3id.org/security#domain",
+      "expires": {
+        "@id": "https://w3id.org/security#expiration",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "nonce": "https://w3id.org/security#nonce",
+      "proofPurpose": {
+        "@id": "https://w3id.org/security#proofPurpose",
+        "@type": "@vocab",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "assertionMethod": {
+            "@id": "https://w3id.org/security#assertionMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "authentication": {
+            "@id": "https://w3id.org/security#authenticationMethod",
+            "@type": "@id",
+            "@container": "@set"
+          }
+        }
+      },
+      "jws": "https://w3id.org/security#jws",
+      "verificationMethod": {
+        "@id": "https://w3id.org/security#verificationMethod",
+        "@type": "@id"
+      },
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  }
+}

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -13,5 +13,3 @@ tokio = { version = "1.0", features = ["macros", "rt"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
-blake2b_simd = "0.5"
-bs58 = { version = "0.4", features = ["check"] }

--- a/src/blakesig.rs
+++ b/src/blakesig.rs
@@ -1,0 +1,63 @@
+use crate::error::Error;
+
+use crate::jwk::{Params, JWK};
+
+const TZ1_EDPK: [u8; 4] = [0x65, 0x64, 0x70, 0x6b];
+const TZ2_SPPK: [u8; 4] = [0x73, 0x70, 0x70, 0x6b];
+const TZ3_P2PK: [u8; 4] = [0x70, 0x32, 0x70, 0x6b];
+
+const TZ1_HASH: [u8; 3] = [0x06, 0xa1, 0x9f];
+const TZ2_HASH: [u8; 3] = [0x06, 0xa1, 0xa1];
+const TZ3_HASH: [u8; 3] = [0x06, 0xa1, 0xa4];
+
+// 'E' + 'd25519BLAKE2BDigestSize20Base58CheckEncoded'.length + 'Sig2021'
+
+fn curve_to_prefixes(curve: &str) -> Result<(&'static [u8; 4], &'static [u8; 3]), Error> {
+    let prefix = match curve {
+        "Ed25519" => (&TZ1_EDPK, &TZ1_HASH),
+        "secp256k1" => (&TZ2_SPPK, &TZ2_HASH),
+        "P-256" => (&TZ3_P2PK, &TZ3_HASH),
+        _ => return Err(Error::KeyTypeNotImplemented),
+    };
+    Ok(prefix)
+}
+
+pub fn hash_public_key(jwk: &JWK) -> Result<String, Error> {
+    let params = match jwk.params {
+        Params::OKP(ref okp_params) => okp_params,
+        _ => return Err(Error::KeyTypeNotImplemented),
+    };
+    let (inner_prefix, outer_prefix) = curve_to_prefixes(&params.curve)?;
+    let encoded = bs58::encode(&params.public_key.0);
+    let pk_b58_vec = encoded.into_vec();
+    let mut inner = Vec::with_capacity(4 + pk_b58_vec.len());
+    inner.extend_from_slice(inner_prefix);
+    inner.extend(pk_b58_vec);
+    let mut hasher = blake2b_simd::Params::new();
+    hasher.hash_length(20);
+    let blake2b = hasher.hash(&inner);
+    let blake2b = blake2b.as_bytes();
+    let mut outer = Vec::with_capacity(23);
+    outer.extend_from_slice(outer_prefix);
+    outer.extend_from_slice(&blake2b);
+    let encoded = bs58::encode(&outer).with_check().into_string();
+    Ok(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn hash() {
+        let jwk: JWK = serde_json::from_str(
+            r#"{
+              "crv": "Ed25519",
+              "kty": "OKP",
+              "x": "G80iskrv_nE69qbGLSpeOHJgmV4MKIzsy5l5iT6pCww"
+            }"#,
+        )
+        .unwrap();
+        let hash = hash_public_key(&jwk).unwrap();
+        assert_eq!(hash, "tz1iY7Am8EqrewptzQXYRZDPKvYnFLzWRgBK");
+    }
+}

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -173,17 +173,12 @@ async fn sign(
         }
     }
     let proof = Proof {
-        type_: type_.to_string(),
         proof_purpose: options.proof_purpose.clone(),
-        proof_value: None,
         verification_method: options.verification_method.clone(),
-        creator: None,
         created: Some(options.created.unwrap_or_else(now_ms)),
         domain: options.domain.clone(),
         challenge: options.challenge.clone(),
-        nonce: None,
-        property_set: None,
-        jws: None,
+        ..Proof::new(type_)
     };
     sign_proof(document, proof, key, algorithm).await
 }
@@ -266,17 +261,13 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         let jwk_value = serde_json::to_value(key.to_public())?;
         property_set.insert("publicKeyJwk".to_string(), jwk_value);
         let proof = Proof {
-            type_: "Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021".to_string(),
             proof_purpose: options.proof_purpose.clone(),
-            proof_value: None,
             verification_method: options.verification_method.clone(),
-            creator: None,
             created: Some(options.created.unwrap_or_else(now_ms)),
             domain: options.domain.clone(),
             challenge: options.challenge.clone(),
-            nonce: None,
-            jws: None,
             property_set: Some(property_set),
+            ..Proof::new("Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021")
         };
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         sign_proof(document, proof, key, Algorithm::EdDSA).await

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -10,11 +10,12 @@ use crate::jwk::{Algorithm, OctetParams as JWKOctetParams, Params as JWKParams, 
 use crate::rdf::DataSet;
 use crate::urdna2015;
 use crate::vc::{Context, Contexts, LinkedDataProofOptions, Proof};
+use serde_json::Value;
 
 // TODO: factor out proof types
 lazy_static! {
     /// JSON-LD context for Linked Data Proofs based on Tezos addresses
-    pub static ref TZ_CONTEXT: Context = {
+    pub static ref TZ_CONTEXT: Value = {
         let context_str = include_str!("../contexts/tz-2021-v1.jsonld");
         serde_json::from_str(&context_str).unwrap()
     };
@@ -273,7 +274,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         property_set.insert("publicKeyJwk".to_string(), jwk_value);
         // It needs custom JSON_LD context too.
         let proof = Proof {
-            context: Some(Contexts::One(TZ_CONTEXT.clone())),
+            context: TZ_CONTEXT.clone(),
             proof_purpose: options.proof_purpose.clone(),
             verification_method: options.verification_method.clone(),
             created: Some(options.created.unwrap_or_else(now_ms)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod blakesig;
 pub mod der;
 pub mod did;
 pub mod did_resolve;

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -114,9 +114,12 @@ pub struct ObjectWithId {
     pub property_set: Option<Map<String, Value>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Proof {
+    #[serde(rename = "@context")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<Contexts>,
     #[serde(rename = "type")]
     pub type_: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -221,7 +224,7 @@ pub struct RefreshService {
 #[serde(rename_all = "camelCase")]
 pub struct Presentation {
     #[serde(rename = "@context")]
-    pub context: Vec<String>,
+    pub context: Contexts,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<URI>,
     #[serde(rename = "type")]
@@ -875,6 +878,13 @@ macro_rules! assert_local {
 }
 
 impl Proof {
+    pub fn new(type_: &str) -> Self {
+        Self {
+            type_: type_.to_string(),
+            ..Default::default()
+        }
+    }
+
     pub fn matches(&self, options: &LinkedDataProofOptions) -> bool {
         if let Some(ref verification_method) = options.verification_method {
             assert_local!(self.verification_method.as_ref() == Some(verification_method));
@@ -1298,7 +1308,7 @@ _:c14n0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#asse
 
         // Issue Presentation with Credential
         let mut vp = Presentation {
-            context: vec![DEFAULT_CONTEXT.to_string()],
+            context: Contexts::Many(vec![Context::URI(URI::String(DEFAULT_CONTEXT.to_string()))]),
             id: Some(URI::String(
                 "http://example.org/presentations/3731".to_string(),
             )),

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -118,8 +118,9 @@ pub struct ObjectWithId {
 #[serde(rename_all = "camelCase")]
 pub struct Proof {
     #[serde(rename = "@context")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub context: Option<Contexts>,
+    // TODO: use consistent types for context
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub context: Value,
     #[serde(rename = "type")]
     pub type_: String,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Linked data proofs using the proof type `Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021` need some custom context, since this proof type is not in the default VC v1 context, and it requires a public key in the proof rather than just a verification method URL.

- Add the custom context in the proof object instead of requiring it to be added to the credential and/or presentation object. This allows issuing and verifying to be done about the same as with `did:key`.
- Move the custom context into its own file in the repo.
- Fix key verification. Previously we were using `to_did_method` to upcast the resolver to a DIDMethod to get a reference to DIDTz, but this doesn't work if there is a layer of indirection in the resolver. Instead, make `ldp.rs` call the key verification (hashing) code directly. This is put in `src/blakesig.rs`.
- Proof struct is update to allow arbitrary `@context`. I was going to reuse the`Context` struct like with the other `context` properties, but there was an error when deserializing about `OneOrMany`, so instead we just use a `Value`.
- Test verification of presentations with `did:tz`

Putting JSON-LD context in the proof object I haven't seen done before, but it is valid JSON-LD so should be fine. `vc-http-api` doesn't set `additionalProperties: false` like it does on `LinkedDataProofOptions`, so I think it is okay to extend it in this way.