### PR TITLE
ssi-contexts v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ thiserror = "1.0"
 keccak-hash = { version = "0.7", optional = true }
 k256 = { version = "0.7", optional = true, features = ["zeroize", "ecdsa"] }
 p256 = { version = "0.7", optional = true, features = ["zeroize", "ecdsa"] }
-ssi-contexts = { version = "0.0.2", path = "contexts/" }
+ssi-contexts = { version = "0.1.0", path = "contexts/" }
 ripemd160 = { version = "0.9", optional = true }
 
 # dependencies for json-ld

--- a/contexts/Cargo.toml
+++ b/contexts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-contexts"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0 AND W3C-20150513 AND CC-BY-SA-3.0"


### PR DESCRIPTION
`ssi-contexts` needs a new release, since it had another context added which is now needed in `ssi`. This will then be used in `ssi`'s next release. I propose updating `ssi-contexts` to `0.1.0` (rather than `0.0.3`) so that in the future it can have patch updates without needing `ssi` to be updated to depend on them specifically.