### PR TITLE
Implement did:onion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
   "did-ethr",
   "did-sol",
   "did-pkh",
+  "did-onion",
   "vc-test",
 ]
 

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "did-onion"
+version = "0.1.0"
+authors = ["Spruce Systems, Inc."]
+edition = "2018"
+
+[features]
+tor-tests = []
+
+[dependencies]
+ssi = { path = "../", default-features = false }
+async-trait = "0.1"
+reqwest = { version = "0.11", features = ["json", "socks"] }
+http = "0.2"
+serde_json = "1.0"
+
+[target.'cfg(target_os = "android")'.dependencies.reqwest]
+version = "0.11"
+features = ["json", "native-tls-vendored"]
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["macros"] }
+serde = { version = "1.0", features = ["derive"] }
+async-std = { version = "1.9", features = ["attributes"] }
+futures = "0.3"
+hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
+#TODO: socks5-async = "0.1.4"

--- a/did-onion/src/lib.rs
+++ b/did-onion/src/lib.rs
@@ -1,0 +1,291 @@
+use async_trait::async_trait;
+use std::default::Default;
+
+use ssi::did::{DIDMethod, Document};
+use ssi::did_resolve::{
+    DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
+    TYPE_DID_LD_JSON,
+};
+
+const TOR_SOCKS_PORT: usize = 9050;
+
+/// did:onion Method
+///
+/// [Specification](https://blockchaincommons.github.io/did-method-onion/)
+#[non_exhaustive]
+pub struct DIDOnion {
+    pub proxy_url: String,
+}
+
+impl DIDOnion {
+    fn with_port(port: usize) -> Self {
+        Self {
+            proxy_url: format!("socks5h://127.0.0.1:{}", port),
+        }
+    }
+}
+
+impl Default for DIDOnion {
+    fn default() -> Self {
+        Self::with_port(TOR_SOCKS_PORT)
+    }
+}
+
+fn did_onion_url(did: &str) -> Result<String, ResolutionMetadata> {
+    let mut parts = did.split(":").peekable();
+    let onion_address = match (parts.next(), parts.next(), parts.next()) {
+        (Some("did"), Some("onion"), Some(domain_name)) => domain_name,
+        _ => {
+            return Err(ResolutionMetadata::from_error(ERROR_INVALID_DID));
+        }
+    };
+    for c in onion_address.chars() {
+        // "The method specific identifier ... MUST NOT include IP addresses or port numbers"
+        if c == '.' || c == ':' {
+            return Err(ResolutionMetadata::from_error(ERROR_INVALID_DID));
+        }
+    }
+    let path = match parts.peek() {
+        Some(_) => parts.collect::<Vec<&str>>().join("/"),
+        None => ".well-known".to_string(),
+    };
+    let url = format!("http://{}.onion/{}/did.json", onion_address, path);
+    Ok(url)
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl DIDResolver for DIDOnion {
+    async fn resolve(
+        &self,
+        did: &str,
+        input_metadata: &ResolutionInputMetadata,
+    ) -> (
+        ResolutionMetadata,
+        Option<Document>,
+        Option<DocumentMetadata>,
+    ) {
+        let (res_meta, doc_data, doc_meta_opt) =
+            self.resolve_representation(did, input_metadata).await;
+        let doc_opt = if doc_data.is_empty() {
+            None
+        } else {
+            match serde_json::from_slice(&doc_data) {
+                Ok(doc) => doc,
+                Err(err) => {
+                    return (
+                        ResolutionMetadata::from_error(
+                            &("JSON Error: ".to_string() + &err.to_string()),
+                        ),
+                        None,
+                        None,
+                    )
+                }
+            }
+        };
+        (res_meta, doc_opt, doc_meta_opt)
+    }
+
+    async fn resolve_representation(
+        &self,
+        did: &str,
+        input_metadata: &ResolutionInputMetadata,
+    ) -> (ResolutionMetadata, Vec<u8>, Option<DocumentMetadata>) {
+        let url = match did_onion_url(did) {
+            Err(meta) => return (meta, Vec::new(), None),
+            Ok(url) => url,
+        };
+        let mut client_builder = reqwest::Client::builder();
+        #[cfg(not(target_arch = "wasm32"))]
+        match reqwest::Proxy::all(&self.proxy_url) {
+            Ok(proxy) => {
+                client_builder = client_builder.proxy(proxy);
+            }
+            Err(err) => {
+                return (
+                    ResolutionMetadata::from_error(&format!(
+                        "Error constructing proxy: {}",
+                        err.to_string()
+                    )),
+                    Vec::new(),
+                    None,
+                )
+            }
+        };
+        let client = match client_builder.build() {
+            Ok(c) => c,
+            Err(err) => {
+                return (
+                    ResolutionMetadata::from_error(&format!(
+                        "Error building HTTP client: {}",
+                        err.to_string()
+                    )),
+                    Vec::new(),
+                    None,
+                )
+            }
+        };
+        let accept = input_metadata
+            .accept
+            .clone()
+            .unwrap_or_else(|| "application/json".to_string());
+        let resp = match client.get(&url).header("Accept", accept).send().await {
+            Ok(req) => req,
+            Err(err) => {
+                return (
+                    ResolutionMetadata::from_error(&format!(
+                        "Error sending HTTP request : {}",
+                        err.to_string()
+                    )),
+                    Vec::new(),
+                    None,
+                )
+            }
+        };
+        match resp.error_for_status_ref() {
+            Ok(_) => (),
+            Err(err) => {
+                return (
+                    ResolutionMetadata::from_error(&err.to_string()),
+                    Vec::new(),
+                    Some(DocumentMetadata::default()),
+                )
+            }
+        };
+        let doc_representation = match resp.bytes().await {
+            Ok(bytes) => bytes.to_vec(),
+            Err(err) => {
+                return (
+                    ResolutionMetadata::from_error(
+                        &("Error reading HTTP response: ".to_string() + &err.to_string()),
+                    ),
+                    Vec::new(),
+                    None,
+                )
+            }
+        };
+        // TODO: set document created/updated metadata from HTTP headers?
+        (
+            ResolutionMetadata {
+                error: None,
+                content_type: Some(TYPE_DID_LD_JSON.to_string()),
+                property_set: None,
+            },
+            doc_representation,
+            Some(DocumentMetadata::default()),
+        )
+    }
+}
+
+impl DIDMethod for DIDOnion {
+    fn name(&self) -> &'static str {
+        return "onion";
+    }
+
+    fn to_resolver(&self) -> &dyn DIDResolver {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::SocketAddr;
+
+    #[async_std::test]
+    async fn parse_did_onion() {
+        assert_eq!(
+            did_onion_url("did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid").unwrap(),
+            "http://fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid.onion/.well-known/did.json"
+        );
+        assert_eq!(
+            did_onion_url("did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid:user:alice").unwrap(),
+            "http://fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid.onion/user/alice/did.json"
+        );
+        assert_eq!(
+            did_onion_url(
+                "did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid:u:bob"
+            )
+            .unwrap(),
+            "http://fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid.onion/u/bob/did.json"
+        );
+    }
+
+    const TORGAP_DEMO_DID: &str =
+        "did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid";
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "tor-tests"), ignore)]
+    async fn did_onion_resolve_live() {
+        let (res_meta, doc_opt, _doc_meta) = DIDOnion::default()
+            .resolve(TORGAP_DEMO_DID, &ResolutionInputMetadata::default())
+            .await;
+        assert_eq!(res_meta.error, None);
+        assert!(doc_opt.is_some());
+    }
+
+    /*
+     * TODO: test with local proxy and local web server
+     * https://github.com/spruceid/ssi/issues/162
+
+    // localhost web server for serving did:onion DID documents.
+    // Based on the one in did-web's tests.
+    fn web_server() -> Result<(String, impl FnOnce() -> Result<(), ()>), hyper::Error> {
+        use http::header::{HeaderValue, CONTENT_TYPE};
+        use hyper::service::{make_service_fn, service_fn};
+        use hyper::{Body, Response, Server};
+        let addr = ([127, 0, 0, 1], 0).into();
+        let make_svc = make_service_fn(|_| async move {
+            Ok::<_, hyper::Error>(service_fn(|req| async move {
+                let uri = req.uri();
+                // Skip leading slash
+                let proxied_url: String = uri.path().chars().skip(1).collect();
+                if proxied_url == DID_URL {
+                    let body = Body::from(DID_JSON);
+                    let mut response = Response::new(body);
+                    response
+                        .headers_mut()
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                    return Ok::<_, hyper::Error>(response);
+                }
+
+                let (mut parts, body) = Response::<Body>::default().into_parts();
+                parts.status = hyper::StatusCode::NOT_FOUND;
+                let response = Response::from_parts(parts, body);
+                return Ok::<_, hyper::Error>(response);
+            }))
+        });
+        let server = Server::try_bind(&addr)?.serve(make_svc);
+        let addr: SocketAddr = server.local_addr().parse()?;
+        let (shutdown_tx, shutdown_rx) = futures::channel::oneshot::channel();
+        let graceful = server.with_graceful_shutdown(async {
+            shutdown_rx.await.ok();
+        });
+        tokio::task::spawn(async move {
+            graceful.await.ok();
+        });
+        let shutdown = || shutdown_tx.send(());
+        Ok((addr, shutdown))
+    }
+
+    #[tokio::test]
+    async fn did_onion_resolve() {
+        use socks5_async::SocksServer;
+        let mut socks5 = SocksServer::new(
+            addr,
+            true,
+            Box::new(move |username, password| {
+                //
+            }),
+        )
+        .await;
+        socks5.server().await;
+
+        let (res_meta, doc_opt, _doc_meta) = DIDOnion::default()
+            .resolve(TORGAP_DEMO_DID, &ResolutionInputMetadata::default())
+            .await;
+        assert_eq!(res_meta.error, None);
+        assert!(doc_opt.is_some());
+    }
+    */
+}


### PR DESCRIPTION
Close #134

- [ ] Test with local proxy server and web server (instead of live)
- [x] Test live? No, but some examples in thread https://github.com/spruceid/didkit/pull/125
- [ ] Security considerations around use in browsers: should some safety be placed around this resolver in WASM usage? In non-WASM, the default is to use proxy `127.0.0.1:9050`, but in the browser there is no such assumption - we just fire off a [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) [reqwest](https://github.com/seanmonstar/reqwest/).