### PR TITLE
Verify signature with JWK in proof for tzvm2021

### DIFF
--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -1300,8 +1300,10 @@ impl ProofSuite for TezosSignature2021 {
                 // VM does not have publicKeyJwk: either proof must have public key or algorithm must support
                 // public key recovery.
                 if let Some(proof_jwk) = proof_jwk_opt {
-                    // Proof has public key: verify it with blockchainAccountId.
+                    // Proof has public key: verify it with blockchainAccountId,
                     account_id.verify(&proof_jwk)?;
+                    // and verify the signature.
+                    crate::jws::verify_bytes(algorithm, &data, &proof_jwk, &sig)?;
                 } else {
                     // Proof has no public key: use public key recovery,
                     let recovered_jwk = crate::jws::recover(algorithm, &data, &sig)?;


### PR DESCRIPTION
The signature was not being verified in TezosSignature2021 in the case where public key is not present in the verification method object but is present in the proof object, and blockchainAccountId is not used.

This reveals that the signature in one of the tests was not being verified: "did:pkh:tz:tz2 - TezosMethod2021"
  https://github.com/spruceid/ssi/blob/13d53a9/did-pkh/src/lib.rs#L890-L899