### PR TITLE
Update json-ld to allow using Rust stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,10 @@ jobs:
       run: cargo test --no-default-features --features rsa,ed25519-dalek,sha2,rand
 
     - name: Test with secp256k1
-      run: cargo test --verbose --workspace --features did-tezos/secp256k1,did-key/secp256k1
+      run: |
+        cargo test --verbose --workspace --features secp256k1
+        cargo test --verbose --manifest-path did-key/Cargo.toml --features secp256k1,ssi/ring
+        cargo test --verbose --manifest-path did-tezos/Cargo.toml --features secp256k1,ssi/ring
 
     - name: Test DID Resolution HTTP(S) Binding
       run: cargo test --features http-did

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
 
-    - name: Install Rust nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        default: true
-
     - name: Build
       run: cargo build --verbose --workspace
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ simple_asn1 = "0.5"
 num-bigint = "0.3"
 async-std = { version = "1.9", features = ["attributes"] }
 async-trait = "0.1"
-json-ld = { git = "https://github.com/timothee-haudebourg/json-ld", rev = "fba5a917638d9f0fc87a450c6dc6de0efdf8ae06" }
+json-ld = { git = "https://github.com/timothee-haudebourg/json-ld", rev = "2475710209fa2a89272294eff1dfe6bf19c2016e" }
 # json = "^0.12"
 json = { git = "https://github.com/timothee-haudebourg/json-rust", branch = "fix#190" }
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 default = ["ring"]
 http-did = ["hyper", "hyper-tls", "http", "percent-encoding", "tokio"]
+secp256k1 = ["libsecp256k1", "rand"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -31,14 +31,8 @@ packages.
 
 ## Install
 
-Please note you must be using Rust 1.51.0 or higher, which is currently `nightly`.
-
 ```sh
-# if using rustup
-$ rustup toolchain install nightly
-$ rustup default nightly
-
-$ git clone https://github.com/spruceid/ssi .
+$ git clone https://github.com/spruceid/ssi
 $ cd ssi
 $ git submodule update
 $ cargo build
@@ -49,4 +43,3 @@ $ cargo build
 - [Rust](https://www.rust-lang.org/)
 - [rustup](https://rustup.rs/)
 - [Cargo](https://doc.rust-lang.org/cargo/)
-- [installing-rust](https://doc.rust-lang.org/nightly/edition-guide/rust-2018/rustup-for-managing-rust-versions.html)

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Charles E. Lehner <charles.lehner@spruceid.com>"]
 edition = "2018"
 
 [features]
-secp256k1 = ["libsecp256k1", "ssi/libsecp256k1", "ssi/rand"]
+secp256k1 = ["libsecp256k1", "ssi/secp256k1", "ssi/rand"]
 
 [dependencies]
 ssi = { path = "../", default-features = false }

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Bihel <simon.bihel@spruceid.com>"]
 edition = "2018"
 
 [features]
-secp256k1 = ["libsecp256k1", "ssi/libsecp256k1", "ssi/rand"]
+secp256k1 = ["libsecp256k1", "ssi/secp256k1", "ssi/rand"]
 
 [dependencies]
 ssi = { path = "../", default-features = false }


### PR DESCRIPTION
Since https://github.com/timothee-haudebourg/json-ld/pull/10, we can use Rust stable.

Minor updates were needed to the `secp256k1` test command in CI.