### PR TITLE
Replace libsecp256k1 with k256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,15 @@ exclude = [
 [features]
 default = ["ring"]
 http-did = ["hyper", "hyper-tls", "http", "percent-encoding", "tokio"]
-secp256k1 = ["libsecp256k1", "rand"]
+libsecp256k1 = ["secp256k1"] # backward compatibility
+secp256k1 = ["k256", "rand", "k256/keccak256"]
+secp256r1 = ["p256", "rand"]
+ripemd-160 = ["ripemd160", "secp256k1"]
+# TODO handle better keccak and sha
+keccak = ["keccak-hash", "secp256k1", "k256/keccak256"]
+sha = ["sha2", "k256/sha256"]
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_jcs = "0.1"
@@ -32,8 +37,8 @@ rsa = { version = "0.3", optional = true }
 ed25519-dalek = { version = "1", optional = true }
 rand = { version = "0.7", optional = true }
 multibase = "0.8"
-simple_asn1 = "0.5"
-num-bigint = "0.3"
+simple_asn1 = "^0.5.2"
+num-bigint = "0.4"
 async-std = { version = "1.9", features = ["attributes"] }
 async-trait = "0.1"
 json = "^0.12"
@@ -51,11 +56,10 @@ percent-encoding = { version = "2.1", optional = true }
 tokio = { version = "1.0", optional = true, features = ["macros"] }
 blake2b_simd = "0.5"
 bs58 = { version = "0.4", features = ["check"] }
-libsecp256k1 = { version = "0.3", optional = true }
 thiserror = "1.0"
 keccak-hash = { version = "0.7", optional = true }
+k256 = { version = "0.7", optional = true, features = ["zeroize", "ecdsa"] }
 p256 = { version = "0.7", optional = true, features = ["zeroize", "ecdsa"] }
-signature = { version = ">= 1.2.2, < 1.3.0" } # match ecdsa 0.10.2
 ssi-contexts = { version = "0.0.2", path = "contexts/" }
 ripemd160 = { version = "0.9", optional = true }
 
@@ -68,6 +72,14 @@ mown = "^0.2"
 once_cell = "^1.4"
 reqwest = { version = "^0.10", optional = true }
 langtag = "^0.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+chrono = { version = "0.4", features = ["serde", "wasmbind"] }
+# https://docs.rs/getrandom/0.2.2/getrandom/#indirect-dependencies
+getrandom = { version = "0.2", features = ["js"] }
 
 [workspace]
 members = [

--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -12,13 +12,11 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-ethr/"
 documentation = "https://docs.rs/did-ethr/"
 
 [dependencies]
-ssi = { version = "0.2", path = "../", default-features = false, features = ["secp256k1", "keccak-hash"] }
+ssi = { version = "0.2", path = "../", default-features = false, features = ["secp256k1", "keccak"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
-libsecp256k1 = { version = "0.3" }
-keccak-hash = "0.7"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -12,15 +12,16 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-key/"
 documentation = "https://docs.rs/did-key/"
 
 [features]
-secp256k1 = ["libsecp256k1", "ssi/secp256k1", "ssi/rand"]
-p256 = ["ssi/p256"]
+secp256k1 = ["k256", "ssi/secp256k1"]
+secp256r1 = ["ssi/secp256r1"]
+p256 = ["secp256r1"] # for backward compatibility
 
 [dependencies]
 ssi = { version = "0.2", path = "../", default-features = false }
 async-trait = "0.1"
 thiserror = "1.0"
 multibase = "0.8"
-libsecp256k1 = { version = "0.3", optional = true }
+k256 = { version = "0.7", optional = true, features = ["zeroize", "ecdsa"] }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-pkh/"
 documentation = "https://docs.rs/did-pkh/"
 
 [dependencies]
-ssi = { version = "0.2", path = "../", default-features = false, features = ["secp256k1", "keccak-hash", "p256", "ripemd160"] }
+ssi = { version = "0.2", path = "../", default-features = false, features = ["secp256k1", "keccak-hash", "secp256r1", "ripemd160"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -8,9 +8,9 @@ use ssi::did_resolve::{
     DIDResolver, DereferencingInputMetadata, DocumentMetadata, ResolutionInputMetadata,
     ResolutionMetadata, ERROR_INVALID_DID, TYPE_DID_LD_JSON,
 };
-#[cfg(feature = "p256")]
+#[cfg(feature = "secp256r1")]
 use ssi::jwk::p256_parse;
-#[cfg(feature = "libsecp256k1")]
+#[cfg(feature = "secp256k1")]
 use ssi::jwk::secp256k1_parse;
 use ssi::jwk::{Base64urlUInt, OctetParams, Params, JWK};
 use ssi::jws::{decode_unverified, decode_verify};
@@ -423,7 +423,7 @@ impl DIDTz {
                                     x509_thumbprint_sha256: None,
                                 }
                             }
-                            #[cfg(feature = "libsecp256k1")]
+                            #[cfg(feature = "secp256k1")]
                             "tz2" => {
                                 let pk = bs58::decode(public_key)
                                     .with_check(None)
@@ -439,7 +439,7 @@ impl DIDTz {
                                     ))
                                 })?
                             }
-                            #[cfg(feature = "p256")]
+                            #[cfg(feature = "secp256r1")]
                             "tz3" => {
                                 let pk = bs58::decode(public_key)
                                     .with_check(None)
@@ -517,7 +517,7 @@ mod tests {
         assert_eq!(tz1, TZ1);
     }
 
-    #[cfg(feature = "p256")]
+    #[cfg(feature = "secp256r1")]
     #[test]
     fn jwk_to_tz3() {
         let jwk: JWK = serde_json::from_value(serde_json::json!({
@@ -847,7 +847,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "libsecp256k1")]
+    #[cfg(feature = "secp256k1")]
     async fn credential_prove_verify_did_tz2() {
         use ssi::jwk::Algorithm;
         use ssi::vc::{Credential, Issuer, LinkedDataProofOptions, URI};
@@ -948,7 +948,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "p256")]
+    #[cfg(feature = "secp256r1")]
     async fn test_derivation_tz3() {
         let (res_meta, doc_opt, _meta_opt) = DIDTZ
             .resolve(
@@ -1040,7 +1040,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "libsecp256k1")]
+    #[cfg(feature = "secp256k1")]
     async fn test_json_patch_tz2() {
         let address = "tz2RZoj9oqoA8bDeUoAKLjf8nLPQKmYjaj6Q";
         let pk = "sppk7bRNbJ2n9PNQo295UJiYQ8iMma8ysRH9mCRFB14yhzLCwdGay9y";
@@ -1102,7 +1102,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "p256")]
+    #[cfg(feature = "secp256r1")]
     async fn test_json_patch_tz3() {
         let address = "tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX";
         let pk = "p2pk679D18uQNkdjpRxuBXL5CqcDKTKzsiXVtc9oCUT6xb82zQmgUks";
@@ -1237,7 +1237,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "p256")]
+    #[cfg(feature = "secp256r1")]
     async fn credential_prove_verify_did_tz3() {
         use ssi::jwk::Algorithm;
         use ssi::vc::{Credential, Issuer, LinkedDataProofOptions, URI};

--- a/src/blakesig.rs
+++ b/src/blakesig.rs
@@ -57,14 +57,13 @@ fn serialize_p256(params: &crate::jwk::ECParams) -> Result<Vec<u8>, Error> {
     Ok(pk_compressed_bytes.to_vec())
 }
 
-#[cfg(feature = "secp256k1")]
+#[cfg(feature = "k256")]
 fn serialize_secp256k1(params: &crate::jwk::ECParams) -> Result<Vec<u8>, Error> {
-    let x = &params.x_coordinate.as_ref().ok_or(Error::MissingPoint)?.0;
-    let y = &params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?.0;
-    let pk_bytes = [x.as_slice(), y.as_slice()].concat();
-    let pk = secp256k1::PublicKey::parse_slice(&pk_bytes, Some(secp256k1::PublicKeyFormat::Raw))?;
-    let pk_compressed_bytes = pk.serialize_compressed().to_vec();
-    Ok(pk_compressed_bytes.to_vec())
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    use std::convert::TryFrom;
+    let pk = k256::PublicKey::try_from(params)?;
+    let pk_compressed_bytes = pk.to_encoded_point(true);
+    Ok(pk_compressed_bytes.as_bytes().to_vec())
 }
 
 #[cfg(test)]

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -699,6 +699,12 @@ impl TypedData {
     /// Encode a typed data message for hashing and signing.
     /// [Reference](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#specification)
     pub fn hash(&self) -> Result<Vec<u8>, TypedDataHashError> {
+        let bytes = self.bytes()?;
+        let hash = keccak(bytes).to_fixed_bytes().to_vec();
+        Ok(hash)
+    }
+
+    pub fn bytes(&self) -> Result<Vec<u8>, TypedDataHashError> {
         let message_hash = hash_struct(&self.message, &self.primary_type, &self.types)?;
         let domain_separator =
             hash_struct(&self.domain, &StructName::from("EIP712Domain"), &self.types)?;
@@ -709,8 +715,7 @@ impl TypedData {
             message_hash.to_vec(),
         ]
         .concat();
-        let hash = keccak(bytes).to_fixed_bytes().to_vec();
-        Ok(hash)
+        Ok(bytes)
     }
 }
 

--- a/src/ripemd.rs
+++ b/src/ripemd.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 use crate::hash::sha256;
 use crate::jwk::{Params, JWK};
 
+use k256::elliptic_curve::sec1::ToEncodedPoint;
 use ripemd160::{Digest, Ripemd160};
 
 pub fn hash_public_key(jwk: &JWK, version: u8) -> Result<String, Error> {
@@ -11,12 +12,12 @@ pub fn hash_public_key(jwk: &JWK, version: u8) -> Result<String, Error> {
         Params::EC(ref params) => params,
         _ => return Err(Error::UnsupportedKeyType),
     };
-    let pk = secp256k1::PublicKey::try_from(ec_params)?;
-    let pk_bytes = pk.serialize_compressed();
+    let pk = k256::PublicKey::try_from(ec_params)?;
+    let pk_bytes = pk.to_encoded_point(true);
     if pk_bytes.len() != 33 {
         return Err(Error::UnsupportedKeyType);
     }
-    let pk_sha256 = sha256(&pk_bytes)?;
+    let pk_sha256 = sha256(&pk_bytes.as_bytes())?;
     let pk_ripemd160 = Ripemd160::digest(&pk_sha256);
     let mut extended_ripemd160 = Vec::with_capacity(21);
     extended_ripemd160.extend_from_slice(&[version]);
@@ -35,7 +36,7 @@ mod tests {
         // https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses#How_to_create_Bitcoin_Address
         let pk_hex = "0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352";
         let pk_bytes = hex::decode(pk_hex).unwrap();
-        let pk = secp256k1::PublicKey::parse_slice(&pk_bytes, None).unwrap();
+        let pk = k256::PublicKey::from_sec1_bytes(&pk_bytes).unwrap();
         let jwk = JWK {
             params: Params::EC(ECParams::try_from(&pk).unwrap()),
             public_key_use: None,


### PR DESCRIPTION
The Cargo features need a bit more work to ensure backward compatibility and sensible behaviours.

The motivations for this change are:
- to insure our future -- `libsecp256k1` has been abandoned a year ago, while `k256` provides an idiomatic Rust implementation and we already use other crates from RustCrypto; and
- `libsecp256k1` generated large binaries (~1.5MB) which was a blocker for some of our deployments -- `k256` seems to give a 10x improvement on that front.