### PR TITLE
Add did:ethr and EIP-712-based linked data proof type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,14 @@ blake2b_simd = "0.5"
 bs58 = { version = "0.4", features = ["check"] }
 libsecp256k1 = { version = "0.3", optional = true }
 thiserror = "1.0"
+keccak-hash = { version = "0.7", optional = true }
 
 [workspace]
 members = [
   "did-tezos",
   "did-key",
   "did-web",
+  "did-ethr",
   "vc-test",
 ]
 

--- a/contexts/eip712vm.jsonld
+++ b/contexts/eip712vm.jsonld
@@ -1,0 +1,52 @@
+{
+  "Eip712Method2021": "https://w3id.org/security#Eip712Method2021",
+  "Eip712Signature2021": {
+    "@id": "https://w3id.org/security#Eip712Signature2021",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "id": "@id",
+      "type": "@type",
+      "challenge": "https://w3id.org/security#challenge",
+      "created": {
+        "@id": "http://purl.org/dc/terms/created",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "domain": "https://w3id.org/security#domain",
+      "expires": {
+        "@id": "https://w3id.org/security#expiration",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "nonce": "https://w3id.org/security#nonce",
+      "proofPurpose": {
+        "@id": "https://w3id.org/security#proofPurpose",
+        "@type": "@vocab",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "assertionMethod": {
+            "@id": "https://w3id.org/security#assertionMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "authentication": {
+            "@id": "https://w3id.org/security#authenticationMethod",
+            "@type": "@id",
+            "@container": "@set"
+          }
+        }
+      },
+      "proofValue": "https://w3id.org/security#proofValue",
+      "verificationMethod": {
+        "@id": "https://w3id.org/security#verificationMethod",
+        "@type": "@id"
+      },
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  }
+}

--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "did-ethr"
+version = "0.0.1"
+authors = ["Spruce Systems, Inc."]
+edition = "2018"
+
+[dependencies]
+ssi = { path = "../", default-features = false, features = ["secp256k1", "keccak-hash"] }
+chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1.0", features = ["macros", "rt"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+async-trait = "0.1"
+libsecp256k1 = { version = "0.3" }
+keccak-hash = "0.7"

--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -1,0 +1,293 @@
+use async_trait::async_trait;
+use chrono::prelude::*;
+
+use ssi::caip10::BlockchainAccountId;
+use ssi::did::{
+    Context, Contexts, DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap,
+    DEFAULT_CONTEXT, DIDURL,
+};
+use ssi::did_resolve::{
+    DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
+    TYPE_DID_LD_JSON,
+};
+
+/// did:ethr DID Method
+///
+/// [Specification](https://github.com/decentralized-identity/ethr-did-resolver/)
+pub struct DIDEthr;
+
+fn parse_did(did: &str) -> Option<(i64, String)> {
+    let (network, address) = match did.split(':').collect::<Vec<&str>>().as_slice() {
+        ["did", "ethr", address] => ("mainnet".to_string(), address.to_string()),
+        ["did", "ethr", network, address] => (network.to_string(), address.to_string()),
+        _ => return None,
+    };
+    if address.len() != 42 {
+        return None;
+    }
+    let chain_id = match &network[..] {
+        "mainnet" => 1,
+        "morden" => 2,
+        "ropsten" => 3,
+        "rinkeby" => 4,
+        "goerli" => 5,
+        "kovan" => 42,
+        network_chain_id if network_chain_id.starts_with("0x") => {
+            match i64::from_str_radix(&network_chain_id[2..], 16) {
+                Ok(chain_id) => chain_id,
+                Err(_) => return None,
+            }
+        }
+        _ => {
+            return None;
+        }
+    };
+    Some((chain_id, address))
+}
+
+#[async_trait]
+impl DIDResolver for DIDEthr {
+    async fn resolve(
+        &self,
+        did: &str,
+        _input_metadata: &ResolutionInputMetadata,
+    ) -> (
+        ResolutionMetadata,
+        Option<Document>,
+        Option<DocumentMetadata>,
+    ) {
+        let (chain_id, address) = match parse_did(did) {
+            Some(parsed) => parsed,
+            None => {
+                return (
+                    ResolutionMetadata::from_error(&ERROR_INVALID_DID),
+                    None,
+                    None,
+                )
+            }
+        };
+
+        let blockchain_account_id = BlockchainAccountId {
+            account_address: address,
+            chain_id: format!("eip155:{}", chain_id),
+        };
+        let vm_didurl = DIDURL {
+            did: did.to_string(),
+            fragment: Some("controller".to_string()),
+            ..Default::default()
+        };
+        let vm = VerificationMethod::Map(VerificationMethodMap {
+            id: vm_didurl.to_string(),
+            type_: "EcdsaSecp256k1RecoveryMethod2020".to_string(),
+            controller: did.to_string(),
+            blockchain_account_id: Some(blockchain_account_id.to_string()),
+            ..Default::default()
+        });
+
+        let doc = Document {
+            context: Contexts::One(Context::URI(DEFAULT_CONTEXT.to_string())),
+            id: did.to_string(),
+            authentication: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
+            assertion_method: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
+            verification_method: Some(vec![vm]),
+            ..Default::default()
+        };
+
+        let res_meta = ResolutionMetadata {
+            content_type: Some(TYPE_DID_LD_JSON.to_string()),
+            ..Default::default()
+        };
+
+        let doc_meta = DocumentMetadata {
+            created: Some(Utc::now()),
+            ..Default::default()
+        };
+
+        (res_meta, Some(doc), Some(doc_meta))
+    }
+
+    fn to_did_method(&self) -> Option<&dyn DIDMethod> {
+        Some(self)
+    }
+}
+
+impl DIDMethod for DIDEthr {
+    fn name(&self) -> &'static str {
+        return "ethr";
+    }
+
+    fn generate(&self, source: &Source) -> Option<String> {
+        let jwk = match source {
+            Source::Key(jwk) => jwk,
+            _ => return None,
+        };
+        let hash = match ssi::keccak_hash::hash_public_key(jwk) {
+            Ok(hash) => hash,
+            _ => return None,
+        };
+        let did = format!("did:ethr:{}", hash);
+        Some(did)
+    }
+
+    fn to_resolver(&self) -> &dyn DIDResolver {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use ssi::did_resolve::ResolutionInputMetadata;
+    use ssi::jwk::JWK;
+
+    #[test]
+    fn jwk_to_did_ethr() {
+        let jwk: JWK = serde_json::from_value(json!({
+            "alg": "ES256K-R",
+            "kty": "EC",
+            "crv": "secp256k1",
+            "x": "yclqMZ0MtyVkKm1eBh2AyaUtsqT0l5RJM3g4SzRT96A",
+            "y": "yQzUwKnftWCJPGs-faGaHiYi1sxA6fGJVw2Px_LCNe8",
+        }))
+        .unwrap();
+        let did = DIDEthr.generate(&Source::Key(&jwk)).unwrap();
+        assert_eq!(did, "did:ethr:0x2fbf1be19d90a29aea9363f4ef0b6bf1c4ff0758");
+    }
+
+    #[tokio::test]
+    async fn resolve_did_ethr() {
+        // https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md#create-register
+        let (res_meta, doc_opt, _meta_opt) = DIDEthr
+            .resolve(
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+                &ResolutionInputMetadata::default(),
+            )
+            .await;
+        assert_eq!(res_meta.error, None);
+        let doc = doc_opt.unwrap();
+        eprintln!("{}", serde_json::to_string_pretty(&doc).unwrap());
+        assert_eq!(
+            serde_json::to_value(doc).unwrap(),
+            json!({
+              "@context": "https://www.w3.org/ns/did/v1",
+              "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+              "verificationMethod": [{
+                "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller",
+                "type": "EcdsaSecp256k1RecoveryMethod2020",
+                "controller": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+                "blockchainAccountId": "0xb9c5714089478a327f09197987f16f9e5d936e8a@eip155:1"
+              }],
+              "authentication": [
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller"
+              ],
+              "assertionMethod": [
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller"
+              ]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn credential_prove_verify_did_ethr() {
+        use ssi::jwk::Algorithm;
+        use ssi::vc::{Credential, Issuer, LinkedDataProofOptions, URI};
+
+        let mut key = JWK::generate_secp256k1().unwrap();
+        // mark this key as being for use with key recovery
+        key.algorithm = Some(Algorithm::ES256KR);
+        let did = DIDEthr.generate(&Source::Key(&key)).unwrap();
+        let mut vc: Credential = serde_json::from_value(json!({
+            "@context": "https://www.w3.org/2018/credentials/v1",
+            "type": "VerifiableCredential",
+            "issuer": did.clone(),
+            "issuanceDate": "2021-02-18T20:23:13Z",
+            "credentialSubject": {
+                "id": "did:example:foo"
+            }
+        }))
+        .unwrap();
+        vc.validate_unsigned().unwrap();
+        let mut issue_options = LinkedDataProofOptions::default();
+        issue_options.verification_method = Some(did.to_string() + "#controller");
+        eprintln!("vm {:?}", issue_options.verification_method);
+        let vc_no_proof = vc.clone();
+        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        println!("{}", serde_json::to_string_pretty(&proof).unwrap());
+        vc.add_proof(proof);
+        vc.validate().unwrap();
+        let verification_result = vc.verify(None, &DIDEthr).await;
+        println!("{:#?}", verification_result);
+        assert!(verification_result.errors.is_empty());
+
+        // test that issuer property is used for verification
+        let mut vc_bad_issuer = vc.clone();
+        vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
+        assert!(vc_bad_issuer.verify(None, &DIDEthr).await.errors.len() > 0);
+
+        // Check that proof JWK must match proof verificationMethod
+        let mut vc_wrong_key = vc_no_proof.clone();
+        let other_key = JWK::generate_ed25519().unwrap();
+        use ssi::ldp::ProofSuite;
+        let proof_bad = ssi::ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021::sign(
+            &vc_no_proof,
+            &issue_options,
+            &other_key,
+        )
+        .await
+        .unwrap();
+        vc_wrong_key.add_proof(proof_bad);
+        vc_wrong_key.validate().unwrap();
+        assert!(vc_wrong_key.verify(None, &DIDEthr).await.errors.len() > 0);
+
+        // Make it into a VP
+        use ssi::one_or_many::OneOrMany;
+        use ssi::vc::{CredentialOrJWT, Presentation, ProofPurpose, DEFAULT_CONTEXT};
+        let mut vp = Presentation {
+            context: ssi::vc::Contexts::Many(vec![ssi::vc::Context::URI(ssi::vc::URI::String(
+                DEFAULT_CONTEXT.to_string(),
+            ))]),
+
+            id: Some(URI::String(
+                "http://example.org/presentations/3731".to_string(),
+            )),
+            type_: OneOrMany::One("VerifiablePresentation".to_string()),
+            verifiable_credential: OneOrMany::One(CredentialOrJWT::Credential(vc)),
+            proof: None,
+            holder: None,
+            property_set: None,
+        };
+        let mut vp_issue_options = LinkedDataProofOptions::default();
+        vp.holder = Some(URI::String(did.to_string()));
+        vp_issue_options.verification_method = Some(did.to_string() + "#controller");
+        vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
+        eprintln!("vp: {}", serde_json::to_string_pretty(&vp).unwrap());
+        let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
+        vp.add_proof(vp_proof);
+        println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
+        vp.validate().unwrap();
+        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDEthr).await;
+        println!("{:#?}", vp_verification_result);
+        assert!(vp_verification_result.errors.is_empty());
+
+        // mess with the VP proof to make verify fail
+        let mut vp1 = vp.clone();
+        match vp1.proof {
+            Some(OneOrMany::One(ref mut proof)) => match proof.jws {
+                Some(ref mut jws) => {
+                    jws.insert(0, 'x');
+                }
+                _ => unreachable!(),
+            },
+            _ => unreachable!(),
+        }
+        let vp_verification_result = vp1.verify(Some(vp_issue_options), &DIDEthr).await;
+        println!("{:#?}", vp_verification_result);
+        assert!(vp_verification_result.errors.len() >= 1);
+
+        // test that holder is verified
+        let mut vp2 = vp.clone();
+        vp2.holder = Some(URI::String("did:example:bad".to_string()));
+        assert!(vp2.verify(None, &DIDEthr).await.errors.len() > 0);
+    }
+}

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -1,0 +1,571 @@
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::num::ParseIntError;
+use std::str::FromStr;
+
+use keccak_hash::keccak;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::ldp::LinkedDataDocument;
+use crate::vc::Proof;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+#[serde(try_from = "String", into = "String")]
+pub enum Type {
+    Bytes,
+    String,
+    BytesN(u16),
+    UintN(u16),
+    IntN(u16),
+    Bool,
+    Address,
+    Array(Box<Type>),
+    ArrayN(Box<Type>, u16),
+    Reference(String),
+}
+
+#[derive(Error, Debug)]
+pub enum TypedDataParseError {
+    // #[error("Unknown data type: {0}")]
+    // UnknownType(String),
+    #[error("Unable to parse data type size: {0}")]
+    SizeParse(#[from] ParseIntError),
+}
+
+impl TryFrom<String> for Type {
+    type Error = TypedDataParseError;
+    fn try_from(string: String) -> Result<Self, Self::Error> {
+        match &string[..] {
+            "bytes" => return Ok(Type::Bytes),
+            "string" => return Ok(Type::String),
+            "address" => return Ok(Type::Address),
+            "bool" => return Ok(Type::Bool),
+            _ => {}
+        }
+        if string.starts_with("uint") {
+            return Ok(Type::UintN(u16::from_str(&string[4..])?));
+        } else if string.starts_with("int") {
+            return Ok(Type::IntN(u16::from_str(&string[3..])?));
+        } else if string.starts_with("bytes") {
+            return Ok(Type::BytesN(u16::from_str(&string[5..])?));
+        } else if string.ends_with("]") {
+            let mut parts = string.rsplitn(2, "[");
+            let amount_str = parts.next().unwrap().split("]").next().unwrap();
+            let base = Type::try_from(parts.next().unwrap().to_string())?;
+            if amount_str.len() == 0 {
+                return Ok(Type::Array(Box::new(base)));
+            } else {
+                return Ok(Type::ArrayN(Box::new(base), u16::from_str(amount_str)?));
+            }
+        }
+        Ok(Type::Reference(string))
+    }
+}
+
+impl From<Type> for String {
+    fn from(type_: Type) -> String {
+        match type_ {
+            Type::Bytes => String::from("bytes"),
+            Type::String => String::from("string"),
+            Type::BytesN(n) => format!("bytes{}", n),
+            Type::UintN(n) => format!("uint{}", n),
+            Type::IntN(n) => format!("int{}", n),
+            Type::Bool => String::from("address"),
+            Type::Address => String::from("address"),
+            Type::Array(type_) => format!("{}[]", String::from(*type_)),
+            Type::ArrayN(type_, n) => format!("{}[{}]", String::from(*type_), n),
+            Type::Reference(string) => string,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Member {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: Type,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Struct(Vec<Member>);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Types {
+    // TODO: collapse eip712_domain into hashmap
+    #[serde(rename = "EIP712Domain")]
+    eip712_domain: Struct,
+    #[serde(flatten)]
+    types: HashMap<String, Struct>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum Data {
+    Struct(HashMap<String, Data>),
+    Array(Vec<Data>),
+    String(String),
+    Bytes(Vec<u8>),
+    Bool(bool),
+    NegativeNumber(i32),
+    Number(u32),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TypedData {
+    pub types: Types,
+    pub primary_type: String,
+    pub domain: Data,
+    pub message: Data,
+}
+
+#[derive(Error, Debug)]
+pub enum TypedDataConstructionError {
+    #[error("Unable to convert document to data set: {0}")]
+    DocumentToDataset(String),
+    #[error("Unable to convert proof to data set: {0}")]
+    ProofToDataset(String),
+    #[error("Unable to normalize document: {0}")]
+    NormalizeDocument(String),
+    #[error("Unable to normalize proof: {0}")]
+    NormalizeProof(String),
+}
+
+#[derive(Error, Debug)]
+pub enum TypedDataHashError {
+    #[error("Error parsing types: {0}")]
+    Parse(TypedDataParseError),
+    #[error("Missing primary type struct")]
+    MissingPrimaryTypeStruct,
+    #[error("Missing referenced type: {0}")]
+    MissingReferencedType(String),
+    #[error("Missing defined type: {0}")]
+    MissingDefinedType(String),
+    #[error("Expected reference type for '{0}'")]
+    ExpectedReference(String),
+    #[error("Not implemented")]
+    NotImplemented,
+}
+
+lazy_static! {
+    /// <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
+    pub static ref EIP712_DOMAIN: Struct = {
+        Struct(vec![
+            Member {
+                name: "name".to_string(),
+                type_: Type::String
+            },
+            Member {
+                name: "version".to_string(),
+                type_: Type::String
+            },
+            Member {
+                name: "chainId".to_string(),
+                type_: Type::UintN(256)
+            },
+            Member {
+                name: "verifyingContract".to_string(),
+                type_: Type::Address
+            },
+            Member {
+                name: "salt".to_string(),
+                type_: Type::BytesN(32)
+            }
+        ])
+    };
+}
+
+impl Struct {
+    /// [`encodeType`](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-encodetype)
+    pub fn encode(&self, name: &str, more_types: &Types) -> Result<Vec<u8>, TypedDataHashError> {
+        let mut string = String::new();
+        self.encode_single(name, &mut string);
+        let mut referenced_types = HashMap::new();
+        self.gather_referenced_types(more_types, &mut referenced_types)?;
+        let mut types: Vec<(&String, &Struct)> = referenced_types.into_iter().collect();
+        types.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
+        for (name, type_) in types {
+            type_.encode_single(name, &mut string);
+        }
+        Ok(string.into_bytes())
+    }
+
+    fn encode_single(&self, name: &str, string: &mut String) {
+        string.push_str(&name);
+        string.push('(');
+        let mut first = true;
+        for member in &self.0 {
+            if first {
+                first = false;
+            } else {
+                string.push(',');
+            }
+            string.push_str(&String::from(member.type_.clone()));
+            string.push(' ');
+            string.push_str(&member.name);
+        }
+        string.push(')');
+    }
+
+    fn gather_referenced_types<'a>(
+        &'a self,
+        types: &'a Types,
+        memo: &mut HashMap<&'a String, &'a Struct>,
+    ) -> Result<(), TypedDataHashError> {
+        for member in &self.0 {
+            if let Type::Reference(ref reference_name) = member.type_ {
+                use std::collections::hash_map::Entry;
+                let entry = memo.entry(reference_name);
+                if let Entry::Vacant(o) = entry {
+                    let referenced_struct = types.types.get(reference_name).ok_or(
+                        TypedDataHashError::MissingReferencedType(reference_name.to_string()),
+                    )?;
+                    o.insert(referenced_struct);
+                    referenced_struct.gather_referenced_types(types, memo)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Data {
+    /// [`hashStruct`](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-hashstruct)
+    pub fn hash(
+        &self,
+        type_: &Struct,
+        name: &str,
+        more_types: &Types,
+    ) -> Result<[u8; 32], TypedDataHashError> {
+        let encoded_data = self.encode(type_, more_types)?.to_vec();
+        let encoded_type = type_.encode(name, more_types)?;
+        let type_hash = keccak(encoded_type).to_fixed_bytes().to_vec();
+        Ok(keccak(vec![type_hash, encoded_data].concat()).to_fixed_bytes())
+    }
+
+    /// [`encodeData`](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-encodedata)
+    pub fn encode(&self, _type: &Struct, _types: &Types) -> Result<Vec<u8>, TypedDataHashError> {
+        Err(TypedDataHashError::NotImplemented)
+        /*
+        let enc = match self {
+            Data::Struct(map) => {
+                let mut enc = Vec::with_capacity(32 * type_.0.len());
+                for member in &type_.0 {
+                    / *
+                    let member_encoded = value.encode(member_type, types)?;
+                    enc.extend_from_slice(&mut member_encoded);
+                    * /
+                    eprintln!("member {:?}", member);
+                    let value =
+                        map.get(&member.name)
+                            .ok_or(TypedDataHashError::MissingDefinedType(
+                                member.name.to_string(),
+                            ))?;
+                    eprintln!("value {:?}", value);
+                    let member_struct = if let Type::Reference(ref reference_name) = member.type_ {
+                        types.types.get(reference_name).ok_or(
+                            TypedDataHashError::MissingReferencedType(reference_name.to_string()),
+                        )?
+                    } else {
+                        / *
+                            return Err(TypedDataHashError::ExpectedReference(
+                                member.name.to_string(),
+                            ))
+                        }
+                        * /
+                    };
+                    eprintln!("memstruct {:?}", member_struct);
+                    let mut member_hash = value.hash(member_struct, &member.name, types)?;
+                    enc.extend_from_slice(&mut member_hash);
+                }
+                // TODO: check that no extra types in map
+                enc
+            }
+            Data::Array(array) => {
+                let mut enc = Vec::with_capacity(32 * array.len());
+                for data in array {
+                    // enc.push(data.encode())
+                }
+                enc
+            }
+            Data::String(string) => keccak(string.as_bytes()).to_fixed_bytes().to_vec(),
+            Data::Bytes(bytes) => keccak(bytes).to_fixed_bytes().to_vec(),
+            Data::Bool(true) => {
+                vec![0, 0, 0, 0, 0, 0, 0, 1]
+            }
+            Data::Bool(false) => {
+                vec![0, 0, 0, 0, 0, 0, 0, 0]
+            }
+            Data::Number(num) => num.to_be_bytes().to_vec(),
+            Data::NegativeNumber(num) => num.to_be_bytes().to_vec(),
+        };
+        Ok(enc)
+        */
+    }
+}
+
+impl TypedData {
+    pub async fn from_document_and_options(
+        document: &(dyn LinkedDataDocument + Sync),
+        proof: &Proof,
+    ) -> Result<Self, TypedDataConstructionError> {
+        let doc_dataset = document
+            .to_dataset_for_signing(None)
+            .await
+            .map_err(|e| TypedDataConstructionError::DocumentToDataset(e.to_string()))?;
+        let doc_dataset_normalized = crate::urdna2015::normalize(&doc_dataset)
+            .map_err(|e| TypedDataConstructionError::NormalizeDocument(e.to_string()))?;
+        let sigopts_dataset = proof
+            .to_dataset_for_signing(Some(document))
+            .await
+            .map_err(|e| TypedDataConstructionError::ProofToDataset(e.to_string()))?;
+        let sigopts_dataset_normalized = crate::urdna2015::normalize(&sigopts_dataset)
+            .map_err(|e| TypedDataConstructionError::NormalizeProof(e.to_string()))?;
+
+        let types = Types {
+            eip712_domain: Struct(vec![Member {
+                name: "name".to_string(),
+                type_: Type::String,
+            }]),
+            types: vec![(
+                "LDPSigningRequest".to_string(),
+                Struct(vec![
+                    Member {
+                        name: "document".to_string(),
+                        type_: Type::Array(Box::new(Type::Array(Box::new(Type::String)))),
+                    },
+                    Member {
+                        name: "proof".to_string(),
+                        type_: Type::Array(Box::new(Type::Array(Box::new(Type::String)))),
+                    },
+                ]),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        use crate::rdf::Statement;
+        fn encode_statement(statement: Statement) -> Data {
+            let mut terms = vec![
+                Data::String(String::from(&statement.subject)),
+                Data::String(String::from(&statement.predicate)),
+                Data::String(String::from(&statement.object)),
+            ];
+            if let Some(graph_label) = statement.graph_label.as_ref() {
+                terms.push(Data::String(String::from(graph_label)));
+            }
+            Data::Array(terms)
+        }
+
+        Ok(Self {
+            types,
+            primary_type: "LDPSigningRequest".to_string(),
+            domain: Data::Struct(
+                vec![(
+                    "name".to_string(),
+                    Data::String("Eip712Method2021".to_string()),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            message: Data::Struct(
+                vec![
+                    (
+                        "document".to_string(),
+                        Data::Array(
+                            doc_dataset_normalized
+                                .statements()
+                                .into_iter()
+                                .map(encode_statement)
+                                .collect(),
+                        ),
+                    ),
+                    (
+                        "proof".to_string(),
+                        Data::Array(
+                            sigopts_dataset_normalized
+                                .statements()
+                                .into_iter()
+                                .map(encode_statement)
+                                .collect(),
+                        ),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        })
+    }
+
+    /// Encode a typed data message for hashing and signing.
+    /// [Reference[(https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#specification)
+    pub fn hash(&self) -> Result<Vec<u8>, TypedDataHashError> {
+        let message_struct = self
+            .types
+            .types
+            .get(&self.primary_type)
+            .ok_or(TypedDataHashError::MissingPrimaryTypeStruct)?;
+        let message_hash = self
+            .message
+            .hash(&message_struct, &self.primary_type, &self.types)?;
+        let domain_separator =
+            self.domain
+                .hash(&self.types.eip712_domain, "EIP712Domain", &self.types)?;
+        let bytes = vec![
+            vec![0x19, 0x01],
+            domain_separator.to_vec(),
+            message_hash.to_vec(),
+        ]
+        .concat();
+        Ok(keccak(bytes).to_fixed_bytes().to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn encode_type() {
+        let types = Types {
+            eip712_domain: Struct(Vec::new()),
+            types: vec![
+                (
+                    "Transaction".to_string(),
+                    Struct(vec![
+                        Member {
+                            name: "from".to_string(),
+                            type_: Type::Reference("Person".to_string()),
+                        },
+                        Member {
+                            name: "to".to_string(),
+                            type_: Type::Reference("Person".to_string()),
+                        },
+                        Member {
+                            name: "tx".to_string(),
+                            type_: Type::Reference("Asset".to_string()),
+                        },
+                    ]),
+                ),
+                (
+                    "Person".to_string(),
+                    Struct(vec![
+                        Member {
+                            name: "wallet".to_string(),
+                            type_: Type::Address,
+                        },
+                        Member {
+                            name: "name".to_string(),
+                            type_: Type::String,
+                        },
+                    ]),
+                ),
+                (
+                    "Asset".to_string(),
+                    Struct(vec![
+                        Member {
+                            name: "token".to_string(),
+                            type_: Type::Address,
+                        },
+                        Member {
+                            name: "amount".to_string(),
+                            type_: Type::UintN(256),
+                        },
+                    ]),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        };
+        let transaction_struct = types.types.get("Transaction").unwrap();
+        let type_encoded = transaction_struct.encode("Transaction", &types).unwrap();
+        let type_encoded_string = String::from_utf8(type_encoded).unwrap();
+        assert_eq!(type_encoded_string, "Transaction(Person from,Person to,Asset tx)Asset(address token,uint256 amount)Person(address wallet,string name)");
+    }
+
+    #[test]
+    // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#example
+    // https://github.com/ethereum/EIPs/blob/master/assets/eip-712/Example.js
+    #[ignore]
+    // TODO
+    fn hash_typed_data() {
+        let _addr = "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826";
+        let typed_data: TypedData = serde_json::from_value(json!({
+          "types": {
+            "EIP712Domain": [
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256"
+              },
+              {
+                "name": "verifyingContract",
+                "type": "address"
+              }
+            ],
+            "Person": [
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "wallet",
+                "type": "address"
+              }
+            ],
+            "Mail": [
+              {
+                "name": "from",
+                "type": "Person"
+              },
+              {
+                "name": "to",
+                "type": "Person"
+              },
+              {
+                "name": "contents",
+                "type": "string"
+              }
+            ]
+          },
+          "primaryType": "Mail",
+          "domain": {
+            "name": "Ether Mail",
+            "version": "1",
+            "chainId": 1,
+            "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+          },
+          "message": {
+            "from": {
+              "name": "Cow",
+              "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to": {
+              "name": "Bob",
+              "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents": "Hello, Bob!"
+          }
+        }))
+        .unwrap();
+        let hash = typed_data.hash().unwrap();
+        let hash_hex = crate::keccak_hash::bytes_to_lowerhex(&hash);
+        assert_eq!(
+            hash_hex,
+            "0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2"
+        );
+        /*
+        let sig_hex = crate::keccak_hash::bytes_to_lowerhex(&sig);
+        assert_eq!(sig_hex, "0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c");
+        */
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,9 @@
 use crate::caip10::BlockchainAccountIdParseError;
 use crate::caip10::BlockchainAccountIdVerifyError;
+#[cfg(feature = "keccak-hash")]
+use crate::eip712::TypedDataConstructionError;
+#[cfg(feature = "keccak-hash")]
+use crate::eip712::TypedDataHashError;
 use base64::DecodeError as Base64Error;
 #[cfg(feature = "ed25519-dalek")]
 use ed25519_dalek::SignatureError as Ed25519SignatureError;
@@ -82,6 +86,7 @@ pub enum Error {
     InvalidProofDomain,
     InvalidSignature,
     InvalidJWS,
+    MissingJWSHeader,
     MissingCredentialSchema,
     UnsupportedProperty,
     UnsupportedKeyType,
@@ -148,6 +153,10 @@ pub enum Error {
     TryFromSlice(TryFromSliceError),
     BlockchainAccountIdParse(BlockchainAccountIdParseError),
     BlockchainAccountIdVerify(BlockchainAccountIdVerifyError),
+    #[cfg(feature = "keccak-hash")]
+    TypedDataConstruction(TypedDataConstructionError),
+    #[cfg(feature = "keccak-hash")]
+    TypedDataHash(TypedDataHashError),
 }
 
 impl fmt::Display for Error {
@@ -206,6 +215,7 @@ impl fmt::Display for Error {
             Error::FutureProof => write!(f, "Proof creation time is in the future"),
             Error::InvalidSignature => write!(f, "Invalid Signature"),
             Error::InvalidJWS => write!(f, "Invalid JWS"),
+            Error::MissingJWSHeader => write!(f, "Missing JWS Header"),
             Error::InvalidProofPurpose => write!(f, "Invalid proof purpose"),
             Error::InvalidProofDomain => write!(f, "Invalid proof domain"),
             Error::MissingCredentialSchema => write!(f, "Missing credential schema for ZKP"),
@@ -276,6 +286,10 @@ impl fmt::Display for Error {
             Error::CharTryFrom(e) => e.fmt(f),
             Error::BlockchainAccountIdParse(e) => e.fmt(f),
             Error::BlockchainAccountIdVerify(e) => e.fmt(f),
+            #[cfg(feature = "keccak-hash")]
+            Error::TypedDataConstruction(e) => e.fmt(f),
+            #[cfg(feature = "keccak-hash")]
+            Error::TypedDataHash(e) => e.fmt(f),
         }
     }
 }
@@ -402,5 +416,19 @@ impl From<BlockchainAccountIdParseError> for Error {
 impl From<BlockchainAccountIdVerifyError> for Error {
     fn from(err: BlockchainAccountIdVerifyError) -> Error {
         Error::BlockchainAccountIdVerify(err)
+    }
+}
+
+#[cfg(feature = "keccak-hash")]
+impl From<TypedDataConstructionError> for Error {
+    fn from(err: TypedDataConstructionError) -> Error {
+        Error::TypedDataConstruction(err)
+    }
+}
+
+#[cfg(feature = "keccak-hash")]
+impl From<TypedDataHashError> for Error {
+    fn from(err: TypedDataHashError) -> Error {
+        Error::TypedDataHash(err)
     }
 }

--- a/src/keccak_hash.rs
+++ b/src/keccak_hash.rs
@@ -1,0 +1,49 @@
+use std::convert::TryFrom;
+
+use keccak_hash::keccak;
+
+use crate::error::Error;
+use crate::jwk::{Params, JWK};
+
+fn bytes_to_lowerhex(bytes: &[u8]) -> String {
+    "0x".to_string()
+        + &bytes
+            .iter()
+            .map(|byte| format!("{:02x}", byte))
+            .collect::<String>()
+}
+
+pub fn hash_public_key(jwk: &JWK) -> Result<String, Error> {
+    let ec_params = match jwk.params {
+        Params::EC(ref params) => params,
+        _ => return Err(Error::UnsupportedKeyType),
+    };
+    let pk = secp256k1::PublicKey::try_from(ec_params)?;
+    let pk_bytes = pk.serialize();
+    if pk_bytes[0] != secp256k1::util::TAG_PUBKEY_FULL || pk_bytes.len() != 65 {
+        return Err(Error::UnsupportedKeyType);
+    }
+    let hash = keccak(&pk_bytes[1..65]).to_fixed_bytes();
+    let hash_last20 = &hash[12..32];
+    Ok(bytes_to_lowerhex(hash_last20))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    #[test]
+    fn hash() {
+        let jwk: JWK = serde_json::from_value(json!({
+            "alg": "ES256K-R",
+            "kty": "EC",
+            "crv": "secp256k1",
+            "x": "_dV63sPUOOojf-RrM-4eAW7aa1hcPifqZmhsLqU1hHk",
+            "y": "Rjk_gUUlLupor-Z-KHs-2bMWhbpsOwAGCnO5sSQtaPc",
+        }))
+        .unwrap();
+        // https://github.com/decentralized-identity/EcdsaSecp256k1RecoverySignature2020/blob/3b6dc297f92abc912049121c38c1098d819855d2/src/__tests__/ES256K-R.spec.js#L63
+        let hash = hash_public_key(&jwk).unwrap();
+        assert_eq!(hash, "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74");
+    }
+}

--- a/src/keccak_hash.rs
+++ b/src/keccak_hash.rs
@@ -5,7 +5,7 @@ use keccak_hash::keccak;
 use crate::error::Error;
 use crate::jwk::{Params, JWK};
 
-fn bytes_to_lowerhex(bytes: &[u8]) -> String {
+pub fn bytes_to_lowerhex(bytes: &[u8]) -> String {
     "0x".to_string()
         + &bytes
             .iter()
@@ -25,13 +25,20 @@ pub fn hash_public_key(jwk: &JWK) -> Result<String, Error> {
     }
     let hash = keccak(&pk_bytes[1..65]).to_fixed_bytes();
     let hash_last20 = &hash[12..32];
-    Ok(bytes_to_lowerhex(hash_last20))
+    let hash_last20_hex = bytes_to_lowerhex(hash_last20);
+    eprintln!(
+        "jwk {}. hex: {}",
+        serde_json::to_string_pretty(jwk)?,
+        hash_last20_hex
+    );
+    Ok(hash_last20_hex)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
     #[test]
     fn hash() {
         let jwk: JWK = serde_json::from_value(json!({

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod jsonld;
 pub mod jwk;
 pub mod jws;
 pub mod jwt;
+#[cfg(feature = "keccak-hash")]
+pub mod keccak_hash;
 pub mod ldp;
 pub mod one_or_many;
 pub mod rdf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ pub mod caip10;
 pub mod der;
 pub mod did;
 pub mod did_resolve;
+#[cfg(feature = "keccak-hash")]
+pub mod eip712;
 pub mod error;
 pub mod hash;
 pub mod jsonld;

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -1238,7 +1238,12 @@ mod tests {
         let algorithm = key.algorithm.unwrap();
         let public_key = key.to_public();
         let preparation = vc.prepare_proof(&public_key, &issue_options).await.unwrap();
-        let sig = crate::jws::sign_bytes(algorithm, &preparation.signing_input, &key).unwrap();
+        let signing_input = match preparation.signing_input {
+            crate::ldp::SigningInput::Bytes(ref bytes) => bytes,
+            #[allow(unreachable_patterns)]
+            _ => panic!("Unexpected signing input type"),
+        };
+        let sig = crate::jws::sign_bytes(algorithm, &signing_input, &key).unwrap();
         let sig_b64 = base64::encode_config(sig, base64::URL_SAFE_NO_PAD);
         let proof = preparation.complete(&sig_b64).await.unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());


### PR DESCRIPTION
Based on: #94

Implements [did:ethr](https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md). There are some some differences compared to the `did:ethr` spec, due to updates to DID Core and using `EcdsaSecp256k1RecoveryMethod2020`, as mentioned in https://github.com/decentralized-identity/ethr-did-resolver/issues/99; and to add a second verification method using a new experimental linked data proof type based on [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#parameters).

The linked data proof type based on EIP-712 is named `Eip712Method2021`. The signing payload includes the [URDNA2015](https://json-ld.github.io/normalization/spec/)-canonicalized linked data document (credential) and options (proof) rendered as an array of RDF statements where each statement (quad/triple) is an array of 3 or 4 strings.

Eip712Method2021 is not yet fully implemented here as the EIP-712 hashing is incomplete. So it can only be used via external signing, and does not yet have verification working.