### PR TITLE
Update DID method package names

### DIFF
--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "did-key"
+name = "did-method-key"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"


### PR DESCRIPTION
Crate name `did-key` cannot be used, because there is already <https://crates.io/crates/did-key>.

~~This PR proposes to name `ssi`'s DID method/resolver crates as `did-method-<name>`, e.g. `did-method-key`. These names appear to be available on `crates.io`.~~ Now only updating `did-key` → `did-method-key`.

Progress for #136

Includes #140