### PR TITLE
Release DID Method implementation crates

### DIFF
--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -3,9 +3,16 @@ name = "did-ethr"
 version = "0.0.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+keywords = ["ssi", "did", "ethereum"]
+categories = ["cryptography::cryptocurrencies"]
+description = "did:ethr DID method, using the ssi crate"
+repository = "https://github.com/spruceid/ssi/"
+homepage = "https://github.com/spruceid/ssi/tree/main/did-ethr/"
+documentation = "https://docs.rs/did-ethr/"
 
 [dependencies]
-ssi = { path = "../", default-features = false, features = ["secp256k1", "keccak-hash"] }
+ssi = { version = "0.2", path = "../", default-features = false, features = ["secp256k1", "keccak-hash"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/did-ethr/README.md
+++ b/did-ethr/README.md
@@ -1,0 +1,10 @@
+# did-ethr
+
+Rust implementation of the [did:ethr][] DID Method, based on the [ssi][] library.
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/)
+
+[did:ethr]: https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md
+[ssi]: https://github.com/spruceid/ssi/

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -3,13 +3,20 @@ name = "did-method-key"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+keywords = ["ssi", "did", "ethereum"]
+categories = ["cryptography::cryptocurrencies"]
+description = "did:key DID method, using the ssi crate"
+repository = "https://github.com/spruceid/ssi/"
+homepage = "https://github.com/spruceid/ssi/tree/main/did-ethr/"
+documentation = "https://docs.rs/did-ethr/"
 
 [features]
 secp256k1 = ["libsecp256k1", "ssi/secp256k1", "ssi/rand"]
 p256 = ["ssi/p256"]
 
 [dependencies]
-ssi = { path = "../", default-features = false }
+ssi = { version = "0.2", path = "../", default-features = false }
 async-trait = "0.1"
 thiserror = "1.0"
 multibase = "0.8"

--- a/did-key/README.md
+++ b/did-key/README.md
@@ -1,0 +1,10 @@
+# did-key
+
+Rust implementation of the [did:key][] DID Method, based on the [ssi][] library.
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/)
+
+[did:key]: https://w3c-ccg.github.io/did-method-key/
+[ssi]: https://github.com/spruceid/ssi/

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -3,12 +3,18 @@ name = "did-onion"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+keywords = ["ssi", "did", "tor", "onion"]
+description = "did:onion DID method, using the ssi crate"
+repository = "https://github.com/spruceid/ssi/"
+homepage = "https://github.com/spruceid/ssi/tree/main/did-onion/"
+documentation = "https://docs.rs/did-onion/"
 
 [features]
 tor-tests = []
 
 [dependencies]
-ssi = { path = "../", default-features = false }
+ssi = { version = "0.2", path = "../", default-features = false }
 async-trait = "0.1"
 reqwest = { version = "0.11", features = ["json", "socks"] }
 http = "0.2"

--- a/did-onion/README.md
+++ b/did-onion/README.md
@@ -1,0 +1,10 @@
+# did-onion
+
+Rust implementation of the [did:onion][] DID Method, based on the [ssi][] library.
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/)
+
+[did:onion]: https://blockchaincommons.github.io/did-method-onion/
+[ssi]: https://github.com/spruceid/ssi/

--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -3,9 +3,16 @@ name = "did-pkh"
 version = "0.0.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+keywords = ["ssi", "did", "tor"]
+categories = ["cryptography"]
+description = "did:pkh DID method, using the ssi crate"
+repository = "https://github.com/spruceid/ssi/"
+homepage = "https://github.com/spruceid/ssi/tree/main/did-pkh/"
+documentation = "https://docs.rs/did-pkh/"
 
 [dependencies]
-ssi = { path = "../", default-features = false, features = ["secp256k1", "keccak-hash", "p256", "ripemd160"] }
+ssi = { version = "0.2", path = "../", default-features = false, features = ["secp256k1", "keccak-hash", "p256", "ripemd160"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/did-pkh/README.md
+++ b/did-pkh/README.md
@@ -1,0 +1,10 @@
+# did-pkh
+
+Rust implementation of the `did:pkh` [DID Method][], based on the [ssi][] library.
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/)
+
+[DID Method]: https://www.w3.org/TR/did-core/#methods
+[ssi]: https://github.com/spruceid/ssi/

--- a/did-sol/Cargo.toml
+++ b/did-sol/Cargo.toml
@@ -3,9 +3,16 @@ name = "did-sol"
 version = "0.0.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+keywords = ["ssi", "did", "solana"]
+categories = ["cryptography::cryptocurrencies"]
+description = "did:sol (Solana) DID method, using the ssi crate"
+repository = "https://github.com/spruceid/ssi/"
+homepage = "https://github.com/spruceid/ssi/tree/main/did-sol/"
+documentation = "https://docs.rs/did-sol/"
 
 [dependencies]
-ssi = { path = "../", default-features = false, features = [] }
+ssi = { version = "0.2", path = "../", default-features = false, features = [] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/did-sol/README.md
+++ b/did-sol/README.md
@@ -1,0 +1,10 @@
+# did-sol
+
+Rust implementation of the `did:sol` [DID Method][], based on the [ssi][] library.
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/)
+
+[DID Method]: https://www.w3.org/TR/did-core/#methods
+[ssi]: https://github.com/spruceid/ssi/

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "did-tezos"
+name = "did-tz"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -3,6 +3,13 @@ name = "did-tz"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+keywords = ["ssi", "did", "tezos"]
+categories = ["cryptography::cryptocurrencies"]
+description = "did:tz Tezos DID method, using the ssi crate"
+repository = "https://github.com/spruceid/ssi/"
+homepage = "https://github.com/spruceid/ssi/tree/main/did-tezos/"
+documentation = "https://docs.rs/did-tezos/"
 
 [features]
 default = ["ssi/ring"]
@@ -11,7 +18,7 @@ secp256k1 = ["libsecp256k1", "ssi/secp256k1", "ssi/rand"]
 p256 = ["ssi/p256"]
 
 [dependencies]
-ssi = { path = "../", default-features = false }
+ssi = { version = "0.2", path = "../", default-features = false }
 chrono = { version = "0.4" }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/did-tezos/README.md
+++ b/did-tezos/README.md
@@ -1,0 +1,10 @@
+# did-tz
+
+Rust implementation of the [did:tz][] DID Method, based on the [ssi][] library.
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/)
+
+[did:tz]: https://did-tezos.spruceid.com/
+[ssi]: https://github.com/spruceid/ssi/

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -3,9 +3,16 @@ name = "did-web"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+keywords = ["ssi", "did"]
+categories = ["web-programming::http-client"]
+description = "did:web DID method, using the ssi crate"
+repository = "https://github.com/spruceid/ssi/"
+homepage = "https://github.com/spruceid/ssi/tree/main/did-web/"
+documentation = "https://docs.rs/did-web/"
 
 [dependencies]
-ssi = { path = "../", default-features = false }
+ssi = { version = "0.2", path = "../", default-features = false }
 async-trait = "0.1"
 reqwest = { version = "0.11", features = ["json"] }
 http = "0.2"

--- a/did-web/README.md
+++ b/did-web/README.md
@@ -1,0 +1,10 @@
+# did-web
+
+Rust implementation of the [did:key][] DID Method, based on the [ssi][] library.
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/)
+
+[did:web]: https://w3c-ccg.github.io/did-method-web/
+[ssi]: https://github.com/spruceid/ssi/

--- a/vc-test/Cargo.toml
+++ b/vc-test/Cargo.toml
@@ -3,8 +3,11 @@ name = "ssi-vc-test"
 version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
+license = "Apache-2.0"
+description = "vc-test-suite test driver for ssi"
+publish = false
 
 [dependencies]
-ssi = { path = "../" }
+ssi = { version = "0.2", path = "../" }
 serde_json = "1.0"
 base64 = "0.12"


### PR DESCRIPTION
Progress for #136

- Add readmes
  - These will show up on the `crates.io` page, as well as in the repo/directories.
  - URLs in these subdirectory readmes must be absolute: https://github.com/rust-lang/crates.io/issues/3484
  - Link to DID method specifications where extant, otherwise link to DID Core.
- Set metadata fields
  - Set `license` to `Apache-2.0`
  - Set `homepage` to the URL of the directory in the source repo on `main` branch.
  - Set repository and docs as appropriate.
  - Set some [categories](https://crates.io/categories/) and [keywords](https://crates.io/keywords/) where applicable.
- Depend on `ssi` crate by its `crates.io` registry version
  - Use [multiple locations](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations) so that the [path dependency](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies) will still be used when running from the checked out `ssi` repo, but when published on the registry the registry's version of `ssi` will be used.
- Mark `ssi-vc-test` as don't publish as it is only used for our testing with `vc-test-suite` in CI

### Crates to be published

  Crate name    |Version
----------------|-------
`did-ethr`      |`0.0.1`
`did-method-key`|`0.1.0`
`did-onion`     |`0.1.0`
`did-pkh`       |`0.0.1`
`did-sol`       |`0.0.1`
`did-tz`        |`0.1.0`
`did-web`       |`0.1.0`

The versions follow a pattern of "0.1.0" where there is a specification and fairly complete implementation, otherwise "0.0.1".

Naming follows a pattern of `did-<method-name>` where available, otherwise `did-method-<method-name>`. `did-method-key` is in the second category, as discussed in https://github.com/spruceid/ssi/pull/146. `did-tezos` is renamed to `did-tz` for consistency between the crate name and the method name: Fix https://github.com/spruceid/ssi/issues/166.