### PR TITLE
did-method-key v0.1.1

### DIFF
--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-method-key"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Release to include changes from https://github.com/spruceid/ssi/pull/180.

Attempt to fix https://github.com/spruceid/didkit/issues/156.

Publish test command:
```
cargo publish --manifest-path did-key/Cargo.toml --dry-run --features ssi/sha,ssi/rand,secp256k1
```