### PR TITLE
Namespace ci cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', '**.rs') }}
+        key: ${{ runner.os }}-ssi-cargo-${{ hashFiles('Cargo.toml', '**.rs') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-
+          ${{ runner.os }}-ssi-cargo-
 
     - name: Build
       run: cargo build --verbose --workspace


### PR DESCRIPTION
Distinguish CI cache from DIDKit's CI cache, by using a different the cache key prefix. DIDKit's CI cache currently may be large due to https://github.com/spruceid/didkit/pull/112 (WIP). This has contributed to `ssi` CI runs running run out of disk space: https://github.com/spruceid/ssi/actions/runs/680660833. The change in this PR should ensure that `ssi`'s cache doesn't get mixed with DIDKit's cache.