### PR TITLE
Add Ethereum Personal Signature 2021

### DIFF
--- a/contexts/epsig-v0.1.jsonld
+++ b/contexts/epsig-v0.1.jsonld
@@ -1,0 +1,47 @@
+{
+  "EthereumPersonalSignature2021": {
+    "@id": "https://demo.spruceid.com/ld/epsig/EthereumPersonalSignature2021",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "id": "@id",
+      "type": "@type",
+      "challenge": "https://w3id.org/security#challenge",
+      "created": {
+        "@id": "http://purl.org/dc/terms/created",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "domain": "https://w3id.org/security#domain",
+      "expires": {
+        "@id": "https://w3id.org/security#expiration",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "nonce": "https://w3id.org/security#nonce",
+      "proofPurpose": {
+        "@id": "https://w3id.org/security#proofPurpose",
+        "@type": "@vocab",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "assertionMethod": {
+            "@id": "https://w3id.org/security#assertionMethod",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "authentication": {
+            "@id": "https://w3id.org/security#authenticationMethod",
+            "@type": "@id",
+            "@container": "@set"
+          }
+        }
+      },
+      "proofValue": "https://w3id.org/security#proofValue",
+      "verificationMethod": {
+        "@id": "https://w3id.org/security#verificationMethod",
+        "@type": "@id"
+      }
+    }
+  }
+}

--- a/contexts/src/lib.rs
+++ b/contexts/src/lib.rs
@@ -32,4 +32,5 @@ pub const EIP712SIG_V0_1: &str = include_str!("../eip712sig-v0.1.jsonld");
 pub const TZ_V2: &str = include_str!("../tz-2021-v2.jsonld");
 pub const TZVM_V1: &str = include_str!("../tzvm-2021-v1.jsonld");
 pub const EIP712VM: &str = include_str!("../eip712vm.jsonld");
+pub const EPSIG_V0_1: &str = include_str!("../epsig-v0.1.jsonld");
 pub const SOLVM: &str = include_str!("../solvm.jsonld");

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -761,6 +761,11 @@ mod tests {
             key_operations: Some(vec!["signTypedData".to_string()]),
             ..key_secp256k1.clone()
         };
+        let key_secp256k1_epsig = JWK {
+            algorithm: Some(Algorithm::ES256KR),
+            key_operations: Some(vec!["signPersonalMessage".to_string()]),
+            ..key_secp256k1.clone()
+        };
 
         let mut key_ed25519: JWK =
             from_str(include_str!("../../tests/ed25519-2020-10-18.json")).unwrap();
@@ -887,6 +892,18 @@ mod tests {
             &ssi::ldp::EthereumEip712Signature2021,
             Some(eip712_domain),
             Some(vp_eip712_domain),
+        )
+        .await;
+
+        // eth/Eip712
+        credential_prove_verify_did_pkh(
+            key_secp256k1_epsig.clone(),
+            other_key_secp256k1.clone(),
+            "eth",
+            "#Recovery2020",
+            &ssi::ldp::Eip712Signature2021,
+            None,
+            None,
         )
         .await;
 
@@ -1045,5 +1062,6 @@ mod tests {
         test_verify_vc(include_str!("../tests/vc-tz1.jsonld")).await;
         test_verify_vc(include_str!("../tests/vc-eth-eip712sig.jsonld")).await;
         test_verify_vc(include_str!("../tests/vc-eth-eip712vm.jsonld")).await;
+        test_verify_vc(include_str!("../tests/vc-eth-epsig.jsonld")).await;
     }
 }

--- a/did-pkh/tests/vc-eth-epsig.jsonld
+++ b/did-pkh/tests/vc-eth-epsig.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "credentialSubject": {},
+  "issuer": "did:pkh:eth:0xdebee5349ba59faa2b9831f108a0f712d8ab26bb",
+  "issuanceDate": "2021-06-15T19:10:36.479Z",
+  "proof": {
+    "@context": [
+      {
+        "EthereumPersonalSignature2021": {
+          "@context": {
+            "@protected": true,
+            "@version": 1.1,
+            "challenge": "https://w3id.org/security#challenge",
+            "created": {
+              "@id": "http://purl.org/dc/terms/created",
+              "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+            },
+            "domain": "https://w3id.org/security#domain",
+            "expires": {
+              "@id": "https://w3id.org/security#expiration",
+              "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+            },
+            "id": "@id",
+            "nonce": "https://w3id.org/security#nonce",
+            "proofPurpose": {
+              "@context": {
+                "@protected": true,
+                "@version": 1.1,
+                "assertionMethod": {
+                  "@container": "@set",
+                  "@id": "https://w3id.org/security#assertionMethod",
+                  "@type": "@id"
+                },
+                "authentication": {
+                  "@container": "@set",
+                  "@id": "https://w3id.org/security#authenticationMethod",
+                  "@type": "@id"
+                },
+                "id": "@id",
+                "type": "@type"
+              },
+              "@id": "https://w3id.org/security#proofPurpose",
+              "@type": "@vocab"
+            },
+            "proofValue": "https://w3id.org/security#proofValue",
+            "type": "@type",
+            "verificationMethod": {
+              "@id": "https://w3id.org/security#verificationMethod",
+              "@type": "@id"
+            }
+          },
+          "@id": "https://demo.spruceid.com/ld/epsig/EthereumPersonalSignature2021"
+        }
+      }
+    ],
+    "type": "EthereumPersonalSignature2021",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "0x26fa05442a9b3bd8fac6d49e3b127ea970df7d7b536bc526b0140ffa3c69073d6bd150a610bc0e023ca6252d3c538188464f1fbe3f756f4c25d336909da64a721c",
+    "verificationMethod": "did:pkh:eth:0xdebee5349ba59faa2b9831f108a0f712d8ab26bb#Recovery2020",
+    "created": "2021-06-15T19:10:36.481Z"
+  }
+}


### PR DESCRIPTION
A signature suite based on signing strings prefixed in Ethereum Personal Message (`personal_sign`) format.

Like [Ethereum EIP712 Signature 2021](https://uport-project.github.io/ethereum-eip712-signature-2021-spec/) and [Eip712Method2021](https://github.com/spruceid/ssi/pull/99), but for when you have `personal_sign` but not `eth_signTypedData`. Uses URDNA2015 and N-Quads (like [TezosSignature2021](TezosSignature2021)).

The string for signing is the canonicalized N-Quads of the proof options, followed by a newline, followed by canonicalized N-Quads of the linked data proof (e.g. verifiable credential). This string is prefixed and hashed according to "Ethereum Personal Message" signing.

Example signing request for EthereumPersonalSignature2021 showing signing string. 

![ethereum-personal-signature-signature-request-metamask](https://demo.spruceid.com/ld/epsig/epsig2021-metamask-signing-request.png)

- [x] Initial implementation
- [x] Fix public key recovery
- [x] Add test vector