### PR TITLE
Improve DID URL dereferencing for verification methods

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -100,9 +100,14 @@ impl DIDResolver for DIDEthr {
         let doc = Document {
             context: Contexts::One(Context::URI(DEFAULT_CONTEXT.to_string())),
             id: did.to_string(),
-            authentication: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
-            assertion_method: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
-            // TODO: authentication/assertion_method?
+            authentication: Some(vec![
+                VerificationMethod::DIDURL(vm_didurl.clone()),
+                VerificationMethod::DIDURL(eip712vm_didurl.clone()),
+            ]),
+            assertion_method: Some(vec![
+                VerificationMethod::DIDURL(vm_didurl.clone()),
+                VerificationMethod::DIDURL(eip712vm_didurl.clone()),
+            ]),
             verification_method: Some(vec![vm, eip712vm]),
             ..Default::default()
         };
@@ -198,10 +203,12 @@ mod tests {
                 "blockchainAccountId": "0xb9c5714089478a327f09197987f16f9e5d936e8a@eip155:1"
               }],
               "authentication": [
-                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller"
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller",
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#Eip712Method2021"
               ],
               "assertionMethod": [
-                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller"
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller",
+                "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#Eip712Method2021"
               ]
             })
         );

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use thiserror::Error;
 
-use ssi::did::{DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap};
+use ssi::did::{DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap, DIDURL};
 use ssi::did_resolve::{
     DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
     ERROR_NOT_FOUND, TYPE_DID_LD_JSON,
@@ -155,6 +155,11 @@ impl DIDResolver for DIDKey {
                 None,
             );
         };
+        let vm_didurl = DIDURL {
+            did: did.to_string(),
+            fragment: Some(method_specific_id.to_string()),
+            ..Default::default()
+        };
         let doc = Document {
             id: did.to_string(),
             verification_method: Some(vec![VerificationMethod::Map(VerificationMethodMap {
@@ -164,6 +169,8 @@ impl DIDResolver for DIDKey {
                 public_key_jwk: Some(jwk),
                 ..Default::default()
             })]),
+            authentication: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
+            assertion_method: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
             ..Default::default()
         };
         (

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -203,7 +203,8 @@ mod tests {
            "crv": "Ed25519",
            "x": "G80iskrv_nE69qbGLSpeOHJgmV4MKIzsy5l5iT6pCww"
          }
-      }]
+      }],
+      "assertionMethod": ["did:web:localhost#key1"]
     }"#;
 
     // localhost web server for serving did:web DID documents.

--- a/src/did.rs
+++ b/src/did.rs
@@ -98,6 +98,9 @@ pub struct Document {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capability_delegation: Option<Vec<VerificationMethod>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    // publicKey is used by legacy DID documents
+    pub public_key: Option<Vec<VerificationMethod>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub service: Option<Vec<Service>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proof: Option<OneOrMany<Proof>>,
@@ -655,6 +658,7 @@ impl Document {
             service: None,
             proof: None,
             property_set: None,
+            public_key: None,
         }
     }
 
@@ -678,6 +682,7 @@ impl Document {
             &self.key_agreement,
             &self.capability_invocation,
             &self.capability_delegation,
+            &self.public_key,
         ]
         .iter()
         .flat_map(|array| array.iter().flatten())

--- a/src/did.rs
+++ b/src/did.rs
@@ -671,7 +671,17 @@ impl Document {
     pub fn select_object(&self, id: &DIDURL) -> Result<Resource, Error> {
         let id_string = String::from(id.clone());
         let id_relative_string_opt = id.to_relative(&self.id).map(|rel_url| rel_url.to_string());
-        for vm in self.verification_method.iter().flatten() {
+        for vm in vec![
+            &self.verification_method,
+            &self.authentication,
+            &self.assertion_method,
+            &self.key_agreement,
+            &self.capability_invocation,
+            &self.capability_delegation,
+        ]
+        .iter()
+        .flat_map(|array| array.iter().flatten())
+        {
             if let VerificationMethod::Map(map) = vm {
                 if map.id == id_string || Some(&map.id) == id_relative_string_opt.as_ref() {
                     let mut map = map.clone();

--- a/tests/did-example-foo.json
+++ b/tests/did-example-foo.json
@@ -24,5 +24,13 @@
         "x": "G80iskrv_nE69qbGLSpeOHJgmV4MKIzsy5l5iT6pCww"
       }
     }
+  ],
+  "assertionMethod": [
+    "did:example:foo#key1",
+    "did:example:foo#key2"
+  ],
+  "authentication": [
+    "did:example:foo#key1",
+    "did:example:foo#key2"
   ]
 }


### PR DESCRIPTION
Copied from #122

[Verification method](https://w3c.github.io/did-core/#verification-methods) maps may appear in a DID document in multiple places, e.g. [`authentication`](https://w3c.github.io/did-core/#authentication) or [`assertionMethod`](https://w3c.github.io/did-core/#assertion). Previously we required them to be under the [`verificationMethod`](https://w3c.github.io/did-core/#dfn-verificationmethod) property. When a verification method (or its `id`) is included in one of these arrays, it indicates a [verification relationship](https://w3c.github.io/did-core/#verification-relationships) between the [DID subject](https://w3c.github.io/did-core/#dfn-did-subjects) and the verification method. These verification relationships correspond to the [proofPurpose](https://w3c-ccg.github.io/security-vocab/#proofPurpose) property in linked data proofs. DID Core says that the [`assertionMethod`](https://w3c.github.io/did-core/#dfn-assertionmethod) verification relationship is used for issuing Verifiable Credentials. It also says that [`authentication`](https://w3c.github.io/did-core/#dfn-authentication) is used for authenticating via challenge-response protocols. Typically, the `authentication` proof purpose is used for creating Verifiable Presentations, as seen in [VC Data Model - Example 45](https://w3c.github.io/vc-data-model/#example-45-a-holder-presenting-a-verifiable-credential-that-was-passed-to-it-by-the-subject), and in test cases in [vc-http-api-test-server](https://github.com/w3c-ccg/vc-http-api/tree/966aba7/packages/vc-http-api-test-server) such as [`case-1.json`](https://github.com/w3c-ccg/vc-http-api/blob/41a8763a93a93974eb073d6f17ac9c561d68ca0e/packages/vc-http-api-test-server/__fixtures__/verifiablePresentations/case-1.json#L46). We should respect verification relationships when verifying proofs.

This PR sets the default behavior for verifying a verifiable credential or verifiable presentation to require the proof's verification method to be in the DID document with the verification relationship corresponding to the proof purpose in the verification options - with `assertionMethod` the default proof purpose for a VC, and `authentication` the default for a VP.

This change only affects verification. During issuance, the proof purpose and verification method must still be passed in as options.

The publicKey is added back to the DID document even though it is no longer in DID Core, since there is a test case in `vc-http-api-test-server` that depends on it. It is treated as another place where verification methods may be stored, like the `verificationMethod` array. A verification method in the `verificationMethod` array or `publicKey` array should also be referenced in one of the verification relationship arrays like `assertionMethod` and/or `authentication`, to express a verification relationship and therefore be used with linked data proofs.