### PR TITLE
Vendor json-ld crate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "json-ld-normalization"]
 	path = json-ld-normalization
 	url = https://github.com/json-ld/normalization/
+[submodule "json-ld"]
+	path = json-ld
+	url = https://github.com/spruceid/json-ld

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add name to `Error::ResourceNotFound`.
 - Make `jws::sign_bytes` return bytes instead of string.
 - Allow multiple proofs and multiple verification methods in a DID document
+- Bundle `json-ld` crate, for `crates.io` release.
 
 ### Fixed
 - Fix `tz1` hashing.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ simple_asn1 = "0.5"
 num-bigint = "0.3"
 async-std = { version = "1.9", features = ["attributes"] }
 async-trait = "0.1"
-json-ld = { git = "https://github.com/timothee-haudebourg/json-ld", rev = "5a30cfe37cfecd36808549caa983de3e5ced926b" }
 json = "^0.12"
 futures = "0.3"
 iref = "1.4"
@@ -49,6 +48,16 @@ keccak-hash = { version = "0.7", optional = true }
 p256 = { version = "0.7", optional = true, features = ["zeroize", "ecdsa"] }
 signature = { version = ">= 1.2.2, < 1.3.0" } # match ecdsa 0.10.2
 
+# dependencies for json-ld
+log = "^0.4"
+mown = "^0.2"
+# json = "^0.12"
+#iref = "^1.4.3"
+#futures = "^0.3"
+once_cell = "^1.4"
+reqwest = { version = "^0.10", optional = true }
+langtag = "^0.2"
+
 [workspace]
 members = [
   "did-tezos",
@@ -62,3 +71,9 @@ members = [
 [dev-dependencies]
 uuid = { version = "0.8", features = ["v4", "serde"] }
 difference = "2.0"
+
+# dev-dependencies for json-ld
+static-iref = "^1.0"
+iref-enum = "^1.2"
+stderrlog = "^0.5"
+tokio = { version = "1.0", features = ["macros"] }

--- a/NOTICE
+++ b/NOTICE
@@ -14,3 +14,8 @@ Copyright © 2018-2021 World Wide Web Consortium, (Massachusetts Institute of Te
 Portions of this software are based in part on the work of schema.org. Because Spruce Systems, Inc. has included the work of schema.org in this product, Spruce Systems, Inc. is providing attribution in the following notice:
 
 Copyright in the schema by the sponsors of schema.org (Google, Inc., Yahoo, Inc., Microsoft Corporation and Yandex) are licensed to website publishers and other third parties under the Creative Commons Attribution-ShareAlike License (version 3.0) according to their Terms of Service, please visit https://schema.org/docs/terms.html. To view a copy of this license, please visit http://creativecommons.org/licenses/by-sa/3.0/.
+
+This software includes a modified copy of the json-ld crate by Timothée Haudebourg.
+The json-ld crate is available under either the Apache License, Version 2.0; or the MIT License.
+Original source: https://github.com/timothee-haudebourg/json-ld
+Modified source: https://github.com/spruceid/json-ld/tree/vendor

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use crate::caip10::BlockchainAccountIdVerifyError;
 use crate::eip712::TypedDataConstructionError;
 #[cfg(feature = "keccak-hash")]
 use crate::eip712::TypedDataHashError;
+use crate::json_ld;
 use base64::DecodeError as Base64Error;
 use iref::Error as IRIError;
 use json::Error as JSONError;

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -8,6 +8,7 @@ use crate::rdf::{
     Object, Predicate, StringLiteral, Subject, Triple, LANG_STRING_IRI_STR,
 };
 
+use crate::json_ld;
 use futures::future::{BoxFuture, FutureExt};
 use iref::{Iri, IriBuf};
 use json::JsonValue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@ pub mod soltx;
 pub mod urdna2015;
 pub mod vc;
 
+#[path = "../json-ld/src/lib.rs"]
+mod json_ld;
+
 extern crate pest;
 #[macro_use]
 extern crate pest_derive;
@@ -29,6 +32,10 @@ extern crate derive_builder;
 extern crate lazy_static;
 #[macro_use]
 extern crate json;
+
+// for json-ld:
+#[macro_use]
+extern crate log;
 
 #[derive(Parser)]
 #[grammar = "did.pest"]


### PR DESCRIPTION
Vendor the `json-ld` crate dependency using a git submodule, to enable publish to `crates.io`.

Progress for #136

Fixes #90

Includes #140, to get CI to work (Closes #140)

Cargo dependencies using git repo URLs cannot be used for publishing to `crates.io` (unless also including a registry version for publishing). We are depending on the `json-ld` crate with changes which are not yet published to `crates.io`. Without being able to depend on this two crates on `crates.io`, we must either fork and publish it to `crates.io` under a different name, or vendor it somehow. I wasn't able to get `cargo vendor` to work, and I'm not sure if that can be used (source replacement) with publishing to `crates.io` anyway. Instead, the approach taken here is to modify the package to make it work in `ssi`'s workspace. It seems to be working to use a git submodule rather than having to include the repos' source files directly. The `json-ld` repos is forked and added to git submodules. The changes to `json-ld` are in the following PR, proposing to use a branch `vendor` for our fork: https://github.com/spruceid/json-ld/pull/1

- [x] `cargo publish --dry-run` works