### PR TITLE
Add Source::KeyAndPattern and DIDMethods::generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support HTTP(S) requests in WASM and on Android.
 - Support relative DID URLs in DID documents.
 - Support [publicKeyBase58][] for Ed25519.
+- Added `DIDMethods::generate` function.
 
 ### Changed
 - Make `ResolutionResult` struct public.
@@ -56,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `jws::sign_bytes` return bytes instead of string.
 - Allow multiple proofs and multiple verification methods in a DID document
 - Bundle `json-ld` crate, for `crates.io` release.
+- Added `Source::KeyAndPattern` enum variant.
 
 ### Fixed
 - Fix `tz1` hashing.

--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -138,6 +138,13 @@ impl DIDMethod for DIDEthr {
     fn generate(&self, source: &Source) -> Option<String> {
         let jwk = match source {
             Source::Key(jwk) => jwk,
+            Source::KeyAndPattern(jwk, pattern) => {
+                if !pattern.is_empty() {
+                    // TODO: support pattern
+                    return None;
+                }
+                jwk
+            }
             _ => return None,
         };
         let hash = match ssi::keccak_hash::hash_public_key(jwk) {

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -193,6 +193,13 @@ impl DIDMethod for DIDKey {
     fn generate(&self, source: &Source) -> Option<String> {
         let jwk = match source {
             Source::Key(jwk) => jwk,
+            Source::KeyAndPattern(jwk, pattern) => {
+                if !pattern.is_empty() {
+                    // pattern not supported
+                    return None;
+                }
+                jwk
+            }
             _ => return None,
         };
         let did = match jwk.params {

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -140,6 +140,13 @@ impl DIDMethod for DIDSol {
     fn generate(&self, source: &Source) -> Option<String> {
         let jwk = match source {
             Source::Key(jwk) => jwk,
+            Source::KeyAndPattern(jwk, pattern) => {
+                if !pattern.is_empty() {
+                    // pattern not supported
+                    return None;
+                }
+                jwk
+            }
             _ => return None,
         };
         let did = match jwk.params {

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -265,6 +265,13 @@ impl DIDMethod for DIDTz {
     fn generate(&self, source: &Source) -> Option<String> {
         let jwk = match source {
             Source::Key(jwk) => jwk,
+            Source::KeyAndPattern(jwk, pattern) => {
+                if !pattern.is_empty() {
+                    // TODO: support pattern
+                    return None;
+                }
+                jwk
+            }
             _ => return None,
         };
         let hash = match hash_public_key(jwk) {


### PR DESCRIPTION
Allow passing an additional string to a DID method in the generate function.

Implementing `generate` on DIDMethods allows generating a DID from a set of DID methods given a DID method name and optional additional string, separated by a colon (`:`).

The additional string may be a prefix or pattern for the DID's method-specific ID, according to the DID method.

This is intended to enable #124.