### PR TITLE
Init git submodules when cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ packages.
 ```sh
 $ git clone https://github.com/spruceid/ssi
 $ cd ssi
-$ git submodule update
+$ git submodule update --init
 $ cargo build
 ```
 


### PR DESCRIPTION
Suggest using command `git submodule update --init` when initially cloning the repo. `ssi` requires git submodules to be initialized and updated after cloning.
The command used is equivalent to the two separate ones:
```
git submodule init
git submodule update
```