### PR TITLE
Improve DID URL dereferencing for verification methods

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -99,9 +99,14 @@ impl DIDResolver for DIDEthr {
         let doc = Document {
             context: Contexts::One(Context::URI(DEFAULT_CONTEXT.to_string())),
             id: did.to_string(),
-            authentication: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
-            assertion_method: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
-            // TODO: authentication/assertion_method?
+            authentication: Some(vec![
+                VerificationMethod::DIDURL(vm_didurl.clone()),
+                VerificationMethod::DIDURL(eip712vm_didurl.clone()),
+            ]),
+            assertion_method: Some(vec![
+                VerificationMethod::DIDURL(vm_didurl.clone()),
+                VerificationMethod::DIDURL(eip712vm_didurl.clone()),
+            ]),
             verification_method: Some(vec![vm, eip712vm]),
             ..Default::default()
         };
@@ -197,10 +202,12 @@ mod tests {
                 "blockchainAccountId": "0xb9c5714089478a327f09197987f16f9e5d936e8a@eip155:1"
               }],
               "authentication": [
-                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller"
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller",
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#Eip712Method2021"
               ],
               "assertionMethod": [
-                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller"
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller",
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#Eip712Method2021"
               ]
             })
         );

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use thiserror::Error;
 
-use ssi::did::{DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap};
+use ssi::did::{DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap, DIDURL};
 use ssi::did_resolve::{
     DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
     ERROR_NOT_FOUND, TYPE_DID_LD_JSON,
@@ -154,6 +154,11 @@ impl DIDResolver for DIDKey {
                 None,
             );
         };
+        let vm_didurl = DIDURL {
+            did: did.to_string(),
+            fragment: Some(method_specific_id.to_string()),
+            ..Default::default()
+        };
         let doc = Document {
             id: did.to_string(),
             verification_method: Some(vec![VerificationMethod::Map(VerificationMethodMap {
@@ -163,6 +168,8 @@ impl DIDResolver for DIDKey {
                 public_key_jwk: Some(jwk),
                 ..Default::default()
             })]),
+            authentication: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
+            assertion_method: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
             ..Default::default()
         };
         (

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -203,7 +203,8 @@ mod tests {
            "crv": "Ed25519",
            "x": "G80iskrv_nE69qbGLSpeOHJgmV4MKIzsy5l5iT6pCww"
          }
-      }]
+      }],
+      "assertionMethod": ["did:web:localhost#key1"]
     }"#;
 
     // localhost web server for serving did:web DID documents.

--- a/src/did.rs
+++ b/src/did.rs
@@ -98,6 +98,9 @@ pub struct Document {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capability_delegation: Option<Vec<VerificationMethod>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    // publicKey is used by legacy DID documents
+    pub public_key: Option<Vec<VerificationMethod>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub service: Option<Vec<Service>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proof: Option<OneOrMany<Proof>>,
@@ -653,6 +656,7 @@ impl Document {
             service: None,
             proof: None,
             property_set: None,
+            public_key: None,
         }
     }
 
@@ -676,6 +680,7 @@ impl Document {
             &self.key_agreement,
             &self.capability_invocation,
             &self.capability_delegation,
+            &self.public_key,
         ]
         .iter()
         .flat_map(|array| array.iter().flatten())

--- a/src/did.rs
+++ b/src/did.rs
@@ -669,7 +669,17 @@ impl Document {
     pub fn select_object(&self, id: &DIDURL) -> Result<Resource, Error> {
         let id_string = String::from(id.clone());
         let id_relative_string_opt = id.to_relative(&self.id).map(|rel_url| rel_url.to_string());
-        for vm in self.verification_method.iter().flatten() {
+        for vm in vec![
+            &self.verification_method,
+            &self.authentication,
+            &self.assertion_method,
+            &self.key_agreement,
+            &self.capability_invocation,
+            &self.capability_delegation,
+        ]
+        .iter()
+        .flat_map(|array| array.iter().flatten())
+        {
             if let VerificationMethod::Map(map) = vm {
                 if map.id == id_string || Some(&map.id) == id_relative_string_opt.as_ref() {
                     let mut map = map.clone();

--- a/src/did.rs
+++ b/src/did.rs
@@ -35,12 +35,37 @@ pub const V0_11_CONTEXT: &str = "https://w3id.org/did/v0.11";
 // @TODO parsed data structs for DID and DIDURL
 type DID = String;
 
+/// [DID URL](https://w3c.github.io/did-core/#did-url-syntax)
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(try_from = "String")]
 #[serde(into = "String")]
 pub struct DIDURL {
     pub did: String,
     pub path_abempty: String,
+    pub query: Option<String>,
+    pub fragment: Option<String>,
+}
+
+/// Path component for a [Relative DID URL](https://w3c.github.io/did-core/#relative-did-urls).
+/// Based on [RFC 3886 - Path syntax](https://tools.ietf.org/html/rfc3986#section-3.3) and
+/// [Relative reference](https://tools.ietf.org/html/rfc3986#section-4.2)
+/// [rfc3986-3.3]: https://tools.ietf.org/html/rfc3986#section-3.3
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum RelativeDIDURLPath {
+    /// `path-absolute` from [RFC 3986 - 3.3. Path][rfc3986-3.3]
+    Absolute(String),
+    /// `path-noscheme` from [RFC 3986 - 3.3. Path][rfc3986-3.3]
+    NoScheme(String),
+    /// `path-empty` from [RFC 3986 - 3.3. Path][rfc3986-3.3]
+    Empty,
+}
+
+/// [Relative DID URL](https://w3c.github.io/did-core/#relative-did-urls)
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
+pub struct RelativeDIDURL {
+    pub path: RelativeDIDURLPath,
     pub query: Option<String>,
     pub fragment: Option<String>,
 }
@@ -126,6 +151,7 @@ pub struct VerificationMethodMap {
 #[serde(untagged)]
 pub enum VerificationMethod {
     DIDURL(DIDURL),
+    RelativeDIDURL(RelativeDIDURL),
     Map(VerificationMethodMap),
 }
 
@@ -310,6 +336,58 @@ impl<'a> DIDResolver for DIDMethods<'a> {
     }
 }
 
+impl DIDURL {
+    /// Convert a DID URL to a [Relative DID URL][RelativeDIDURL], given a DID as base URI.
+    pub fn to_relative(&self, base_did: &str) -> Option<RelativeDIDURL> {
+        // TODO: support [Reference Resolution](https://tools.ietf.org/html/rfc3986#section-5) more
+        // generally, i.e. where the base is a DID URL (not necessarily a DID), and including [path
+        // segment normalization](https://tools.ietf.org/html/rfc3986#section-6.2.2.3)
+        if self.did != base_did {
+            return None;
+        }
+        Some(RelativeDIDURL {
+            path: match RelativeDIDURLPath::from_str(&self.path_abempty) {
+                Ok(path) => path,
+                Err(_) => return None,
+            },
+            query: self.query.as_ref().map(|x| x.clone()),
+            fragment: self.fragment.as_ref().map(|x| x.clone()),
+        })
+    }
+}
+
+impl RelativeDIDURL {
+    /// Convert a DID URL to a absolute DID URL, given a DID as base URI,
+    /// according to [DID Core - Relative DID URLs](https://w3c.github.io/did-core/#relative-did-urls).
+    pub fn to_absolute(&self, base_did: &str) -> DIDURL {
+        // TODO: support [Reference Resolution](https://tools.ietf.org/html/rfc3986#section-5) more
+        // generally, e.g. when base is not a DID
+        DIDURL {
+            did: base_did.to_string(),
+            path_abempty: self.path.to_string(),
+            query: self.query.as_ref().map(|x| x.clone()),
+            fragment: self.fragment.as_ref().map(|x| x.clone()),
+        }
+    }
+}
+
+impl VerificationMethod {
+    /// Return a DID URL for this verification method, given a DID as base URI
+    pub fn get_id(&self, did: &str) -> String {
+        match self {
+            Self::DIDURL(didurl) => didurl.to_string(),
+            Self::RelativeDIDURL(relative_did_url) => relative_did_url.to_absolute(did).to_string(),
+            Self::Map(map) => {
+                if let Ok(rel_did_url) = RelativeDIDURL::from_str(&map.id) {
+                    rel_did_url.to_absolute(did).to_string()
+                } else {
+                    map.id.to_string()
+                }
+            }
+        }
+    }
+}
+
 impl FromStr for DIDURL {
     type Err = Error;
     fn from_str(didurl: &str) -> Result<Self, Self::Err> {
@@ -337,6 +415,56 @@ impl FromStr for DIDURL {
     }
 }
 
+impl FromStr for RelativeDIDURL {
+    type Err = Error;
+    fn from_str(didurl: &str) -> Result<Self, Self::Err> {
+        let mut parts = didurl.splitn(2, '#');
+        let before_fragment = parts.next().unwrap().to_string();
+        let fragment = parts.next().map(|x| x.to_owned());
+        let mut parts = before_fragment.splitn(2, '?');
+        let before_query = parts.next().unwrap().to_string();
+        let query = parts.next().map(|x| x.to_owned());
+        let path = RelativeDIDURLPath::from_str(&before_query)?;
+        Ok(Self {
+            path,
+            query,
+            fragment,
+        })
+    }
+}
+
+impl FromStr for RelativeDIDURLPath {
+    type Err = Error;
+    fn from_str(path: &str) -> Result<Self, Self::Err> {
+        if path.is_empty() {
+            return Ok(Self::Empty);
+        }
+        if path.starts_with("/") {
+            // path-absolute = "/" [ segment-nz *( "/" segment ) ]
+            // segment-nz    = 1*pchar
+            // segment       = *pchar
+            if path.len() >= 2 {
+                if path.chars().nth(1) == Some('/') {
+                    // Beginning with "//" would make a scheme-relative URI.
+                    return Err(Error::DIDURL);
+                }
+            }
+            // TODO: validate segment and pchar
+            return Ok(Self::Absolute(path.to_string()));
+        } else {
+            // path-noscheme = segment-nz-nc *( "/" segment )
+            // segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
+            let first_segment = path.splitn(2, '/').next().unwrap().to_string();
+            if first_segment.contains(':') {
+                // First path segment containing ":" would make an absolute URI.
+                return Err(Error::DIDURL);
+            }
+            // TODO: validate segment-nz-nc and pchar more
+            return Ok(Self::NoScheme(path.to_string()));
+        }
+    }
+}
+
 impl fmt::Display for DIDURL {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}{}", self.did, self.path_abempty)?;
@@ -347,6 +475,29 @@ impl fmt::Display for DIDURL {
             write!(f, "#{}", fragment)?;
         }
         Ok(())
+    }
+}
+
+impl fmt::Display for RelativeDIDURL {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.path.fmt(f)?;
+        if let Some(ref query) = self.query {
+            write!(f, "?{}", query)?;
+        }
+        if let Some(ref fragment) = self.fragment {
+            write!(f, "#{}", fragment)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for RelativeDIDURLPath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Empty => Ok(()),
+            Self::Absolute(string) => string.fmt(f),
+            Self::NoScheme(string) => string.fmt(f),
+        }
     }
 }
 
@@ -365,9 +516,30 @@ impl From<DIDURL> for String {
     }
 }
 
+/// needed for #[serde(try_from = "String")]
+impl TryFrom<String> for RelativeDIDURL {
+    type Error = Error;
+    fn try_from(relative_did_url: String) -> Result<Self, Self::Error> {
+        RelativeDIDURL::from_str(&relative_did_url)
+    }
+}
+
+/// needed for #[serde(into = "String")]
+impl From<RelativeDIDURL> for String {
+    fn from(relative_did_url: RelativeDIDURL) -> String {
+        relative_did_url.to_string()
+    }
+}
+
 impl Default for Document {
     fn default() -> Self {
         Document::new("")
+    }
+}
+
+impl Default for RelativeDIDURLPath {
+    fn default() -> Self {
+        Self::Empty
     }
 }
 
@@ -496,9 +668,10 @@ impl Document {
     /// For the [DID URL dereferencing algorithm, Step 1.1](https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm-secondary)
     pub fn select_object(&self, id: &DIDURL) -> Result<Resource, Error> {
         let id_string = String::from(id.clone());
+        let id_relative_string_opt = id.to_relative(&self.id).map(|rel_url| rel_url.to_string());
         for vm in self.verification_method.iter().flatten() {
             if let VerificationMethod::Map(map) = vm {
-                if map.id == id_string {
+                if map.id == id_string || Some(&map.id) == id_relative_string_opt.as_ref() {
                     let mut map = map.clone();
                     merge_context(&mut map.context, &self.context);
                     return Ok(Resource::VerificationMethod(map));
@@ -607,6 +780,16 @@ mod tests {
                 fragment: None,
             }
         );
+    }
+
+    #[test]
+    fn did_url_relative_to_absolute() {
+        // https://w3c.github.io/did-core/#relative-did-urls
+        let relative_did_url_str = "#key-1";
+        let did_url_ref = RelativeDIDURL::from_str(relative_did_url_str).unwrap();
+        let did = "did:example:123456789abcdefghi";
+        let did_url = did_url_ref.to_absolute(did);
+        assert_eq!(did_url.to_string(), "did:example:123456789abcdefghi#key-1");
     }
 
     #[test]

--- a/src/did.rs
+++ b/src/did.rs
@@ -13,6 +13,9 @@ use crate::error::Error;
 use crate::jwk::JWK;
 use crate::one_or_many::OneOrMany;
 
+/// <https://w3c.github.io/did-core/#dfn-verification-relationship>
+type VerificationRelationship = crate::vc::ProofPurpose;
+
 use async_trait::async_trait;
 use chrono::prelude::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -711,6 +714,25 @@ impl Document {
             }
         }
         None
+    }
+
+    /// Get verification method ids from a DID document,
+    /// optionally limited to a specific [verification relationship](VerificationRelationship).
+    pub fn get_verification_method_ids(
+        &self,
+        verification_relationship: VerificationRelationship,
+    ) -> Result<Vec<String>, String> {
+        let did = &self.id;
+        let vms = match verification_relationship {
+            VerificationRelationship::AssertionMethod => &self.assertion_method,
+            VerificationRelationship::Authentication => &self.authentication,
+            VerificationRelationship::KeyAgreement => &self.key_agreement,
+            VerificationRelationship::CapabilityInvocation => &self.capability_invocation,
+            VerificationRelationship::CapabilityDelegation => &self.capability_delegation,
+            rel => return Err(format!("Unsupported verification relationship: {:?}", rel)),
+        };
+        let vm_ids = vms.iter().flatten().map(|vm| vm.get_id(did)).collect();
+        Ok(vm_ids)
     }
 
     pub fn to_representation(&self, content_type: &str) -> Result<Vec<u8>, Error> {

--- a/src/did_resolve.rs
+++ b/src/did_resolve.rs
@@ -1335,7 +1335,7 @@ mod tests {
     async fn dereference_did_url() {
         const DID: &str = "did:example:123456789abcdefghi";
         // https://w3c-ccg.github.io/did-resolution/#example-7
-        const DOC_STR: &str = r#"
+        const DOC_STR: &str = r###"
 {
 	"@context": "https://www.w3.org/ns/did/v1",
 	"id": "did:example:123456789abcdefghi",
@@ -1344,6 +1344,11 @@ mod tests {
 		"type": "Ed25519VerificationKey2018",
 		"controller": "did:example:123456789abcdefghi",
 		"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+	}, {
+		"id": "#keys-2",
+		"type": "Ed25519VerificationKey2018",
+		"controller": "did:example:123456789abcdefghi",
+		"publicKeyBase58": "4BWwfeqdp1obQptLLMvPNgBw48p7og1ie6Hf9p5nTpNN"
 	}],
 	"service": [{
 		"id": "did:example:123456789abcdefghi#agent",
@@ -1355,7 +1360,7 @@ mod tests {
 		"serviceEndpoint": "https://example.com/messages/8377464"
 	}]
 }
-        "#;
+        "###;
         struct DerefExampleResolver;
         #[async_trait]
         impl DIDResolver for DerefExampleResolver {
@@ -1424,5 +1429,23 @@ mod tests {
         .await;
         assert_eq!(deref_meta.error, None);
         assert_eq!(content, expected_content);
+
+        // Dereference DID URL where id property is a relative IRI
+        let (deref_meta, _content, _content_meta) = dereference(
+            &DerefExampleResolver,
+            "did:example:123456789abcdefghi#keys-2",
+            &DereferencingInputMetadata::default(),
+        )
+        .await;
+        assert_eq!(deref_meta.error, None);
+
+        // Dereferencing unknown ID fails
+        let (deref_meta, _content, _content_meta) = dereference(
+            &DerefExampleResolver,
+            "did:example:123456789abcdefghi#nope",
+            &DereferencingInputMetadata::default(),
+        )
+        .await;
+        assert_ne!(deref_meta.error, None);
     }
 }

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap as Map;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
-use crate::did::VerificationMethod;
 use crate::did_resolve::{DIDResolver, ResolutionInputMetadata};
 use crate::error::Error;
 use crate::jsonld::{json_to_dataset, StaticLoader};
@@ -894,10 +893,7 @@ pub async fn get_verification_methods(
         .verification_method
         .iter()
         .flatten()
-        .map(|vm| match vm {
-            VerificationMethod::Map(map) => map.id.to_owned(),
-            VerificationMethod::DIDURL(didurl) => didurl.to_string(),
-        })
+        .map(|vm| vm.get_id(did))
         .collect();
     Ok(vms)
 }

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -623,7 +623,15 @@ impl Credential {
                         Issuer::Object(object_with_id) => object_with_id.id,
                     };
                     let URI::String(issuer_did) = issuer_uri;
-                    get_verification_methods(&issuer_did, resolver).await?
+                    // https://w3c.github.io/did-core/#assertion
+                    // assertionMethod is the verification relationship usually used for issuing
+                    // VCs.
+                    let proof_purpose = options
+                        .proof_purpose
+                        .clone()
+                        .unwrap_or_else(|| ProofPurpose::AssertionMethod);
+                    get_verification_methods_for_purpose(&issuer_did, resolver, proof_purpose)
+                        .await?
                 } else {
                     Vec::new()
                 }
@@ -811,7 +819,11 @@ impl Presentation {
             Some(vm) => vec![vm],
             None => {
                 if let Some(URI::String(ref holder)) = self.holder {
-                    get_verification_methods(&holder, resolver).await?
+                    let proof_purpose = options
+                        .proof_purpose
+                        .clone()
+                        .unwrap_or_else(|| ProofPurpose::Authentication);
+                    get_verification_methods_for_purpose(&holder, resolver, proof_purpose).await?
                 } else {
                     Vec::new()
                 }
@@ -871,13 +883,30 @@ impl Default for Presentation {
 
 /// Get a DID's first verification method
 pub async fn get_verification_method(did: &str, resolver: &dyn DIDResolver) -> Option<String> {
-    let vms = get_verification_methods(did, resolver)
-        .await
-        .unwrap_or_default();
-    vms.into_iter().next()
+    let (res_meta, doc_opt, _meta) = resolver
+        .resolve(did, &ResolutionInputMetadata::default())
+        .await;
+    if res_meta.error.is_some() {
+        return None;
+    }
+    let doc = match doc_opt {
+        Some(doc) => doc,
+        None => return None,
+    };
+    let vms_auth = doc
+        .get_verification_method_ids(ProofPurpose::Authentication)
+        .ok();
+    if let Some(id) = vms_auth.iter().flatten().next() {
+        return Some(id.to_owned());
+    }
+    let vms_assert = doc
+        .get_verification_method_ids(ProofPurpose::AssertionMethod)
+        .ok();
+    vms_assert.iter().flatten().next().cloned()
 }
 
 /// Resolve a DID and get its the verification methods from its DID document.
+#[deprecated(note = "Use get_verification_methods_for_purpose")]
 pub async fn get_verification_methods(
     did: &str,
     resolver: &dyn DIDResolver,
@@ -896,6 +925,21 @@ pub async fn get_verification_methods(
         .map(|vm| vm.get_id(did))
         .collect();
     Ok(vms)
+}
+
+async fn get_verification_methods_for_purpose(
+    did: &str,
+    resolver: &dyn DIDResolver,
+    proof_purpose: ProofPurpose,
+) -> Result<Vec<String>, String> {
+    let (res_meta, doc_opt, _meta) = resolver
+        .resolve(did, &ResolutionInputMetadata::default())
+        .await;
+    if let Some(err) = res_meta.error {
+        return Err(err.to_string());
+    }
+    let doc = doc_opt.ok_or("Missing document".to_string())?;
+    doc.get_verification_method_ids(proof_purpose)
 }
 
 #[async_trait]

--- a/tests/did-example-foo.json
+++ b/tests/did-example-foo.json
@@ -24,5 +24,13 @@
         "x": "G80iskrv_nE69qbGLSpeOHJgmV4MKIzsy5l5iT6pCww"
       }
     }
+  ],
+  "assertionMethod": [
+    "did:example:foo#key1",
+    "did:example:foo#key2"
+  ],
+  "authentication": [
+    "did:example:foo#key1",
+    "did:example:foo#key2"
   ]
 }


### PR DESCRIPTION
Depends on: https://github.com/spruceid/ssi/pull/119

[Verification method](https://w3c.github.io/did-core/#verification-methods) maps may appear in a DID document in multiple places, e.g. [`authentication`](https://w3c.github.io/did-core/#authentication) or [`assertionMethod`](https://w3c.github.io/did-core/#assertion). Previously we required them to be under the [`verificationMethod`](https://w3c.github.io/did-core/#dfn-verificationmethod) property. When a verification method (or its `id`) is included in one of these arrays, it indicates a [verification relationship](https://w3c.github.io/did-core/#verification-relationships) between the [DID subject](https://w3c.github.io/did-core/#dfn-did-subjects) and the verification method. These verification relationships correspond to the [proofPurpose](https://w3c-ccg.github.io/security-vocab/#proofPurpose) property in linked data proofs. DID Core says that the [`assertionMethod`](https://w3c.github.io/did-core/#dfn-assertionmethod) is used for issuing Verifiable Credentials. It also says that [`authentication`](https://w3c.github.io/did-core/#dfn-authentication) is used e.g. for authenticating via challenge-response protocol. Typically, the `authentication` proof purpose is used for creating Verifiable Presentations, as seen in [VC Data Model - Example 45](https://w3c.github.io/vc-data-model/#example-45-a-holder-presenting-a-verifiable-credential-that-was-passed-to-it-by-the-subject), and in test cases in [vc-http-api-test-server](https://github.com/w3c-ccg/vc-http-api/tree/966aba7/packages/vc-http-api-test-server) such as [`case-1.json`](https://github.com/w3c-ccg/vc-http-api/blob/41a8763a93a93974eb073d6f17ac9c561d68ca0e/packages/vc-http-api-test-server/__fixtures__/verifiablePresentations/case-1.json#L46).

This PR sets the default behavior for verifying a verifiable credential or verifiable presentation to require the proof's verification method to be in the DID document with the verification relationship corresponding to the proof purpose in the verification options - with `assertionMethod` the default proof purpose for a VC, and `authentication` the default for a VP.

This change only affects verification. During issuance, the proof purpose and verification method must still be passed in as options.

The publicKey is added back to the DID document even though it is no longer in DID Core, since there is a test case in `vc-http-api-test-server` that depends on it. It is treated as another place to look for verification methods (like the ``verificationMethod` array). A verification method in the `verificationMethod` array or `publicKey` array to be useful with proofs should also be referenced in one of the verification relationship arrays like `assertionMethod` and/or `authentication`, to express a verification relationship.