### PR TITLE
Support relative DID URLs

### DIFF
--- a/src/did_resolve.rs
+++ b/src/did_resolve.rs
@@ -1338,7 +1338,7 @@ mod tests {
     async fn dereference_did_url() {
         const DID: &str = "did:example:123456789abcdefghi";
         // https://w3c-ccg.github.io/did-resolution/#example-7
-        const DOC_STR: &str = r#"
+        const DOC_STR: &str = r###"
 {
 	"@context": "https://www.w3.org/ns/did/v1",
 	"id": "did:example:123456789abcdefghi",
@@ -1347,6 +1347,11 @@ mod tests {
 		"type": "Ed25519VerificationKey2018",
 		"controller": "did:example:123456789abcdefghi",
 		"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+	}, {
+		"id": "#keys-2",
+		"type": "Ed25519VerificationKey2018",
+		"controller": "did:example:123456789abcdefghi",
+		"publicKeyBase58": "4BWwfeqdp1obQptLLMvPNgBw48p7og1ie6Hf9p5nTpNN"
 	}],
 	"service": [{
 		"id": "did:example:123456789abcdefghi#agent",
@@ -1358,7 +1363,7 @@ mod tests {
 		"serviceEndpoint": "https://example.com/messages/8377464"
 	}]
 }
-        "#;
+        "###;
         struct DerefExampleResolver;
         #[async_trait]
         impl DIDResolver for DerefExampleResolver {
@@ -1427,5 +1432,23 @@ mod tests {
         .await;
         assert_eq!(deref_meta.error, None);
         assert_eq!(content, expected_content);
+
+        // Dereference DID URL where id property is a relative IRI
+        let (deref_meta, _content, _content_meta) = dereference(
+            &DerefExampleResolver,
+            "did:example:123456789abcdefghi#keys-2",
+            &DereferencingInputMetadata::default(),
+        )
+        .await;
+        assert_eq!(deref_meta.error, None);
+
+        // Dereferencing unknown ID fails
+        let (deref_meta, _content, _content_meta) = dereference(
+            &DerefExampleResolver,
+            "did:example:123456789abcdefghi#nope",
+            &DereferencingInputMetadata::default(),
+        )
+        .await;
+        assert_ne!(deref_meta.error, None);
     }
 }

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap as Map;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
-use crate::did::VerificationMethod;
 use crate::did_resolve::{DIDResolver, ResolutionInputMetadata};
 use crate::error::Error;
 use crate::jsonld::{json_to_dataset, StaticLoader};
@@ -895,10 +894,7 @@ pub async fn get_verification_methods(
         .verification_method
         .iter()
         .flatten()
-        .map(|vm| match vm {
-            VerificationMethod::Map(map) => map.id.to_owned(),
-            VerificationMethod::DIDURL(didurl) => didurl.to_string(),
-        })
+        .map(|vm| vm.get_id(did))
         .collect();
     Ok(vms)
 }


### PR DESCRIPTION
This adds support for DID Documents containing [verification method](https://w3c.github.io/did-core/#verification-methods) `id` values that are [Relative DID URLs](https://w3c.github.io/did-core/#relative-did-urls) rather than [DID URLs](https://w3c.github.io/did-core/#did-url-syntax). This is as in DID Core's [Example 9](https://w3c.github.io/did-core/#example-9-an-example-of-a-relative-did-url). A verification method embedded in the DID document can be dereferenced by its DID URL and used with linked data proofs.