### PR TITLE
Fix ES256 hashing

### DIFF
--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -739,25 +739,16 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_vc_issue_verify() {
-        let key_secp256k1_recovery: JWK = from_value(json!({
-            "alg": "ES256K-R",
-            "kty": "EC",
-            "crv": "secp256k1",
-            "x": "yclqMZ0MtyVkKm1eBh2AyaUtsqT0l5RJM3g4SzRT96A",
-            "y": "yQzUwKnftWCJPGs-faGaHiYi1sxA6fGJVw2Px_LCNe8",
-            "d": "meTmccmR_6ZsOa2YuTTkKkJ4ZPYsKdAH1Wx_RRf2j_E"
-        }))
-        .unwrap();
+        let key_secp256k1: JWK =
+            from_str(include_str!("../../tests/secp256k1-2021-02-17.json")).unwrap();
+        let key_secp256k1_recovery = JWK {
+            algorithm: Some(Algorithm::ES256KR),
+            ..key_secp256k1
+        };
         let key_ed25519: JWK =
             from_str(include_str!("../../tests/ed25519-2020-10-18.json")).unwrap();
-        let key_p256: JWK = from_value(json!({
-            "kty": "EC",
-            "crv": "P-256",
-            "x": "OnI8cxizlWZUBw5icIHEUn5EVMpcz4bNr__HnrmYGrE",
-            "y": "IB3NJQlX9rCu0yyAYSm0k-Vk1NlNkkEcRUZLwZHnuGc",
-            "d": "Bb1hTpaG2OIWkq-mXEAga5_kYE8hJ_J35a_CB8rVOSM"
-        }))
-        .unwrap();
+        let key_p256: JWK =
+            from_str(include_str!("../../tests/secp256r1-2021-03-18.json")).unwrap();
         let other_key_secp256k1 = JWK::generate_secp256k1().unwrap();
         let other_key_ed25519 = JWK::generate_ed25519().unwrap();
         let other_key_p256 = JWK::generate_p256().unwrap();

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -129,8 +129,7 @@ pub fn sign_bytes(algorithm: Algorithm, data: &[u8], key: &JWK) -> Result<Vec<u8
                 }
                 let secret_key = p256::SecretKey::try_from(ec)?;
                 let signing_key = p256::ecdsa::SigningKey::from(secret_key);
-                let hashed = crate::hash::sha256(data)?;
-                let sig = signing_key.try_sign(&hashed)?;
+                let sig = signing_key.try_sign(&data)?;
                 sig.as_bytes().to_vec()
             }
             #[cfg(feature = "k256")]
@@ -232,8 +231,7 @@ pub fn verify_bytes(
                 let public_key = p256::PublicKey::try_from(ec)?;
                 let verifying_key = p256::ecdsa::VerifyingKey::from(public_key);
                 let sig = Signature::from_bytes(signature)?;
-                let hashed = crate::hash::sha256(data)?;
-                verifying_key.verify(&hashed, &sig)?;
+                verifying_key.verify(&data, &sig)?;
             }
             #[cfg(feature = "k256")]
             Algorithm::ES256K | Algorithm::ES256KR => {

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -522,5 +522,12 @@ mod tests {
         let sig = sign_bytes(Algorithm::ES256, data, &key).unwrap();
         verify_bytes(Algorithm::ES256, data, &key, &sig).unwrap();
         verify_bytes(Algorithm::ES256, b"no", &key, &sig).unwrap_err();
+
+        let key: JWK =
+            serde_json::from_str(include_str!("../tests/secp256r1-2021-03-18.json")).unwrap();
+        let payload = "{\"iss\":\"did:example:foo\",\"vp\":{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"type\":\"VerifiablePresentation\"}}";
+        let jws = encode_sign(Algorithm::ES256, payload, &key).unwrap();
+        assert_eq!(jws, "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTpmb28iLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJ9fQ.rJzO6MmTNS8Tn-L3baIf9_2Jr9OoK8E06MxJtofz8xMUGSom6eRUmWGZ7oQVjgP3HogOD80miTvuvKTWa54Nvw");
+        decode_verify(&jws, &key).unwrap();
     }
 }

--- a/tests/secp256k1-2021-02-17.json
+++ b/tests/secp256k1-2021-02-17.json
@@ -1,0 +1,7 @@
+{
+  "kty": "EC",
+  "crv": "secp256k1",
+  "x": "yclqMZ0MtyVkKm1eBh2AyaUtsqT0l5RJM3g4SzRT96A",
+  "y": "yQzUwKnftWCJPGs-faGaHiYi1sxA6fGJVw2Px_LCNe8",
+  "d": "meTmccmR_6ZsOa2YuTTkKkJ4ZPYsKdAH1Wx_RRf2j_E"
+}

--- a/tests/secp256r1-2021-03-18.json
+++ b/tests/secp256r1-2021-03-18.json
@@ -1,0 +1,7 @@
+{
+  "kty": "EC",
+  "crv": "P-256",
+  "x": "OnI8cxizlWZUBw5icIHEUn5EVMpcz4bNr__HnrmYGrE",
+  "y": "IB3NJQlX9rCu0yyAYSm0k-Vk1NlNkkEcRUZLwZHnuGc",
+  "d": "Bb1hTpaG2OIWkq-mXEAga5_kYE8hJ_J35a_CB8rVOSM"
+}


### PR DESCRIPTION
Remove incorrect SHA-256 hashing for ES256. The [p256](https://crates.io/crates/p256) crates already handles the hashing. To prevent regression, add a test vector for ES256 JWS (signing and verification). Move the test private key files from inside the Rust code into standalone files so they can be more easily reused in tests such as these.

To confirm correctness, I verified this JWT using both [jwt.io](https://jwt.io/#debugger-io?token=eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTpmb28iLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJ9fQ.rJzO6MmTNS8Tn-L3baIf9_2Jr9OoK8E06MxJtofz8xMUGSom6eRUmWGZ7oQVjgP3HogOD80miTvuvKTWa54Nvw&publicKey=-----BEGIN%20PUBLIC%20KEY-----%0AMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOnI8cxizlWZUBw5icIHEUn5EVMpc%0Az4bNr%2F%2FHnrmYGrEgHc0lCVf2sK7TLIBhKbST5WTU2U2SQRxFRkvBkee4Zw%3D%3D%0A-----END%20PUBLIC%20KEY-----%0A) (using [jwk-to-pem](https://github.com/Brightspace/node-jwk-to-pem) to convert the public key JWK to PEM), and using the [jose](https://github.com/latchset/jose) command-line tool (Note: it is sensitive to trailing newlines). I also similarly verified the existing RS256 JWT test vector.

To verify the added JWT with `jose`:
```sh
echo -n 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTpmb28iLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJ9fQ.rJzO6MmTNS8Tn-L3baIf9_2Jr9OoK8E06MxJtofz8xMUGSom6eRUmWGZ7oQVjgP3HogOD80miTvuvKTWa54Nvw' > es256-jwt
jose jws ver -k tests/secp256r1-2021-03-18.json -i es256-jwt && echo ok
```

Related: #201