### PR TITLE
Disable CI cache of Cargo build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,9 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-          target
-        key: ${{ runner.os }}-ssi1-cargo-${{ hashFiles('Cargo.toml', '**.rs') }}
+        key: ${{ runner.os }}-ssi2-cargo-${{ hashFiles('Cargo.toml', '**.rs') }}
         restore-keys: |
-          ${{ runner.os }}-ssi1-cargo-
+          ${{ runner.os }}-ssi2-cargo-
 
     - name: Build
       run: cargo build --verbose --workspace


### PR DESCRIPTION
The cache size quickly gets large and uses up all free disk space: https://github.com/spruceid/ssi/issues/158

This PR disables caching of `target/`, but leaves  in caching of the registry data since that doesn't become stale so often, as it is mostly appending to a git repo.