### PR TITLE
Implement external signing for credential proofs

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -258,6 +258,9 @@ impl JWK {
             return Some(algorithm);
         }
         match &self.params {
+            Params::RSA(_) => {
+                return Some(Algorithm::RS256);
+            }
             Params::OKP(okp_params) if okp_params.curve == "Ed25519" => {
                 return Some(Algorithm::EdDSA);
             }

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -299,6 +299,27 @@ pub fn detached_sign_unencoded_payload(
     Ok(jws)
 }
 
+pub fn prepare_detached_unencoded_payload(
+    algorithm: Algorithm,
+    payload: &[u8],
+) -> Result<(Header, Vec<u8>), Error> {
+    let header = Header {
+        algorithm,
+        critical: Some(vec!["b64".to_string()]),
+        base64urlencode_payload: Some(false),
+        ..Default::default()
+    };
+    let header_b64 = base64_encode_json(&header)?;
+    let signing_input = [header_b64.as_bytes(), b".", payload].concat().to_vec();
+    Ok((header, signing_input))
+}
+
+pub fn complete_sign_unencoded_payload(header: Header, sig_b64: &str) -> Result<String, Error> {
+    let header_b64 = base64_encode_json(&header)?;
+    let jws = header_b64 + ".." + sig_b64;
+    Ok(jws)
+}
+
 pub fn encode_sign(algorithm: Algorithm, payload: &str, key: &JWK) -> Result<String, Error> {
     let header = Header {
         algorithm,


### PR DESCRIPTION
Builds on #93. Partially implements #53.

This adds a mode for creating proofs for verifiable credentials without `ssi`/DIDKit having access to the private key material. Instead of calling `issueCredential`, callers use `prepareIssueCredential` which takes the same options except without the private key, and returns a `ProofPreparation`. The `ProofPreparation` data structure includes the signing input bytes that need to be signed, along with data needed to resume creating the proof. The caller then externally signs the signing input, and passes it back along with the `ProofPreparation` struct, to the `completeIssueCredential` function, which recombines it into the proof to add to the credential and return it is a newly issued verifiable credential.

Currently this technique is implemented for all the supported proof types, but it is not fully tested for all of them. It is also only implemented for issuing credentials - but the pattern could be reused for issuing/proving verifiable presentations, reusing the `ProofPreparation` struct.

This technique is as an alternative to making `issueCredential` take a callback parameter to request a signature interactively. Instead, control flow remains with the caller.