### PR TITLE
Add Citizenship and Vaccination contexts

### DIFF
--- a/contexts/w3c-ccg-citizenship-v1.jsonld
+++ b/contexts/w3c-ccg-citizenship-v1.jsonld
@@ -1,0 +1,54 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+
+    "name": "http://schema.org/name",
+    "description": "http://schema.org/description",
+    "identifier": "http://schema.org/identifier",
+    "image": {"@id": "http://schema.org/image", "@type": "@id"},
+
+    "PermanentResidentCard": {
+      "@id": "https://w3id.org/citizenship#PermanentResidentCard",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name",
+        "identifier": "http://schema.org/identifier",
+        "image": {"@id": "http://schema.org/image", "@type": "@id"}
+      }
+    },
+
+    "PermanentResident": {
+      "@id": "https://w3id.org/citizenship#PermanentResident",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "ctzn": "https://w3id.org/citizenship#",
+        "schema": "http://schema.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "birthCountry": "ctzn:birthCountry",
+        "birthDate": {"@id": "schema:birthDate", "@type": "xsd:dateTime"},
+        "commuterClassification": "ctzn:commuterClassification",
+        "familyName": "schema:familyName",
+        "gender": "schema:gender",
+        "givenName": "schema:givenName",
+        "lprCategory": "ctzn:lprCategory",
+        "lprNumber": "ctzn:lprNumber",
+        "residentSince": {"@id": "ctzn:residentSince", "@type": "xsd:dateTime"}
+      }
+    },
+
+    "Person": "http://schema.org/Person"
+  }
+}

--- a/contexts/w3c-ccg-vaccination-v1.jsonld
+++ b/contexts/w3c-ccg-vaccination-v1.jsonld
@@ -1,0 +1,88 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "description": "http://schema.org/description",
+        "identifier": "http://schema.org/identifier",
+        "name": "http://schema.org/name",
+        "image": "http://schema.org/image",
+        "VaccinationCertificate": {
+            "@id": "https://w3id.org/vaccination#VaccinationCertificate",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type",
+                "description": "http://schema.org/description",
+                "identifier": "http://schema.org/identifier",
+                "name": "http://schema.org/name",
+                "image": "http://schema.org/image"
+            }
+        },
+        "VaccinationEvent": {
+            "@id": "https://w3id.org/vaccination#VaccinationEvent",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type",
+                "administeringCentre": "https://w3id.org/vaccination#administeringCentre",
+                "batchNumber": "https://w3id.org/vaccination#batchNumber",
+                "countryOfVaccination": "https://w3id.org/vaccination#countryOfVaccination",
+                "dateOfVaccination": {
+                    "@id": "https://w3id.org/vaccination#dateOfVaccination",
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+                },
+                "healthProfessional": "https://w3id.org/vaccination#healthProfessional",
+                "nextVaccinationDate": {
+                    "@id": "https://w3id.org/vaccination#nextVaccinationDate",
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+                },
+                "order": "https://w3id.org/vaccination#order",
+                "recipient": {
+                    "@id": "https://w3id.org/vaccination#recipient",
+                    "@type": "https://w3id.org/vaccination#VaccineRecipient"
+                },
+                "vaccine": {
+                    "@id": "https://w3id.org/vaccination#VaccineEventVaccine",
+                    "@type": "https://w3id.org/vaccination#Vaccine"
+                }
+            }
+        },
+        "VaccineRecipient": {
+            "@id": "https://w3id.org/vaccination#VaccineRecipient",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type",
+                "birthDate": {
+                    "@id": "http://schema.org/birthDate",
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+                },
+                "familyName": "http://schema.org/familyName",
+                "gender": "http://schema.org/gender",
+                "givenName": "http://schema.org/givenName"
+            }
+        },
+        "Vaccine": {
+            "@id": "https://w3id.org/vaccination#Vaccine",
+            "@context": {
+                "@version": 1.1,
+                "@protected": true,
+                "id": "@id",
+                "type": "@type",
+                "atcCode": "https://w3id.org/vaccination#atc-code",
+                "disease": "https://w3id.org/vaccination#disease",
+                "event": {
+                    "@id": "https://w3id.org/vaccination#VaccineRecipientVaccineEvent",
+                    "@type": "https://w3id.org/vaccination#VaccineEvent"
+                },
+                "marketingAuthorizationHolder": "https://w3id.org/vaccination#marketingAuthorizationHolder",
+                "medicinalProductName": "https://w3id.org/vaccination#medicinalProductName"
+            }
+        }
+    }
+}

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -123,6 +123,8 @@ pub const DID_RESOLUTION_V1_CONTEXT: &str = "https://w3id.org/did-resolution/v1"
 pub const DIF_ESRS2020_CONTEXT: &str = "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/lds-ecdsa-secp256k1-recovery2020-0.0.jsonld";
 pub const LDS_JWS2020_V1_CONTEXT: &str =
     "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json";
+pub const CITIZENSHIP_V1_CONTEXT: &str = "https://w3id.org/citizenship/v1";
+pub const VACCINATION_V1_CONTEXT: &str = "https://w3id.org/vaccination/v1";
 
 lazy_static! {
     pub static ref CREDENTIALS_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
@@ -185,6 +187,18 @@ lazy_static! {
         let iri = Iri::new(LDS_JWS2020_V1_CONTEXT).unwrap();
         RemoteDocument::new(doc, iri)
     };
+    pub static ref CITIZENSHIP_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
+        let jsonld = include_str!("../contexts/w3c-ccg-citizenship-v1.jsonld");
+        let doc = json::parse(jsonld).unwrap();
+        let iri = Iri::new(CITIZENSHIP_V1_CONTEXT).unwrap();
+        RemoteDocument::new(doc, iri)
+    };
+    pub static ref VACCINATION_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
+        let jsonld = include_str!("../contexts/w3c-ccg-vaccination-v1.jsonld");
+        let doc = json::parse(jsonld).unwrap();
+        let iri = Iri::new(VACCINATION_V1_CONTEXT).unwrap();
+        RemoteDocument::new(doc, iri)
+    };
 }
 
 pub struct StaticLoader;
@@ -209,6 +223,8 @@ impl Loader for StaticLoader {
                 DID_RESOLUTION_V1_CONTEXT => Ok(DID_RESOLUTION_V1_CONTEXT_DOCUMENT.clone()),
                 DIF_ESRS2020_CONTEXT => Ok(DIF_ESRS2020_CONTEXT_DOCUMENT.clone()),
                 LDS_JWS2020_V1_CONTEXT => Ok(LDS_JWS2020_V1_CONTEXT_DOCUMENT.clone()),
+                CITIZENSHIP_V1_CONTEXT => Ok(CITIZENSHIP_V1_CONTEXT_DOCUMENT.clone()),
+                VACCINATION_V1_CONTEXT => Ok(VACCINATION_V1_CONTEXT_DOCUMENT.clone()),
                 _ => {
                     eprintln!("unknown context {}", url);
                     Err(json_ld::ErrorCode::LoadingDocumentFailed.into())


### PR DESCRIPTION
These are needed for [vc-http-api tests](https://github.com/w3c-ccg/vc-http-api/tree/966aba7862f577cc9895fa477755a41d18315c69/packages/vc-http-api-test-server)

- [Citizenship Vocabulary](https://w3c-ccg.github.io/citizenship-vocab/)
- [Vaccination Certificate Vocabulary](https://w3c-ccg.github.io/vaccination-vocab/)

https://github.com/spruceid/didkit/issues/100