### PR TITLE
Fix Eip712Signature2021 canonicalization, and enable in did:pkh

### DIFF
--- a/did-ethr/tests/vc.jsonld
+++ b/did-ethr/tests/vc.jsonld
@@ -1,20 +1,13 @@
 {
   "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    {
-      "sameAs": "https://www.w3.org/TR/owl-ref/#sameAs-def"
-    }
+    "https://www.w3.org/2018/credentials/v1"
   ],
-  "id": "urn:uuid:dc093ee6-e039-40e7-8599-da2075666e2c",
   "type": [
     "VerifiableCredential"
   ],
-  "credentialSubject": {
-    "id": "did:example:foo",
-    "sameAs": "did:ethr:0xf7398bacf610bb4e3b567811279fcb3c41919f89"
-  },
-  "issuer": "did:ethr:0xf7398bacf610bb4e3b567811279fcb3c41919f89",
-  "issuanceDate": "2021-02-27T04:03:23.188Z",
+  "credentialSubject": {},
+  "issuer": "did:ethr:0xdebee5349ba59faa2b9831f108a0f712d8ab26bb",
+  "issuanceDate": "2021-06-16T21:16:03.362Z",
   "proof": {
     "@context": [
       {
@@ -72,8 +65,8 @@
     ],
     "type": "Eip712Signature2021",
     "proofPurpose": "assertionMethod",
-    "proofValue": "0x258e647f27ac39de2fe43b629b6189a20bfa1454bf76eb486f1461565c6c119c58b0676b2003c75ad51e88bbbca0a5ca944a2f292dc5f76f5d2db2be705a50ca1b",
-    "verificationMethod": "did:ethr:0xf7398bacf610bb4e3b567811279fcb3c41919f89#Eip712Method2021",
-    "created": "2021-02-27T04:03:23.189Z"
+    "proofValue": "0xdb25f8a6cab65e3a83cd5933cc3a16a45b90f8a91ec447ca0f0bafcf9dbbabe25710a7d2082f34644faa484a156894d87998235adebeab8e44fa4ba74e122f581b",
+    "verificationMethod": "did:ethr:0xdebee5349ba59faa2b9831f108a0f712d8ab26bb#controller",
+    "created": "2021-06-16T21:16:03.362Z"
   }
 }

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -903,9 +903,7 @@ mod tests {
         other_key_p256.algorithm = Some(Algorithm::ES256);
     }
 
-    #[tokio::test]
-    async fn verify_vc() {
-        let vc_str = include_str!("../tests/vc-tz1.jsonld");
+    async fn test_verify_vc(vc_str: &str) {
         let mut vc = ssi::vc::Credential::from_json_unsigned(vc_str).unwrap();
         vc.validate().unwrap();
         let verification_result = vc.verify(None, &DIDPKH).await;
@@ -918,5 +916,11 @@ mod tests {
         let verification_result = vc.verify(None, &DIDPKH).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.len() > 0);
+    }
+
+    #[tokio::test]
+    async fn verify_vc() {
+        test_verify_vc(include_str!("../tests/vc-tz1.jsonld")).await;
+        test_verify_vc(include_str!("../tests/vc-eth-eip712vm.jsonld")).await;
     }
 }

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -743,7 +743,12 @@ mod tests {
             from_str(include_str!("../../tests/secp256k1-2021-02-17.json")).unwrap();
         let key_secp256k1_recovery = JWK {
             algorithm: Some(Algorithm::ES256KR),
-            ..key_secp256k1
+            ..key_secp256k1.clone()
+        };
+        let key_secp256k1_eip712vm = JWK {
+            algorithm: Some(Algorithm::ES256KR),
+            key_operations: Some(vec!["signTypedData".to_string()]),
+            ..key_secp256k1.clone()
         };
         let mut key_ed25519: JWK =
             from_str(include_str!("../../tests/ed25519-2020-10-18.json")).unwrap();
@@ -763,17 +768,15 @@ mod tests {
         )
         .await;
 
-        /*
         // eth/Eip712
         credential_prove_verify_did_pkh(
-            key_secp256k1_recovery.clone(),
+            key_secp256k1_eip712vm.clone(),
             other_key_secp256k1.clone(),
             "eth",
-            "#Eip712Method2021",
+            "#Recovery2020",
             &ssi::ldp::Eip712Signature2021,
         )
         .await;
-        */
 
         println!("did:pkh:tz:tz1");
         key_ed25519.algorithm = Some(Algorithm::EdBlake2b);

--- a/did-pkh/tests/vc-eth-eip712vm.jsonld
+++ b/did-pkh/tests/vc-eth-eip712vm.jsonld
@@ -1,0 +1,72 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "credentialSubject": {},
+  "issuer": "did:pkh:eth:0xdebee5349ba59faa2b9831f108a0f712d8ab26bb",
+  "issuanceDate": "2021-06-11T17:21:41.204Z",
+  "proof": {
+    "@context": [
+      {
+        "Eip712Method2021": "https://w3id.org/security#Eip712Method2021",
+        "Eip712Signature2021": {
+          "@context": {
+            "@protected": true,
+            "@version": 1.1,
+            "challenge": "https://w3id.org/security#challenge",
+            "created": {
+              "@id": "http://purl.org/dc/terms/created",
+              "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+            },
+            "domain": "https://w3id.org/security#domain",
+            "expires": {
+              "@id": "https://w3id.org/security#expiration",
+              "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+            },
+            "id": "@id",
+            "nonce": "https://w3id.org/security#nonce",
+            "proofPurpose": {
+              "@context": {
+                "@protected": true,
+                "@version": 1.1,
+                "assertionMethod": {
+                  "@container": "@set",
+                  "@id": "https://w3id.org/security#assertionMethod",
+                  "@type": "@id"
+                },
+                "authentication": {
+                  "@container": "@set",
+                  "@id": "https://w3id.org/security#authenticationMethod",
+                  "@type": "@id"
+                },
+                "id": "@id",
+                "type": "@type"
+              },
+              "@id": "https://w3id.org/security#proofPurpose",
+              "@type": "@vocab"
+            },
+            "proofValue": "https://w3id.org/security#proofValue",
+            "publicKeyJwk": {
+              "@id": "https://w3id.org/security#publicKeyJwk",
+              "@type": "@json"
+            },
+            "type": "@type",
+            "verificationMethod": {
+              "@id": "https://w3id.org/security#verificationMethod",
+              "@type": "@id"
+            }
+          },
+          "@id": "https://w3id.org/security#Eip712Signature2021"
+        }
+      }
+    ],
+    "type": "Eip712Signature2021",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "0x647596d87c842e27126924310cf517059a5972cf8f510c5699798754ffbcafb0046efc185f7bf8d9af24e729394ba7248776a3bc204ac82a529c41407a884dec1c",
+    "verificationMethod": "did:pkh:eth:0xdebee5349ba59faa2b9831f108a0f712d8ab26bb#Recovery2020",
+    "created": "2021-06-11T17:21:41.204Z"
+  }
+}

--- a/did-pkh/tests/vc-eth-eip712vm.jsonld
+++ b/did-pkh/tests/vc-eth-eip712vm.jsonld
@@ -7,7 +7,7 @@
   ],
   "credentialSubject": {},
   "issuer": "did:pkh:eth:0xdebee5349ba59faa2b9831f108a0f712d8ab26bb",
-  "issuanceDate": "2021-06-11T17:21:41.204Z",
+  "issuanceDate": "2021-06-16T20:55:45.850Z",
   "proof": {
     "@context": [
       {
@@ -65,8 +65,8 @@
     ],
     "type": "Eip712Signature2021",
     "proofPurpose": "assertionMethod",
-    "proofValue": "0x647596d87c842e27126924310cf517059a5972cf8f510c5699798754ffbcafb0046efc185f7bf8d9af24e729394ba7248776a3bc204ac82a529c41407a884dec1c",
+    "proofValue": "0x97f9776899dfc8aacbffd96ca6bfbb34a1e2281fc5bedc39e3ce02c6dd9255cf238466eabfc4c7b10933362f488dbc7bcd230168d1f551f56827e1189c9448081c",
     "verificationMethod": "did:pkh:eth:0xdebee5349ba59faa2b9831f108a0f712d8ab26bb#Recovery2020",
-    "created": "2021-06-11T17:21:41.204Z"
+    "created": "2021-06-16T20:55:45.850Z"
   }
 }

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -610,12 +610,16 @@ impl TypedData {
             .map_err(|e| TypedDataConstructionError::DocumentToDataset(e.to_string()))?;
         let doc_dataset_normalized = crate::urdna2015::normalize(&doc_dataset)
             .map_err(|e| TypedDataConstructionError::NormalizeDocument(e.to_string()))?;
+        let mut doc_statements_normalized = doc_dataset_normalized.statements();
+        doc_statements_normalized.sort_by_cached_key(|statement| String::from(statement));
         let sigopts_dataset = proof
             .to_dataset_for_signing(Some(document))
             .await
             .map_err(|e| TypedDataConstructionError::ProofToDataset(e.to_string()))?;
         let sigopts_dataset_normalized = crate::urdna2015::normalize(&sigopts_dataset)
             .map_err(|e| TypedDataConstructionError::NormalizeProof(e.to_string()))?;
+        let mut sigopts_statements_normalized = sigopts_dataset_normalized.statements();
+        sigopts_statements_normalized.sort_by_cached_key(|statement| String::from(statement));
 
         let types = Types {
             eip712_domain: StructType(vec![MemberVariable {
@@ -671,8 +675,7 @@ impl TypedData {
                     (
                         "document".to_string(),
                         EIP712Value::Array(
-                            doc_dataset_normalized
-                                .statements()
+                            doc_statements_normalized
                                 .into_iter()
                                 .map(encode_statement)
                                 .collect(),
@@ -681,8 +684,7 @@ impl TypedData {
                     (
                         "proof".to_string(),
                         EIP712Value::Array(
-                            sigopts_dataset_normalized
-                                .statements()
+                            sigopts_statements_normalized
                                 .into_iter()
                                 .map(encode_statement)
                                 .collect(),

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -155,6 +155,22 @@ impl ProofPreparation {
     }
 }
 
+fn use_eip712vm(options: &LinkedDataProofOptions, key: &JWK) -> bool {
+    if let Some(ref vm) = options.verification_method {
+        if vm.ends_with("#Eip712Method2021") {
+            return true;
+        }
+    }
+    // Use unregistered "signTypedData" key operation value to indicate using Eip712Signature2021, until
+    // LinkedDataProofOptions has type property
+    if let Some(ref key_ops) = key.key_operations {
+        if key_ops.contains(&"signTypedData".to_string()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 pub struct LinkedDataProofs;
 impl LinkedDataProofs {
     // https://w3c-ccg.github.io/ld-proofs/#proof-algorithm
@@ -227,13 +243,11 @@ impl LinkedDataProofs {
                 match &curve[..] {
                     "secp256k1" => {
                         if algorithm.as_ref() == Some(&Algorithm::ES256KR) {
-                            if let Some(ref vm) = options.verification_method {
-                                if vm.ends_with("#Eip712Method2021") {
-                                    #[cfg(feature = "keccak-hash")]
-                                    return Eip712Signature2021.sign(document, options, &key).await;
-                                    #[cfg(not(feature = "keccak-hash"))]
-                                    return Err(Error::ProofTypeNotImplemented);
-                                }
+                            if use_eip712vm(options, key) {
+                                #[cfg(feature = "keccak-hash")]
+                                return Eip712Signature2021.sign(document, options, &key).await;
+                                #[cfg(not(feature = "keccak-hash"))]
+                                return Err(Error::ProofTypeNotImplemented);
                             }
                             return EcdsaSecp256k1RecoverySignature2020
                                 .sign(document, options, &key)
@@ -355,15 +369,13 @@ impl LinkedDataProofs {
                 }
             }
             Algorithm::ES256KR => {
-                if let Some(ref vm) = options.verification_method {
-                    if vm.ends_with("#Eip712Method2021") {
-                        #[cfg(feature = "keccak-hash")]
-                        return Eip712Signature2021
-                            .prepare(document, options, public_key)
-                            .await;
-                        #[cfg(not(feature = "keccak-hash"))]
-                        return Err(Error::ProofTypeNotImplemented);
-                    }
+                if use_eip712vm(options, public_key) {
+                    #[cfg(feature = "keccak-hash")]
+                    return Eip712Signature2021
+                        .prepare(document, options, public_key)
+                        .await;
+                    #[cfg(not(feature = "keccak-hash"))]
+                    return Err(Error::ProofTypeNotImplemented);
                 }
                 return EcdsaSecp256k1RecoverySignature2020
                     .prepare(document, options, public_key)
@@ -1098,9 +1110,12 @@ impl ProofSuite for Eip712Signature2021 {
             .as_ref()
             .ok_or(Error::MissingVerificationMethod)?;
         let vm = resolve_vm(&verification_method, resolver).await?;
-        if vm.type_ != "Eip712Method2021" {
-            return Err(Error::VerificationMethodMismatch);
-        }
+        match &vm.type_[..] {
+            "Eip712Method2021" => (),
+            "EcdsaSecp256k1VerificationKey2019" => (),
+            "EcdsaSecp256k1RecoveryMethod2020" => (),
+            _ => Err(Error::VerificationMethodMismatch)?,
+        };
         let typed_data = TypedData::from_document_and_options(document, &proof).await?;
         let bytes = typed_data.bytes()?;
         if !sig_hex.starts_with("0x") {
@@ -1512,7 +1527,7 @@ mod tests {
     async fn eip712vm() {
         let mut key = JWK::generate_secp256k1().unwrap();
         key.algorithm = Some(Algorithm::ES256KR);
-        let vm = format!("{}#Eip712Method2021", "did:example:foo");
+        let vm = format!("{}#Recovery2020", "did:example:foo");
         let issue_options = LinkedDataProofOptions {
             verification_method: Some(vm),
             ..Default::default()


### PR DESCRIPTION
Allow using Eip712Signature2021 with verification method types
EcdsaSecp256k1RecoveryMethod2020 and EcdsaSecp256k1VerificationKey2019,
instead of adding Eip712Method2021 to DID document.

Use unregistered JWK key operation "signTypedData" to request Eip712Signature2021.

More info about JSON Web Key Operations:
- https://datatracker.ietf.org/doc/html/rfc7517#section-4.3
- https://www.iana.org/assignments/jose/jose.xhtml#web-key-operations

Add test vector for Eip712Signature2021 verifiable credential with `did:pkh:eth.

Fix canonicalization (sorting of RDF statements) bug that was causing intermittent verification failure; regenerate the `ethr` vector as needed.