### PR TITLE
did:sol and SolanaMethod2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
   "did-key",
   "did-web",
   "did-ethr",
+  "did-sol",
   "vc-test",
 ]
 

--- a/contexts/solvm.jsonld
+++ b/contexts/solvm.jsonld
@@ -1,0 +1,53 @@
+{
+  "SolanaMethod2021": "https://w3id.org/security#SolanaMethod2021",
+  "SolanaSignature2021": {
+    "@id": "https://w3id.org/security#SolanaSignature2021",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "id": "@id",
+      "type": "@type",
+      "challenge": "https://w3id.org/security#challenge",
+      "created": {
+        "@id": "http://purl.org/dc/terms/created",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "domain": "https://w3id.org/security#domain",
+      "expires": {
+        "@id": "https://w3id.org/security#expiration",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "nonce": "https://w3id.org/security#nonce",
+      "proofPurpose": {
+        "@id": "https://w3id.org/security#proofPurpose",
+        "@type": "@vocab",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "assertionMethod": {
+            "@id": "https://w3id.org/security#assertionMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "authentication": {
+            "@id": "https://w3id.org/security#authenticationMethod",
+            "@type": "@id",
+            "@container": "@set"
+          }
+        }
+      },
+      "proofValue": "https://w3id.org/security#proofValue",
+      "verificationMethod": {
+        "@id": "https://w3id.org/security#verificationMethod",
+        "@type": "@id"
+      },
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  }
+}
+

--- a/did-sol/Cargo.toml
+++ b/did-sol/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "did-sol"
+version = "0.0.1"
+authors = ["Spruce Systems, Inc."]
+edition = "2018"
+
+[dependencies]
+ssi = { path = "../", default-features = false, features = [] }
+chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1.0", features = ["macros", "rt"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+async-trait = "0.1"
+bs58 = { version = "0.4", features = ["check"] }

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -1,0 +1,328 @@
+use async_trait::async_trait;
+use chrono::prelude::*;
+
+use ssi::caip10::BlockchainAccountId;
+use ssi::did::{
+    Context, Contexts, DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap,
+    DEFAULT_CONTEXT, DIDURL,
+};
+use ssi::did_resolve::{
+    DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
+    TYPE_DID_LD_JSON,
+};
+use ssi::jwk::{Base64urlUInt, OctetParams, Params, JWK};
+
+/// did:sol DID Method
+pub struct DIDSol;
+
+fn parse_did(did: &str) -> Option<(String, Vec<u8>)> {
+    let address = match did.split(':').collect::<Vec<&str>>().as_slice() {
+        ["did", "sol", address] => address.to_string(),
+        _ => return None,
+    };
+    let bytes = match bs58::decode(&address).into_vec() {
+        Ok(bytes) => bytes,
+        Err(_) => return None,
+    };
+    if bytes.len() != 32 {
+        return None;
+    }
+    Some((address, bytes))
+}
+
+#[async_trait]
+impl DIDResolver for DIDSol {
+    async fn resolve(
+        &self,
+        did: &str,
+        _input_metadata: &ResolutionInputMetadata,
+    ) -> (
+        ResolutionMetadata,
+        Option<Document>,
+        Option<DocumentMetadata>,
+    ) {
+        let (address, public_key_bytes) = match parse_did(did) {
+            Some(parsed) => parsed,
+            None => {
+                return (
+                    ResolutionMetadata::from_error(&ERROR_INVALID_DID),
+                    None,
+                    None,
+                )
+            }
+        };
+        let blockchain_account_id = BlockchainAccountId {
+            account_address: address,
+            chain_id: "solana".to_string(), // TODO: standardize
+        };
+        let vm_didurl = DIDURL {
+            did: did.to_string(),
+            fragment: Some("controller".to_string()),
+            ..Default::default()
+        };
+        let solvm_didurl = DIDURL {
+            did: did.to_string(),
+            fragment: Some("SolanaMethod2021".to_string()),
+            ..Default::default()
+        };
+        let pk_jwk = JWK {
+            params: Params::OKP(OctetParams {
+                curve: "Ed25519".to_string(),
+                public_key: Base64urlUInt(public_key_bytes),
+                private_key: None,
+            }),
+            public_key_use: None,
+            key_operations: None,
+            algorithm: None,
+            key_id: None,
+            x509_url: None,
+            x509_certificate_chain: None,
+            x509_thumbprint_sha1: None,
+            x509_thumbprint_sha256: None,
+        };
+        let vm = VerificationMethod::Map(VerificationMethodMap {
+            id: vm_didurl.to_string(),
+            type_: "Ed25519VerificationKey2018".to_string(),
+            public_key_jwk: Some(pk_jwk.clone()),
+            controller: did.to_string(),
+            blockchain_account_id: Some(blockchain_account_id.to_string()),
+            ..Default::default()
+        });
+        let solvm = VerificationMethod::Map(VerificationMethodMap {
+            id: solvm_didurl.to_string(),
+            type_: "SolanaMethod2021".to_string(),
+            public_key_jwk: Some(pk_jwk.clone()),
+            controller: did.to_string(),
+            blockchain_account_id: Some(blockchain_account_id.to_string()),
+            ..Default::default()
+        });
+
+        let doc = Document {
+            context: Contexts::One(Context::URI(DEFAULT_CONTEXT.to_string())),
+            id: did.to_string(),
+            authentication: Some(vec![
+                VerificationMethod::DIDURL(vm_didurl.clone()),
+                VerificationMethod::DIDURL(solvm_didurl.clone()),
+            ]),
+            assertion_method: Some(vec![
+                VerificationMethod::DIDURL(vm_didurl.clone()),
+                VerificationMethod::DIDURL(solvm_didurl.clone()),
+            ]),
+            // TODO: authentication/assertion_method?
+            verification_method: Some(vec![vm, solvm]),
+            ..Default::default()
+        };
+
+        let res_meta = ResolutionMetadata {
+            content_type: Some(TYPE_DID_LD_JSON.to_string()),
+            ..Default::default()
+        };
+
+        let doc_meta = DocumentMetadata {
+            created: Some(Utc::now()),
+            ..Default::default()
+        };
+
+        (res_meta, Some(doc), Some(doc_meta))
+    }
+
+    fn to_did_method(&self) -> Option<&dyn DIDMethod> {
+        Some(self)
+    }
+}
+
+impl DIDMethod for DIDSol {
+    fn name(&self) -> &'static str {
+        return "sol";
+    }
+
+    fn generate(&self, source: &Source) -> Option<String> {
+        let jwk = match source {
+            Source::Key(jwk) => jwk,
+            _ => return None,
+        };
+        let did = match jwk.params {
+            Params::OKP(ref params) if params.curve == "Ed25519" => {
+                let addr = bs58::encode(&params.public_key.0).into_string();
+                format!("did:sol:{}", addr)
+            }
+            _ => {
+                dbg!(&jwk.params);
+                return None;
+            }
+        };
+        Some(did)
+    }
+
+    fn to_resolver(&self) -> &dyn DIDResolver {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use ssi::did_resolve::ResolutionInputMetadata;
+    use ssi::jwk::JWK;
+
+    #[test]
+    fn key_to_did_sol() {
+        let jwk: JWK = serde_json::from_value(json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
+        }))
+        .unwrap();
+        let did = DIDSol.generate(&Source::Key(&jwk)).unwrap();
+        assert_eq!(did, "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev");
+    }
+
+    #[tokio::test]
+    async fn resolve_did_sol() {
+        let (res_meta, doc_opt, _meta_opt) = DIDSol
+            .resolve(
+                "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+                &ResolutionInputMetadata::default(),
+            )
+            .await;
+        assert_eq!(res_meta.error, None);
+        let doc = doc_opt.unwrap();
+        eprintln!("{}", serde_json::to_string_pretty(&doc).unwrap());
+        let doc_expected: Document =
+            serde_json::from_str(include_str!("../tests/did.jsonld")).unwrap();
+        assert_eq!(
+            serde_json::to_value(doc).unwrap(),
+            serde_json::to_value(doc_expected).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn credential_prove_verify_did_sol() {
+        eprintln!("with Ed25519VerificationKey2018...");
+        credential_prove_verify_did_sol_1(false).await;
+        eprintln!("with SolanaMethod2021...");
+        credential_prove_verify_did_sol_1(true).await;
+    }
+
+    async fn credential_prove_verify_did_sol_1(solvm: bool) {
+        use ssi::vc::{Credential, Issuer, LinkedDataProofOptions, URI};
+
+        let key: JWK = serde_json::from_value(json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": "YwT3Ce5YqSjXK_bmI35kPEmzZT2WtUSE6XTllrLUGbQ",
+            "d": "ybizk5eZVSZiUtWURVdp-dx9JWtiP9uJaWfLupGU2ZU"
+        }))
+        .unwrap();
+        let did = DIDSol.generate(&Source::Key(&key)).unwrap();
+        eprintln!("did: {}", did);
+        let mut vc: Credential = serde_json::from_value(json!({
+            "@context": "https://www.w3.org/2018/credentials/v1",
+            "type": "VerifiableCredential",
+            "issuer": did.clone(),
+            "issuanceDate": "2021-02-18T20:23:13Z",
+            "credentialSubject": {
+                "id": "did:example:foo"
+            }
+        }))
+        .unwrap();
+        vc.validate_unsigned().unwrap();
+        let mut issue_options = LinkedDataProofOptions::default();
+        if solvm {
+            issue_options.verification_method = Some(did.to_string() + "#SolanaMethod2021");
+        } else {
+            issue_options.verification_method = Some(did.to_string() + "#controller");
+        }
+        eprintln!("vm {:?}", issue_options.verification_method);
+        let vc_no_proof = vc.clone();
+        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        println!("{}", serde_json::to_string_pretty(&proof).unwrap());
+        vc.add_proof(proof);
+        vc.validate().unwrap();
+        let verification_result = vc.verify(None, &DIDSol).await;
+        println!("{:#?}", verification_result);
+        assert!(verification_result.errors.is_empty());
+
+        // test that issuer property is used for verification
+        let mut vc_bad_issuer = vc.clone();
+        vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
+        assert!(vc_bad_issuer.verify(None, &DIDSol).await.errors.len() > 0);
+
+        // Check that proof JWK must match proof verificationMethod
+        let mut vc_wrong_key = vc_no_proof.clone();
+        let other_key = JWK::generate_ed25519().unwrap();
+        use ssi::ldp::ProofSuite;
+        let proof_bad = ssi::ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021::sign(
+            &vc_no_proof,
+            &issue_options,
+            &other_key,
+        )
+        .await
+        .unwrap();
+        vc_wrong_key.add_proof(proof_bad);
+        vc_wrong_key.validate().unwrap();
+        assert!(vc_wrong_key.verify(None, &DIDSol).await.errors.len() > 0);
+
+        // Make it into a VP
+        use ssi::one_or_many::OneOrMany;
+        use ssi::vc::{CredentialOrJWT, Presentation, ProofPurpose, DEFAULT_CONTEXT};
+        let mut vp = Presentation {
+            context: ssi::vc::Contexts::Many(vec![ssi::vc::Context::URI(ssi::vc::URI::String(
+                DEFAULT_CONTEXT.to_string(),
+            ))]),
+
+            id: Some(URI::String(
+                "http://example.org/presentations/3731".to_string(),
+            )),
+            type_: OneOrMany::One("VerifiablePresentation".to_string()),
+            verifiable_credential: Some(OneOrMany::One(CredentialOrJWT::Credential(vc))),
+            proof: None,
+            holder: None,
+            property_set: None,
+        };
+        let mut vp_issue_options = LinkedDataProofOptions::default();
+        vp.holder = Some(URI::String(did.to_string()));
+        vp_issue_options.verification_method = Some(did.to_string() + "#controller");
+        vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
+        let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
+        vp.add_proof(vp_proof);
+        println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
+        vp.validate().unwrap();
+        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDSol).await;
+        println!("{:#?}", vp_verification_result);
+        assert!(vp_verification_result.errors.is_empty());
+
+        // mess with the VP proof to make verify fail
+        let mut vp1 = vp.clone();
+        match vp1.proof {
+            Some(OneOrMany::One(ref mut proof)) => match proof.jws {
+                Some(ref mut jws) => {
+                    jws.insert(0, 'x');
+                }
+                _ => unreachable!(),
+            },
+            _ => unreachable!(),
+        }
+        let vp_verification_result = vp1.verify(Some(vp_issue_options), &DIDSol).await;
+        println!("{:#?}", vp_verification_result);
+        assert!(vp_verification_result.errors.len() >= 1);
+
+        // test that holder is verified
+        let mut vp2 = vp.clone();
+        vp2.holder = Some(URI::String("did:example:bad".to_string()));
+        assert!(vp2.verify(None, &DIDSol).await.errors.len() > 0);
+    }
+
+    /*
+    #[tokio::test]
+    async fn credential_verify_eip712vm() {
+        use ssi::vc::Credential;
+        let vc: Credential = serde_json::from_str(include_str!("../tests/vc.jsonld")).unwrap();
+        eprintln!("vc {:?}", vc);
+        let verification_result = vc.verify(None, &DIDSol).await;
+        println!("{:#?}", verification_result);
+        assert!(verification_result.errors.is_empty());
+    }
+    */
+}

--- a/did-sol/tests/did.jsonld
+++ b/did-sol/tests/did.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": "https://www.w3.org/ns/did/v1",
+  "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+  "verificationMethod": [{
+    "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+    "type": "Ed25519VerificationKey2018",
+    "controller": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+    "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
+    "publicKeyJwk": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
+    }
+  }, {
+    "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
+    "type": "SolanaMethod2021",
+    "controller": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+    "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
+    "publicKeyJwk": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
+    }
+  }],
+  "authentication": [
+    "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+    "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021"
+  ],
+  "assertionMethod": [
+    "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+    "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021"
+  ]
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -158,6 +158,7 @@ pub enum Error {
     #[cfg(feature = "keccak-hash")]
     TypedDataHash(TypedDataHashError),
     FromHex(hex::FromHexError),
+    Base58(bs58::decode::Error),
     HexString,
 }
 
@@ -294,6 +295,7 @@ impl fmt::Display for Error {
             #[cfg(feature = "keccak-hash")]
             Error::TypedDataHash(e) => e.fmt(f),
             Error::FromHex(e) => e.fmt(f),
+            Error::Base58(e) => e.fmt(f),
         }
     }
 }
@@ -440,5 +442,11 @@ impl From<TypedDataHashError> for Error {
 impl From<hex::FromHexError> for Error {
     fn from(err: hex::FromHexError) -> Error {
         Error::FromHex(err)
+    }
+}
+
+impl From<bs58::decode::Error> for Error {
+    fn from(err: bs58::decode::Error) -> Error {
+        Error::Base58(err)
     }
 }

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -13,6 +13,7 @@ use crate::did_resolve::{dereference, Content, DIDResolver, DereferencingInputMe
 use crate::eip712::TypedData;
 use crate::error::Error;
 use crate::hash::sha256;
+use crate::jwk::Base64urlUInt;
 use crate::jwk::{Algorithm, OctetParams as JWKOctetParams, Params as JWKParams, JWK};
 use crate::jws::Header;
 use crate::rdf::DataSet;
@@ -90,8 +91,9 @@ pub struct ProofPreparation {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum SigningInput {
-    Bytes(Vec<u8>),
+    Bytes(Base64urlUInt),
     #[cfg(feature = "keccak-hash")]
     TypedData(TypedData),
 }
@@ -389,7 +391,7 @@ async fn prepare_proof(
     Ok(ProofPreparation {
         proof,
         jws_header: Some(jws_header),
-        signing_input: SigningInput::Bytes(signing_input),
+        signing_input: SigningInput::Bytes(Base64urlUInt(signing_input)),
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod keccak_hash;
 pub mod ldp;
 pub mod one_or_many;
 pub mod rdf;
+pub mod soltx;
 pub mod urdna2015;
 pub mod vc;
 

--- a/src/soltx.rs
+++ b/src/soltx.rs
@@ -1,0 +1,16 @@
+pub struct LocalSolanaTransaction {
+    bytes: Vec<u8>,
+}
+
+impl LocalSolanaTransaction {
+    pub fn with_message(bytes: &[u8]) -> Self {
+        // TODO
+        Self {
+            bytes: bytes.into(),
+        }
+    }
+    pub fn to_bytes(&self) -> Vec<u8> {
+        // TODO
+        self.bytes.clone()
+    }
+}

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -1255,7 +1255,7 @@ mod tests {
         let public_key = key.to_public();
         let preparation = vc.prepare_proof(&public_key, &issue_options).await.unwrap();
         let signing_input = match preparation.signing_input {
-            crate::ldp::SigningInput::Bytes(ref bytes) => bytes,
+            crate::ldp::SigningInput::Bytes(ref bytes) => &bytes.0,
             #[allow(unreachable_patterns)]
             _ => panic!("Unexpected signing input type"),
         };


### PR DESCRIPTION
This adds a DID method for [Solana](https://solana.com/), `did:sol`, and a partial implementation of a [linked data proof](https://w3c-ccg.github.io/ld-proofs/) type for Solana transaction signatures, `SolanaMethod2021`.

A Solana DID contains the public key or program ID as the method-specific ID. Currently only the public key is supported, without rotation.

The verification method `SolanaMethod2021` is intended to allow signing linked data proofs using wallet applications, e.g. [SPL Token Wallet](https://github.com/project-serum/spl-token-wallet). Since Solana wallets such as SPL don't currently expose functionality for signing arbitrary messages or structured data, we use the [signTransaction](https://github.com/project-serum/sol-wallet-adapter#signtransaction) function to request a signature, wrapping the signing input in a dummy transaction for the user to sign. In UI this appears as an [Unknown instruction](https://github.com/project-serum/spl-token-wallet/blob/a4d700951c164091ebd11707206dc893c74112f8/src/components/instructions/UnknownInstruction.js). Ideally, the wallet would show meaningful data, but it seems that the UI treats the data as binary, so for the payload we just put the [hash](https://w3c-ccg.github.io/ld-proofs/#create-verify-hash-algorithm) that would ordinarily be used with a linked data proof, using SHA256 and URDNA2015. Creating the transaction is not yet implemented, so these proofs cannot yet be verified.

I also changed `SigningInput::Bytes` (in `ProofPreparation`) to use a base64url-encoded string rather than a `Vec<u8>`. This serializes to base64url rather than an array of byte numbers, which should be more consistent with other uses of base64-url, e.g. for JWS.