### PR TITLE
Fix WASM compilation for resolvers that use HTTP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,4 +67,4 @@ jobs:
         npm test
 
     - name: Test WASM compilation
-      return: cargo check --workspace --target wasm32-unknown-unknown
+      run: cargo check --workspace --target wasm32-unknown-unknown

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,4 +67,6 @@ jobs:
         npm test
 
     - name: Test WASM compilation
-      run: cargo check --workspace --target wasm32-unknown-unknown
+      run: |
+        rustup target add wasm32-unknown-unknown
+        cargo check --workspace --target wasm32-unknown-unknown

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,3 +65,6 @@ jobs:
         npm i
         cp ../vc-test/config.json .
         npm test
+
+    - name: Test WASM compilation
+      return: cargo check --workspace --target wasm32-unknown-unknown

--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2018"
 [dependencies]
 ssi = { path = "../", default-features = false, features = ["secp256k1", "keccak-hash"] }
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.0", features = ["macros", "rt"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
 libsecp256k1 = { version = "0.3" }
 keccak-hash = "0.7"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["macros"] }

--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -45,7 +45,8 @@ fn parse_did(did: &str) -> Option<(i64, String)> {
     Some((chain_id, address))
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl DIDResolver for DIDEthr {
     async fn resolve(
         &self,

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -28,7 +28,8 @@ pub enum DIDKeyError {
 
 pub struct DIDKey;
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl DIDResolver for DIDKey {
     async fn resolve(
         &self,

--- a/did-sol/Cargo.toml
+++ b/did-sol/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2018"
 [dependencies]
 ssi = { path = "../", default-features = false, features = [] }
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.0", features = ["macros", "rt"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
 bs58 = { version = "0.4", features = ["check"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["macros"] }

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -30,7 +30,8 @@ fn parse_did(did: &str) -> Option<(String, Vec<u8>)> {
     Some((address, bytes))
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl DIDResolver for DIDSol {
     async fn resolve(
         &self,

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -21,7 +21,6 @@ libsecp256k1 = { version = "0.3", optional = true }
 anyhow = "1.0.33"
 json-patch = "0.2.6"
 bs58 = { version = "0.4", features = ["check"] }
-futures = { version = "0.3", features = ["executor"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -13,8 +13,7 @@ p256 = ["ssi/p256"]
 [dependencies]
 ssi = { path = "../", default-features = false }
 chrono = { version = "0.4" }
-tokio = { version = "1.0", features = ["macros", "rt"] }
-reqwest = { version = "0.11", features = ["json", "default-tls"] }
+reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
@@ -22,6 +21,8 @@ libsecp256k1 = { version = "0.3", optional = true }
 anyhow = "1.0.33"
 json-patch = "0.2.6"
 bs58 = { version = "0.4", features = ["check"] }
+futures = { version = "0.3", features = ["executor"] }
 
 [dev-dependencies]
+tokio = { version = "1.0", features = ["macros"] }
 tezedge_client = { git = "https://github.com/binier/tezedge-client", rev = "672e61297f0ba7d1d94168a2588b9b27d76c1fc4", package = "lib" }

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -22,6 +22,9 @@ anyhow = "1.0.33"
 json-patch = "0.2.6"
 bs58 = { version = "0.4", features = ["check"] }
 
+[target.'cfg(target_os = "android")'.dependencies.reqwest]
+features = ["native-tls-vendored"]
+
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }
 tezedge_client = { git = "https://github.com/binier/tezedge-client", rev = "672e61297f0ba7d1d94168a2588b9b27d76c1fc4", package = "lib" }

--- a/did-tezos/src/explorer.rs
+++ b/did-tezos/src/explorer.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use futures::executor::block_on;
 use reqwest;
 use serde::Deserialize;
 use ssi::did::{Service, ServiceEndpoint};
@@ -29,20 +30,22 @@ struct SearchResult {
     items: Vec<SearchItem>,
 }
 
-pub async fn retrieve_did_manager(address: &str, network: &str) -> Result<Option<String>> {
-    let client = reqwest::Client::new();
-    let mut search_result: SearchResult = client
-        .get(&format!("{}v1/search", BCD_URL))
-        .query(&[
-            ("q", address),
-            ("f", "manager"),
-            ("n", network),
-            ("i", "contract"),
-        ])
-        .send()
-        .await?
-        .json()
-        .await?;
+pub fn retrieve_did_manager(address: &str, network: &str) -> Result<Option<String>> {
+    let client = reqwest::Client::builder().build()?;
+    let mut search_result: SearchResult = block_on(
+        block_on(
+            client
+                .get(&format!("{}v1/search", BCD_URL))
+                .query(&[
+                    ("q", address),
+                    ("f", "manager"),
+                    ("n", network),
+                    ("i", "contract"),
+                ])
+                .send(),
+        )?
+        .json(),
+    )?;
 
     // TODO this is a hack for the tests as there were multiple DID managers deployed
     search_result.items.reverse();
@@ -72,18 +75,20 @@ struct ServiceResultItem {
     value: String,
 }
 
-pub async fn execute_service_view(did: &str, contract: &str, network: &str) -> Result<Service> {
-    let client = reqwest::Client::new();
-    let service_result: ServiceResult = client
-        .post(&format!(
-            "{}v1/contract/{}/{}/views/execute",
-            BCD_URL, network, contract
-        ))
-        .json(&serde_json::json!({"data": {}, "name": "GetService", "implementation": 0}))
-        .send()
-        .await?
-        .json()
-        .await?;
+pub fn execute_service_view(did: &str, contract: &str, network: &str) -> Result<Service> {
+    let client = reqwest::Client::builder().build()?;
+    let service_result: ServiceResult = block_on(
+        block_on(
+            client
+                .post(&format!(
+                    "{}v1/contract/{}/{}/views/execute",
+                    BCD_URL, network, contract
+                ))
+                .json(&serde_json::json!({"data": {}, "name": "GetService", "implementation": 0}))
+                .send(),
+        )?
+        .json(),
+    )?;
     Ok(Service {
         id: format!("{}{}", did, "#discovery"),
         type_: OneOrMany::One(service_result.children[1].value.clone()),
@@ -104,7 +109,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_retrieve_did_manager() {
-        let did_manager = retrieve_did_manager(LIVE_TZ1, LIVE_NETWORK).await;
+        let did_manager = retrieve_did_manager(LIVE_TZ1, LIVE_NETWORK);
         assert!(did_manager.is_ok());
         assert_eq!(did_manager.unwrap().unwrap(), LIVE_DID_MANAGER.to_string());
     }
@@ -115,8 +120,7 @@ mod tests {
             &format!("did:tz:{}:{}", LIVE_NETWORK, LIVE_TZ1),
             LIVE_DID_MANAGER,
             LIVE_NETWORK,
-        )
-        .await;
+        );
         println!("{:?}", service_endpoint);
         assert!(service_endpoint.is_ok());
     }

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -294,10 +294,12 @@ impl DIDTz {
     }
 
     async fn tier2_resolution(did: &str, address: &str, network: &str) -> Result<Option<Service>> {
-        if let Some(did_manager) = explorer::retrieve_did_manager(address, network).await? {
-            Ok(Some(
-                explorer::execute_service_view(did, &did_manager, network).await?,
-            ))
+        if let Some(did_manager) = explorer::retrieve_did_manager(address, network)? {
+            Ok(Some(explorer::execute_service_view(
+                did,
+                &did_manager,
+                network,
+            )?))
         } else {
             Ok(None)
         }

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -28,7 +28,8 @@ use std::convert::TryInto;
 /// [Specification](https://github.com/spruceid/did-tezos/)
 pub struct DIDTz;
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl DIDResolver for DIDTz {
     async fn resolve(
         &self,
@@ -294,12 +295,10 @@ impl DIDTz {
     }
 
     async fn tier2_resolution(did: &str, address: &str, network: &str) -> Result<Option<Service>> {
-        if let Some(did_manager) = explorer::retrieve_did_manager(address, network)? {
-            Ok(Some(explorer::execute_service_view(
-                did,
-                &did_manager,
-                network,
-            )?))
+        if let Some(did_manager) = explorer::retrieve_did_manager(address, network).await? {
+            Ok(Some(
+                explorer::execute_service_view(did, &did_manager, network).await?,
+            ))
         } else {
             Ok(None)
         }

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 [dependencies]
 ssi = { path = "../", default-features = false }
 async-trait = "0.1"
-hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
-hyper-tls = "0.5"
+reqwest = { version = "0.11", features = ["json"] }
 http = "0.2"
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["macros"] }
-futures = "0.3"
 
 [dev-dependencies]
+tokio = { version = "1.0", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"] }
 async-std = { version = "1.9", features = ["attributes"] }
+futures = "0.3"
+hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -11,6 +11,9 @@ reqwest = { version = "0.11", features = ["json"] }
 http = "0.2"
 serde_json = "1.0"
 
+[target.'cfg(target_os = "android")'.dependencies.reqwest]
+features = ["native-tls-vendored"]
+
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/did.rs
+++ b/src/did.rs
@@ -197,7 +197,8 @@ pub struct DIDParameters {
     pub property_set: Option<Map<String, Value>>,
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait DIDMethod: DIDResolver {
     /// Get the DID method name.
     /// <https://w3c.github.io/did-core/#method-schemes>
@@ -261,7 +262,8 @@ impl<'a> DIDMethods<'a> {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<'a> DIDResolver for DIDMethods<'a> {
     async fn resolve(
         &self,
@@ -545,7 +547,8 @@ pub mod example {
 
     pub struct DIDExample;
 
-    #[async_trait]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl DIDMethod for DIDExample {
         fn name(&self) -> &'static str {
             return "example";
@@ -556,7 +559,8 @@ pub mod example {
         }
     }
 
-    #[async_trait]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl DIDResolver for DIDExample {
         async fn resolve(
             &self,

--- a/src/did_resolve.rs
+++ b/src/did_resolve.rs
@@ -217,7 +217,8 @@ impl Default for ResolutionResult {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait DIDResolver: Sync {
     async fn resolve(
         &self,
@@ -623,7 +624,8 @@ impl HTTPDIDResolver {
 }
 
 #[cfg(feature = "http")]
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl DIDResolver for HTTPDIDResolver {
     // https://w3c-ccg.github.io/did-resolution/#bindings-https
     async fn resolve(
@@ -972,7 +974,8 @@ pub struct SeriesResolver<'a> {
     pub resolvers: Vec<&'a (dyn DIDResolver)>,
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<'a> DIDResolver for SeriesResolver<'a> {
     async fn resolve(
         &self,

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -51,7 +51,8 @@ pub fn now_ms() -> DateTime<Utc> {
     datetime.with_nanosecond(ns).unwrap_or(datetime)
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait LinkedDataDocument {
     fn get_contexts(&self) -> Result<Option<String>, Error>;
     async fn to_dataset_for_signing(
@@ -60,7 +61,8 @@ pub trait LinkedDataDocument {
     ) -> Result<DataSet, Error>;
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ProofSuite {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -485,7 +487,8 @@ async fn verify(
 }
 
 pub struct RsaSignature2018;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for RsaSignature2018 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -514,7 +517,8 @@ impl ProofSuite for RsaSignature2018 {
 }
 
 pub struct Ed25519Signature2018;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for Ed25519Signature2018 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -550,7 +554,8 @@ impl ProofSuite for Ed25519Signature2018 {
 }
 
 pub struct EcdsaSecp256k1Signature2019;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for EcdsaSecp256k1Signature2019 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -586,7 +591,8 @@ impl ProofSuite for EcdsaSecp256k1Signature2019 {
 }
 
 pub struct EcdsaSecp256k1RecoverySignature2020;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -662,7 +668,8 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
 
 /// Proof type used with [did:tz](https://github.com/spruceid/did-tezos/) `tz1` addresses.
 pub struct Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -754,7 +761,8 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
 
 /// Proof type used with [did:tz](https://github.com/spruceid/did-tezos/) `tz3` addresses.
 pub struct P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -846,7 +854,8 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
 
 #[cfg(feature = "keccak-hash")]
 pub struct Eip712Signature2021;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg(feature = "keccak-hash")]
 impl ProofSuite for Eip712Signature2021 {
     async fn sign(
@@ -956,7 +965,8 @@ impl ProofSuite for Eip712Signature2021 {
 }
 
 pub struct SolanaSignature2021;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for SolanaSignature2021 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -1039,7 +1049,8 @@ impl ProofSuite for SolanaSignature2021 {
 }
 
 pub struct EcdsaSecp256r1Signature2019;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for EcdsaSecp256r1Signature2019 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
@@ -1076,7 +1087,8 @@ impl ProofSuite for EcdsaSecp256r1Signature2019 {
 
 /// <https://w3c-ccg.github.io/lds-jws2020/>
 pub struct JsonWebSignature2020;
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProofSuite for JsonWebSignature2020 {
     async fn sign(
         document: &(dyn LinkedDataDocument + Sync),

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -702,7 +702,8 @@ impl Credential {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LinkedDataDocument for Credential {
     fn get_contexts(&self) -> Result<Option<String>, Error> {
         Ok(Some(serde_json::to_string(&self.context)?))
@@ -902,7 +903,8 @@ pub async fn get_verification_methods(
     Ok(vms)
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LinkedDataDocument for Presentation {
     fn get_contexts(&self) -> Result<Option<String>, Error> {
         Ok(Some(serde_json::to_string(&self.context)?))
@@ -975,7 +977,8 @@ impl Proof {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LinkedDataDocument for Proof {
     fn get_contexts(&self) -> Result<Option<String>, Error> {
         Ok(None)


### PR DESCRIPTION
I couldn't find a better way than just remove the Send bound for everything.