### PR TITLE
Implement TezosSignature2021 (TezosMethod2021)

### DIFF
--- a/contexts/src/lib.rs
+++ b/contexts/src/lib.rs
@@ -29,5 +29,6 @@ pub const TRACEABILITY_V1: &str = include_str!("../w3c-ccg-traceability-v1.jsonl
 pub const ESRS2020_EXTRA: &str = include_str!("../esrs2020-extra-0.0.jsonld");
 
 pub const TZ_V2: &str = include_str!("../tz-2021-v2.jsonld");
+pub const TZVM_V1: &str = include_str!("../tzvm-2021-v1.jsonld");
 pub const EIP712VM: &str = include_str!("../eip712vm.jsonld");
 pub const SOLVM: &str = include_str!("../solvm.jsonld");

--- a/contexts/tzvm-2021-v1.jsonld
+++ b/contexts/tzvm-2021-v1.jsonld
@@ -1,0 +1,52 @@
+{
+  "TezosMethod2021": "https://w3id.org/security#TezosMethod2021",
+  "TezosSignature2021": {
+    "@id": "https://w3id.org/security#TezosSignature2021",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "id": "@id",
+      "type": "@type",
+      "challenge": "https://w3id.org/security#challenge",
+      "created": {
+        "@id": "http://purl.org/dc/terms/created",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "domain": "https://w3id.org/security#domain",
+      "expires": {
+        "@id": "https://w3id.org/security#expiration",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "nonce": "https://w3id.org/security#nonce",
+      "proofPurpose": {
+        "@id": "https://w3id.org/security#proofPurpose",
+        "@type": "@vocab",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "assertionMethod": {
+            "@id": "https://w3id.org/security#assertionMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "authentication": {
+            "@id": "https://w3id.org/security#authenticationMethod",
+            "@type": "@id",
+            "@container": "@set"
+          }
+        }
+      },
+      "proofValue": "https://w3id.org/security#proofValue",
+      "verificationMethod": {
+        "@id": "https://w3id.org/security#verificationMethod",
+        "@type": "@id"
+      },
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  }
+}

--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -21,3 +21,5 @@ bs58 = { version = "0.4", features = ["check"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"] }
+hex = "0.4"
+blake2b_simd = "0.5"

--- a/did-pkh/tests/did-tz1.jsonld
+++ b/did-pkh/tests/did-tz1.jsonld
@@ -7,12 +7,20 @@
       "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
       "controller": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
       "blockchainAccountId": "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8@tezos:mainnet"
+    },
+    {
+      "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
+      "blockchainAccountId": "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8@tezos:mainnet"
     }
   ],
   "authentication": [
-    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId"
+    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
+    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021"
   ],
   "assertionMethod": [
-    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId"
+    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
+    "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021"
   ]
 }

--- a/did-pkh/tests/did-tz2.jsonld
+++ b/did-pkh/tests/did-tz2.jsonld
@@ -7,12 +7,20 @@
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
       "blockchainAccountId": "tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq@tezos:mainnet"
+    },
+    {
+      "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
+      "blockchainAccountId": "tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq@tezos:mainnet"
     }
   ],
   "authentication": [
-    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId"
+    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
+    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021"
   ],
   "assertionMethod": [
-    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId"
+    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
+    "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021"
   ]
 }

--- a/did-pkh/tests/did-tz3.jsonld
+++ b/did-pkh/tests/did-tz3.jsonld
@@ -7,12 +7,20 @@
       "type": "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
       "controller": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
       "blockchainAccountId": "tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX@tezos:mainnet"
+    },
+    {
+      "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021",
+      "type": "TezosMethod2021",
+      "controller": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
+      "blockchainAccountId": "tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX@tezos:mainnet"
     }
   ],
   "authentication": [
-    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId"
+    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
+    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021"
   ],
   "assertionMethod": [
-    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId"
+    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
+    "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021"
   ]
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,6 +160,7 @@ pub enum Error {
     FromHex(hex::FromHexError),
     Base58(bs58::decode::Error),
     HexString,
+    SignaturePrefix,
     P256KeyLength(usize),
     ECEncodingError,
     ECDecompress,
@@ -274,6 +275,7 @@ impl fmt::Display for Error {
             Error::UnknownProcessingMode(mode) => write!(f, "Unknown processing mode '{}'", mode),
             Error::UnknownRdfDirection(direction) => write!(f, "Unknown RDF direction '{}'", direction),
             Error::HexString => write!(f, "Expected string beginning with '0x'"),
+            Error::SignaturePrefix => write!(f, "Unknown signature prefix"),
             Error::FromUtf8(e) => e.fmt(f),
             Error::TryFromSlice(e) => e.fmt(f),
             #[cfg(feature = "ring")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -161,6 +161,7 @@ pub enum Error {
     Base58(bs58::decode::Error),
     HexString,
     SignaturePrefix,
+    KeyPrefix,
     P256KeyLength(usize),
     ECEncodingError,
     ECDecompress,
@@ -276,6 +277,7 @@ impl fmt::Display for Error {
             Error::UnknownRdfDirection(direction) => write!(f, "Unknown RDF direction '{}'", direction),
             Error::HexString => write!(f, "Expected string beginning with '0x'"),
             Error::SignaturePrefix => write!(f, "Unknown signature prefix"),
+            Error::KeyPrefix => write!(f, "Unknown key prefix"),
             Error::FromUtf8(e) => e.fmt(f),
             Error::TryFromSlice(e) => e.fmt(f),
             #[cfg(feature = "ring")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod rdf;
 #[cfg(feature = "ripemd160")]
 pub mod ripemd;
 pub mod soltx;
+pub mod tzkey;
 pub mod urdna2015;
 pub mod vc;
 

--- a/src/tzkey.rs
+++ b/src/tzkey.rs
@@ -1,0 +1,70 @@
+use crate::error::Error;
+use crate::jwk::{Algorithm, Base64urlUInt, ECParams, OctetParams, Params, JWK};
+
+/// Parse a Tezos key string into a JWK.
+pub fn jwk_from_tezos_key(tz_pk: &str) -> Result<JWK, Error> {
+    if tz_pk.len() < 4 {
+        return Err(Error::KeyPrefix);
+    }
+    let (alg, params) = match &tz_pk[..4] {
+        "edpk" => (
+            Algorithm::EdDSA,
+            Params::OKP(OctetParams {
+                curve: "Ed25519".into(),
+                public_key: Base64urlUInt(
+                    bs58::decode(&tz_pk).with_check(None).into_vec()?[4..].to_owned(),
+                ),
+                private_key: None,
+            }),
+        ),
+        "sppk" => (
+            Algorithm::ES256KR,
+            Params::EC(ECParams {
+                curve: Some("secp256k1".into()),
+                // TODO
+                x_coordinate: None,
+                y_coordinate: None,
+                ecc_private_key: None,
+            }),
+        ),
+        "p2pk" => (
+            Algorithm::PS256,
+            Params::EC(ECParams {
+                curve: Some("P-256".into()),
+                // TODO
+                x_coordinate: None,
+                y_coordinate: None,
+                ecc_private_key: None,
+            }),
+        ),
+        // TODO: secret keys?
+        _ => return Err(Error::KeyPrefix),
+    };
+    Ok(JWK {
+        public_key_use: None,
+        key_operations: None,
+        algorithm: Some(alg),
+        key_id: None,
+        x509_url: None,
+        x509_certificate_chain: None,
+        x509_thumbprint_sha1: None,
+        x509_thumbprint_sha256: None,
+        params,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn edpk_to_jwk() {
+        let jwk =
+            jwk_from_tezos_key("edpkuxZ5AQVCeEJ9inUG3w6VFhio5KBwC22ekPLBzcvub3QY2DvJ7n").unwrap();
+        let jwk_expected: JWK = serde_json::from_value(json!(
+            {"alg":"EdDSA","kty":"OKP","crv":"Ed25519","x":"rVEB0Icbomw1Ir-ck52iCZl1SICc5lCg2pxI8AmydDw"}
+        )).unwrap();
+        assert_eq!(jwk, jwk_expected);
+    }
+}


### PR DESCRIPTION
Create a [linked data signature suite](https://w3c-ccg.github.io/ld-proofs/) (verification method type and proof type) for signed Tezos messages.

Temple (https://github.com/madfish-solutions/templewallet-extension/pull/238) and Kukai (https://github.com/kukai-wallet/kukai/pull/65) allow signing messages, either as raw bytes or as a string [Micheline](https://tezos.gitlab.io/shell/micheline.html) expression beginning with prefix "Tezos Signed Message". We use the Micheline option, since that enables the user to see a string in the signing request instead of only bytes. 

Similar to the [Eip712Signature2021](https://github.com/spruceid/ssi/pull/99), this attempts to create a verification method for using with existing wallet applications, allowing the user to see data being signed in a richer format than a byte string. The signing format implemented here is a string containing NQuads of the [URDNA2015](https://json-ld.github.io/normalization/spec/)-normalized linked data document (VC/VP) and the linked data proof options. This is as done in 
existing suites such as [Ed25519 Signature 2018](https://w3c-ccg.github.io/lds-ed25519-2018/) and [JSON Web Signature 2020](https://github.com/w3c-ccg/lds-jws2020) but with the [Create Verify Hash Algorithm](https://w3c-ccg.github.io/ld-proofs/#create-verify-hash-algorithm) modified in order to present the user with unhashed data.

Since this proof type is intended for use with Tezos accounts, which are identified by public key hashes, this signature suite will support including the public key in the proof object instead of in the verification method, and using the [blockchainAccountId](https://www.w3.org/TR/did-spec-registries/#blockchainaccountid) property of the verification method to validate the public key included in the proof. This is to enable use with signing algorithms that do not support public key recovery, as done in the existing proof types `Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021` and `P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021` (which are being considered for renaming in https://github.com/spruceid/ssi/issues/152).

The `jwk_from_tezos_key` function I copied from @chunningham and add it here since it will be needed in DIDKit in the browser in order to convert the wallet's `edpk` into a `JWK` to pass to DIDKit. This function only supports `edpk` currently, not yet `p2pk` or `sppk`.

I found an odd thing with `spsig` which is that unlike `edsig` and `p2sig`, the prefix bytes do not match the base58: it results in "4sLJ" instead. I am following the bytes ("4sLJ") rather than the ASCII. I have not tested this with an actual Tezos implementation so I don't know if this is correct. Only `edpk`/`edsig` here has been used externally (with Temple wallet).

- [x] Initial draft of `ProofSuite` implementation
- [x] Add the verification method to DID documents: added to `did:pkh`
- [x] Test signing with tz1, tz2, and tz3
- [ ] Add demo app using Kukai and/or Temple for VC/VP issuance: https://github.com/spruceid/didkit-tezos-wallet-example/pull/1 (Temple)
- [ ] Create specification for signature suite