### PR TITLE
Check for negative zero without match

### DIFF
--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -1199,11 +1199,11 @@ pub fn object_to_rdf(
             }
         } else {
             // 11
-            let num_f64 = match num_f64 {
-                -0.0 => 0.0,
-                nonzero => nonzero,
+            let num = if num_f64 == -0.0 {
+                "0".to_string()
+            } else {
+                format!("{:.0}", num_f64)
             };
-            let num = format!("{:.0}", num_f64);
             value = JsonValue::String(num);
             if datatype == None {
                 datatype = Some("http://www.w3.org/2001/XMLSchema#integer");


### PR DESCRIPTION
Fix warning introduced by #207:
```
warning: floating-point types cannot be used in patterns
    --> src/jsonld.rs:1203:18
     |
1203 |                 -0.0 => 0.0,
     |                  ^^^
     |
     = note: `#[warn(illegal_floating_point_literal_pattern)]` on by default
     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>

```