### PR TITLE
Add ssi package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,15 @@ name = "ssi"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+description = "Core library for Verifiable Credentials and Decentralized Identifiers."
+repository = "https://github.com/spruceid/ssi/"
+documentation = "https://docs.rs/ssi/"
+
+exclude = [
+  "json-ld-api/*",
+  "json-ld-normalization/*",
+]
 
 [features]
 default = ["ring"]
@@ -47,7 +56,7 @@ thiserror = "1.0"
 keccak-hash = { version = "0.7", optional = true }
 p256 = { version = "0.7", optional = true, features = ["zeroize", "ecdsa"] }
 signature = { version = ">= 1.2.2, < 1.3.0" } # match ecdsa 0.10.2
-ssi-contexts = { path = "contexts/" }
+ssi-contexts = { version = "0.0.1", path = "contexts/" }
 ripemd160 = { version = "0.9", optional = true }
 
 # dependencies for json-ld


### PR DESCRIPTION
Set license field, description, repository and documentation URLs, in preparation for publishing `ssi` to `crates.io` (#136).

`cargo publish --dry-run` gives a warning if these fields are not set.

Also add `json-ld-api` and `json-ld-normalization` (git submodules) to excludes, since they would otherwise be included in the crate.

~~The license field is set to `Apache-2.0 AND W3C-20150513 AND CC-BY-SA-3.0`, since we have not just Apache-2.0 code, but also some JSON-LD context files, which are under the [W3C Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software) (corresponding to [W3C-20150513](https://spdx.org/licenses/W3C-20150513.html) in SPDX) and [Creative Commons Attribution-ShareAlike License (version 3.0)](http://creativecommons.org/licenses/by-sa/3.0/) (SPDX: [CC-BY-SA-3.0](https://spdx.org/licenses/CC-BY-SA-3.0.html)), as noted in our NOTICE file. The Cargo Book [reference for package fields](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) says, "Using AND indicates the user must comply with both licenses simultaneously." We could consider moving these context files into separate crates, to simplify the license fields.~~ License remains `Apache-2.0` as the otherwise-licensed JSON-LD context files have been moved into a separate crate, `ssi-contexts`: #157
