### PR TITLE
Implement EthereumEip712Signature2021

### DIFF
--- a/contexts/eip712sig-v0.1.jsonld
+++ b/contexts/eip712sig-v0.1.jsonld
@@ -1,0 +1,64 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "Eip712SchemaValidator2021": "https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#eip712-schema-validator-2021",
+    "EthereumEip712Signature2021": {
+      "@id": "https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#ethereum-eip712-signature-2021",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "eip712Domain": {
+          "@id": "https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#eip712-domain",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "messageSchema": {
+              "@id": "https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#message-schema",
+              "@type": "@json"
+            },
+            "primaryType": "https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#primary-type",
+            "domain": {
+              "@id": "https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#domain",
+              "@type": "@json"
+            }
+          }
+        },
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/contexts/src/lib.rs
+++ b/contexts/src/lib.rs
@@ -27,6 +27,7 @@ pub const VACCINATION_V1: &str = include_str!("../w3c-ccg-vaccination-v1.jsonld"
 pub const TRACEABILITY_V1: &str = include_str!("../w3c-ccg-traceability-v1.jsonld");
 /// <https://demo.spruceid.com/EcdsaSecp256k1RecoverySignature2020/esrs2020-extra-0.0.jsonld>
 pub const ESRS2020_EXTRA: &str = include_str!("../esrs2020-extra-0.0.jsonld");
+pub const EIP712SIG_V0_1: &str = include_str!("../eip712sig-v0.1.jsonld");
 
 pub const TZ_V2: &str = include_str!("../tz-2021-v2.jsonld");
 pub const TZVM_V1: &str = include_str!("../tzvm-2021-v1.jsonld");

--- a/did-pkh/tests/vc-eth-eip712sig.jsonld
+++ b/did-pkh/tests/vc-eth-eip712sig.jsonld
@@ -1,0 +1,89 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "credentialSubject": {
+    "id": "did:example:foo"
+  },
+  "issuer": "did:pkh:eth:0x2fbf1be19d90a29aea9363f4ef0b6bf1c4ff0758",
+  "issuanceDate": "2021-03-18T16:38:25Z",
+  "proof": {
+    "@context": "https://demo.spruceid.com/ld/eip712sig-2021/v0.1.jsonld",
+    "type": "EthereumEip712Signature2021",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "0x9abee96d684a146aa0b30498d8799ee9a4f8f54488c73d4a4fba3a6fb94eca8764af54f15a24deba0dd9ee2f460d1f6bd174a4ca7504a72d6b1fe9b739d613fe1b",
+    "verificationMethod": "did:pkh:eth:0x2fbf1be19d90a29aea9363f4ef0b6bf1c4ff0758#Recovery2020",
+    "created": "2021-06-17T17:16:39.791Z",
+    "eip712Domain": {
+      "domain": {
+        "name": "EthereumEip712Signature2021"
+      },
+      "messageSchema": {
+        "CredentialSubject": [
+          {
+            "name": "id",
+            "type": "string"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ],
+        "Proof": [
+          {
+            "name": "@context",
+            "type": "string"
+          },
+          {
+            "name": "verificationMethod",
+            "type": "string"
+          },
+          {
+            "name": "created",
+            "type": "string"
+          },
+          {
+            "name": "proofPurpose",
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "type": "string"
+          }
+        ],
+        "VerifiableCredential": [
+          {
+            "name": "@context",
+            "type": "string[]"
+          },
+          {
+            "name": "type",
+            "type": "string[]"
+          },
+          {
+            "name": "issuer",
+            "type": "string"
+          },
+          {
+            "name": "issuanceDate",
+            "type": "string"
+          },
+          {
+            "name": "credentialSubject",
+            "type": "CredentialSubject"
+          },
+          {
+            "name": "proof",
+            "type": "Proof"
+          }
+        ]
+      },
+      "primaryType": "VerifiableCredential"
+    }
+  }
+}

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -85,6 +85,25 @@ pub struct TypedData {
     pub message: EIP712Value,
 }
 
+/// Object containing EIP-712 types, or a URI for such.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum TypesOrURI {
+    URI(String),
+    Object(Types),
+}
+
+/// Object at eip712Domain property of [Ethereum EIP712 Signature 2021](https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#ethereum-eip712-signature-2021) proof object
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ProofInfo {
+    #[serde(rename = "messageSchema")]
+    pub types_or_uri: TypesOrURI,
+    pub primary_type: StructName,
+    pub domain: EIP712Value,
+}
+
 #[derive(Error, Debug)]
 pub enum TypedDataConstructionError {
     #[error("Unable to convert document to data set: {0}")]
@@ -95,6 +114,30 @@ pub enum TypedDataConstructionError {
     NormalizeDocument(String),
     #[error("Unable to normalize proof: {0}")]
     NormalizeProof(String),
+}
+
+#[derive(Error, Debug)]
+pub enum TypedDataConstructionJSONError {
+    #[error("Not Implemented")]
+    NotImplemented,
+    #[error("Unable to convert document to JSON: {0}")]
+    DocumentToJSON(String),
+    #[error("Unable to convert proof object to JSON: {0}")]
+    ProofToJSON(String),
+    #[error("Expected document to be a JSON object")]
+    ExpectedDocumentObject,
+    #[error("Expected proof to be a JSON object")]
+    ExpectedProofObject,
+    #[error("Expected eip712Domain in proof object")]
+    ExpectedEip712Domain,
+    #[error("Expected types (messageSchema) in proof.eip712Domain")]
+    ExpectedTypes,
+    #[error("Unable to parse eip712Domain: {0}")]
+    ParseInfo(serde_json::Error),
+    #[error("Unable to convert document to EIP-712 message: {0}")]
+    ConvertMessage(TypedDataParseError),
+    #[error("Unable to dereference EIP-712 types: {0}")]
+    DereferenceTypes(DereferenceTypesError),
 }
 
 #[derive(Error, Debug)]
@@ -133,6 +176,14 @@ pub enum TypedDataHashError {
     ExpectedHex,
     #[error("Untyped properties: {0:?}")]
     UntypedProperties(Vec<String>),
+}
+
+#[derive(Error, Debug)]
+pub enum DereferenceTypesError {
+    #[error("Remote types loading not implemented")]
+    RemoteLoadingNotImplemented,
+    #[error("Unable to convert types from JSON: {0}")]
+    JSON(serde_json::Error),
 }
 
 impl EIP712Value {
@@ -301,6 +352,21 @@ impl Types {
         } else {
             self.types.get(struct_name)
         }
+    }
+}
+
+impl TypesOrURI {
+    async fn dereference(self) -> Result<Types, DereferenceTypesError> {
+        let uri = match self {
+            Self::URI(string) => string,
+            Self::Object(types) => return Ok(types),
+        };
+        let value = match &uri[..] {
+            _ => Err(DereferenceTypesError::RemoteLoadingNotImplemented)?,
+        };
+        let types: Types =
+            serde_json::from_value(value).map_err(|e| DereferenceTypesError::JSON(e))?;
+        Ok(types)
     }
 }
 
@@ -708,6 +774,49 @@ impl TypedData {
         Ok(typed_data)
     }
 
+    /// Convert linked data document and proof to TypedData according to
+    /// [EthereumEip712Signature2021](https://uport-project.github.io/ethereum-eip712-signature-2021-spec/)
+    pub async fn from_document_and_options_json(
+        document: &(dyn LinkedDataDocument + Sync),
+        proof: &Proof,
+    ) -> Result<Self, TypedDataConstructionJSONError> {
+        let mut doc_value = document
+            .to_value()
+            .map_err(|e| TypedDataConstructionJSONError::DocumentToJSON(e.to_string()))?;
+        let doc_obj = doc_value
+            .as_object_mut()
+            .ok_or(TypedDataConstructionJSONError::ExpectedDocumentObject)?;
+        let mut proof_value = serde_json::to_value(proof)
+            .map_err(|e| TypedDataConstructionJSONError::ProofToJSON(e.to_string()))?;
+        let proof_obj = proof_value
+            .as_object_mut()
+            .ok_or(TypedDataConstructionJSONError::ExpectedProofObject)?;
+        proof_obj.remove("proofValue");
+        let info = proof_obj
+            .remove("eip712Domain")
+            .ok_or(TypedDataConstructionJSONError::ExpectedEip712Domain)?;
+        let ProofInfo {
+            types_or_uri,
+            primary_type,
+            domain,
+        } = serde_json::from_value(info)
+            .map_err(|e| TypedDataConstructionJSONError::ParseInfo(e))?;
+        doc_obj.insert("proof".to_string(), proof_value);
+        let message = EIP712Value::try_from(doc_value)
+            .map_err(|e| TypedDataConstructionJSONError::ConvertMessage(e))?;
+        let types = types_or_uri
+            .dereference()
+            .await
+            .map_err(|e| TypedDataConstructionJSONError::DereferenceTypes(e))?;
+        let typed_data = Self {
+            types,
+            primary_type,
+            domain,
+            message,
+        };
+        Ok(typed_data)
+    }
+
     /// Encode a typed data message for hashing and signing.
     /// [Reference](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#specification)
     pub fn hash(&self) -> Result<Vec<u8>, TypedDataHashError> {
@@ -955,6 +1064,174 @@ mod tests {
         assert_eq!(
             bytes_to_lowerhex(&hash),
             "0x3128ae562d7141585a21f9c04e87520857ae9025d5c57293255f25d72f869b2e"
+        );
+    }
+
+    #[async_std::test]
+    async fn convert_typed_data() {
+        let proof: Proof = serde_json::from_value(json!({
+          "verificationMethod": "did:example:aaaabbbb#issuerKey-1",
+          "created": "2010-01-01T19:23:24Z",
+          "proofPurpose": "assertionMethod",
+          "type": "EthereumEip712Signature2021",
+          "eip712Domain": {
+            "messageSchema": {
+              "EIP712Domain": [
+                { "name": "name", "type": "string" },
+                { "name": "version", "type": "string" },
+                { "name": "chainId", "type": "uint256" },
+                { "name": "salt", "type": "bytes32" }
+              ],
+              "VerifiableCredential": [
+                { "name": "@context", "type": "string[]" },
+                { "name": "type", "type": "string[]" },
+                { "name": "id", "type": "string" },
+                { "name": "issuer", "type": "string" },
+                { "name": "issuanceDate", "type": "string" },
+                { "name": "credentialSubject", "type": "CredentialSubject" },
+                { "name": "credentialSchema", "type": "CredentialSchema" },
+                { "name": "proof", "type": "Proof" }
+              ],
+              "CredentialSchema": [
+                { "name": "id", "type": "string" },
+                { "name": "type", "type": "string" }
+              ],
+              "CredentialSubject": [
+                { "name": "type", "type": "string" },
+                { "name": "id", "type": "string" },
+                { "name": "name", "type": "string" },
+                { "name": "child", "type": "Person" }
+              ],
+              "Person": [
+                { "name": "name", "type": "string" }
+              ],
+              "Proof": [
+                { "name": "verificationMethod", "type": "string" },
+                { "name": "created", "type": "string" },
+                { "name": "proofPurpose", "type": "string" },
+                { "name": "type", "type": "string" }
+              ]
+            },
+            "primaryType": "VerifiableCredential",
+            "domain": {
+              "name": "https://example.com",
+              "version": "2",
+              "chainId": 4,
+              "salt": "0xaaaabbbbccccdddd"
+            }
+          }
+        }))
+        .unwrap();
+        let vc: crate::vc::Credential = serde_json::from_value(json!({
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.org"
+          ],
+          "type": [
+            "VerifiableCredential"
+          ],
+          "id": "https://example.org/person/1234",
+          "issuer": "did:example:aaaabbbb",
+          "issuanceDate": "2010-01-01T19:23:24Z",
+          "credentialSubject": {
+            "type": "Person",
+            "id": "did:example:bbbbaaaa",
+            "name": "Vitalik",
+            "child": {
+              "type": "Person",
+              "name": "Ethereum"
+            }
+          },
+          "credentialSchema": {
+            "id": "https://example.com/schemas/v1",
+            "type": "Eip712SchemaValidator2021"
+          }
+        }))
+        .unwrap();
+        let typed_data = TypedData::from_document_and_options_json(&vc, &proof)
+            .await
+            .unwrap();
+        // https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#example-4
+        let expected_typed_data = json!({
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "salt", "type": "bytes32" }
+            ],
+            "VerifiableCredential": [
+              { "name": "@context", "type": "string[]" },
+              { "name": "type", "type": "string[]" },
+              { "name": "id", "type": "string" },
+              { "name": "issuer", "type": "string" },
+              { "name": "issuanceDate", "type": "string" },
+              { "name": "credentialSubject", "type": "CredentialSubject" },
+              { "name": "credentialSchema", "type": "CredentialSchema" },
+              { "name": "proof", "type": "Proof" }
+            ],
+            "CredentialSchema": [
+              { "name": "id", "type": "string" },
+              { "name": "type", "type": "string" }
+            ],
+            "CredentialSubject": [
+              { "name": "type", "type": "string" },
+              { "name": "id", "type": "string" },
+              { "name": "name", "type": "string" },
+              { "name": "child", "type": "Person" }
+            ],
+            "Person": [
+              { "name": "name", "type": "string" }
+            ],
+            "Proof": [
+              { "name": "verificationMethod", "type": "string" },
+              { "name": "created", "type": "string" },
+              { "name": "proofPurpose", "type": "string" },
+              { "name": "type", "type": "string" }
+            ]
+          },
+          "domain": {
+            "name": "https://example.com",
+            "version": "2",
+            "chainId": 4,
+            "salt": "0xaaaabbbbccccdddd"
+          },
+          "primaryType": "VerifiableCredential",
+          "message": {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://schema.org"
+            ],
+            "type": [
+              "VerifiableCredential"
+            ],
+            "id": "https://example.org/person/1234",
+            "issuer": "did:example:aaaabbbb",
+            "issuanceDate": "2010-01-01T19:23:24Z",
+            "credentialSubject": {
+              "type": "Person",
+              "id": "did:example:bbbbaaaa",
+              "name": "Vitalik",
+              "child": {
+                "type": "Person",
+                "name": "Ethereum"
+              }
+            },
+            "credentialSchema": {
+              "id": "https://example.com/schemas/v1",
+              "type": "Eip712SchemaValidator2021"
+            },
+            "proof": {
+              "verificationMethod": "did:example:aaaabbbb#issuerKey-1",
+              "created": "2010-01-01T19:23:24Z",
+              "proofPurpose": "assertionMethod",
+              "type": "EthereumEip712Signature2021"
+            }
+          }
+        });
+        assert_eq!(
+            serde_json::to_value(typed_data).unwrap(),
+            expected_typed_data
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@ use crate::caip10::BlockchainAccountIdVerifyError;
 #[cfg(feature = "keccak-hash")]
 use crate::eip712::TypedDataConstructionError;
 #[cfg(feature = "keccak-hash")]
+use crate::eip712::TypedDataConstructionJSONError;
+#[cfg(feature = "keccak-hash")]
 use crate::eip712::TypedDataHashError;
 use crate::json_ld;
 use crate::tzkey::{DecodeTezosSignatureError, EncodeTezosSignedMessageError};
@@ -170,6 +172,8 @@ pub enum Error {
     #[cfg(feature = "keccak-hash")]
     TypedDataConstruction(TypedDataConstructionError),
     #[cfg(feature = "keccak-hash")]
+    TypedDataConstructionJSON(TypedDataConstructionJSONError),
+    #[cfg(feature = "keccak-hash")]
     TypedDataHash(TypedDataHashError),
     FromHex(hex::FromHexError),
     Base58(bs58::decode::Error),
@@ -328,6 +332,8 @@ impl fmt::Display for Error {
             #[cfg(feature = "keccak-hash")]
             Error::TypedDataConstruction(e) => e.fmt(f),
             #[cfg(feature = "keccak-hash")]
+            Error::TypedDataConstructionJSON(e) => e.fmt(f),
+            #[cfg(feature = "keccak-hash")]
             Error::TypedDataHash(e) => e.fmt(f),
             Error::FromHex(e) => e.fmt(f),
             Error::Base58(e) => e.fmt(f),
@@ -458,6 +464,13 @@ impl From<BlockchainAccountIdVerifyError> for Error {
 impl From<TypedDataConstructionError> for Error {
     fn from(err: TypedDataConstructionError) -> Error {
         Error::TypedDataConstruction(err)
+    }
+}
+
+#[cfg(feature = "keccak-hash")]
+impl From<TypedDataConstructionJSONError> for Error {
+    fn from(err: TypedDataConstructionJSONError) -> Error {
+        Error::TypedDataConstructionJSON(err)
     }
 }
 

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -129,6 +129,7 @@ pub const LDS_JWS2020_V1_CONTEXT: &str =
 pub const CITIZENSHIP_V1_CONTEXT: &str = "https://w3id.org/citizenship/v1";
 pub const VACCINATION_V1_CONTEXT: &str = "https://w3id.org/vaccination/v1";
 pub const TRACEABILITY_CONTEXT: &str = "https://w3id.org/traceability/v1";
+pub const EIP712SIG_V0_1_CONTEXT: &str = "https://demo.spruceid.com/ld/eip712sig-2021/v0.1.jsonld";
 
 lazy_static! {
     pub static ref CREDENTIALS_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
@@ -215,6 +216,12 @@ lazy_static! {
         let iri = Iri::new(TRACEABILITY_CONTEXT).unwrap();
         RemoteDocument::new(doc, iri)
     };
+    pub static ref EIP712SIG_V0_1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
+        let jsonld = ssi_contexts::EIP712SIG_V0_1;
+        let doc = json::parse(jsonld).unwrap();
+        let iri = Iri::new(EIP712SIG_V0_1_CONTEXT).unwrap();
+        RemoteDocument::new(doc, iri)
+    };
 }
 
 pub struct StaticLoader;
@@ -243,6 +250,7 @@ impl Loader for StaticLoader {
                 CITIZENSHIP_V1_CONTEXT => Ok(CITIZENSHIP_V1_CONTEXT_DOCUMENT.clone()),
                 VACCINATION_V1_CONTEXT => Ok(VACCINATION_V1_CONTEXT_DOCUMENT.clone()),
                 TRACEABILITY_CONTEXT => Ok(TRACEABILITY_CONTEXT_DOCUMENT.clone()),
+                EIP712SIG_V0_1_CONTEXT => Ok(EIP712SIG_V0_1_CONTEXT_DOCUMENT.clone()),
                 _ => {
                     eprintln!("unknown context {}", url);
                     Err(json_ld::ErrorCode::LoadingDocumentFailed.into())

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -60,6 +60,7 @@ pub fn now_ms() -> DateTime<Utc> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait LinkedDataDocument {
     fn get_contexts(&self) -> Result<Option<String>, Error>;
+    fn to_value(&self) -> Result<Value, Error>;
     async fn to_dataset_for_signing(
         &self,
         parent: Option<&(dyn LinkedDataDocument + Sync)>,
@@ -150,6 +151,10 @@ impl ProofPreparation {
             }
             #[cfg(feature = "keccak-hash")]
             "Eip712Signature2021" => Eip712Signature2021.complete(self, signature).await,
+            #[cfg(feature = "keccak-hash")]
+            "EthereumEip712Signature2021" => {
+                EthereumEip712Signature2021.complete(self, signature).await
+            }
             "TezosSignature2021" => TezosSignature2021.complete(self, signature).await,
             "SolanaSignature2021" => SolanaSignature2021.complete(self, signature).await,
             "JsonWebSignature2020" => JsonWebSignature2020.complete(self, signature).await,
@@ -158,16 +163,19 @@ impl ProofPreparation {
     }
 }
 
-fn use_eip712vm(options: &LinkedDataProofOptions, key: &JWK) -> bool {
-    if let Some(ref vm) = options.verification_method {
-        if vm.ends_with("#Eip712Method2021") {
+fn use_eip712sig(key: &JWK) -> bool {
+    // Use unregistered "signTypedData" key operation value to indicate using EthereumEip712Signature2021, until
+    if let Some(ref key_ops) = key.key_operations {
+        if key_ops.contains(&"signTypedData".to_string()) {
             return true;
         }
     }
-    // Use unregistered "signTypedData" key operation value to indicate using Eip712Signature2021, until
-    // LinkedDataProofOptions has type property
-    if let Some(ref key_ops) = key.key_operations {
-        if key_ops.contains(&"signTypedData".to_string()) {
+    return false;
+}
+
+fn use_eip712vm(options: &LinkedDataProofOptions) -> bool {
+    if let Some(ref vm) = options.verification_method {
+        if vm.ends_with("#Eip712Method2021") {
             return true;
         }
     }
@@ -246,7 +254,15 @@ impl LinkedDataProofs {
                 match &curve[..] {
                     "secp256k1" => {
                         if algorithm.as_ref() == Some(&Algorithm::ES256KR) {
-                            if use_eip712vm(options, key) {
+                            if use_eip712sig(key) {
+                                #[cfg(feature = "keccak-hash")]
+                                return EthereumEip712Signature2021
+                                    .sign(document, options, &key)
+                                    .await;
+                                #[cfg(not(feature = "keccak-hash"))]
+                                return Err(Error::ProofTypeNotImplemented);
+                            }
+                            if use_eip712vm(options) {
                                 #[cfg(feature = "keccak-hash")]
                                 return Eip712Signature2021.sign(document, options, &key).await;
                                 #[cfg(not(feature = "keccak-hash"))]
@@ -372,7 +388,15 @@ impl LinkedDataProofs {
                 }
             }
             Algorithm::ES256KR => {
-                if use_eip712vm(options, public_key) {
+                if use_eip712sig(public_key) {
+                    #[cfg(feature = "keccak-hash")]
+                    return EthereumEip712Signature2021
+                        .prepare(document, options, public_key)
+                        .await;
+                    #[cfg(not(feature = "keccak-hash"))]
+                    return Err(Error::ProofTypeNotImplemented);
+                }
+                if use_eip712vm(options) {
                     #[cfg(feature = "keccak-hash")]
                     return Eip712Signature2021
                         .prepare(document, options, public_key)
@@ -420,6 +444,12 @@ impl LinkedDataProofs {
             }
             #[cfg(feature = "keccak-hash")]
             "Eip712Signature2021" => Eip712Signature2021.verify(proof, document, resolver).await,
+            #[cfg(feature = "keccak-hash")]
+            "EthereumEip712Signature2021" => {
+                EthereumEip712Signature2021
+                    .verify(proof, document, resolver)
+                    .await
+            }
             "TezosSignature2021" => TezosSignature2021.verify(proof, document, resolver).await,
             "SolanaSignature2021" => SolanaSignature2021.verify(proof, document, resolver).await,
             "JsonWebSignature2020" => JsonWebSignature2020.verify(proof, document, resolver).await,
@@ -1151,6 +1181,142 @@ impl ProofSuite for Eip712Signature2021 {
     }
 }
 
+#[cfg(feature = "keccak-hash")]
+pub struct EthereumEip712Signature2021;
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg(feature = "keccak-hash")]
+impl ProofSuite for EthereumEip712Signature2021 {
+    async fn sign(
+        &self,
+        document: &(dyn LinkedDataDocument + Sync),
+        options: &LinkedDataProofOptions,
+        key: &JWK,
+    ) -> Result<Proof, Error> {
+        use k256::ecdsa::signature::Signer;
+        // TODO: conform to spec: no domain
+        let mut property_set = std::collections::HashMap::new();
+        if let Some(ref eip712_domain) = options.eip712_domain {
+            let info = serde_json::to_value(eip712_domain.clone())?;
+            property_set.insert("eip712Domain".to_string(), info);
+        }
+        let mut proof = Proof {
+            context: serde_json::json!(crate::jsonld::EIP712SIG_V0_1_CONTEXT),
+            proof_purpose: options.proof_purpose.clone(),
+            verification_method: options.verification_method.clone(),
+            created: Some(options.created.unwrap_or_else(now_ms)),
+            domain: options.domain.clone(),
+            challenge: options.challenge.clone(),
+            property_set: Some(property_set),
+            ..Proof::new("EthereumEip712Signature2021")
+        };
+        let typed_data = TypedData::from_document_and_options_json(document, &proof).await?;
+        let bytes = typed_data.bytes()?;
+        let ec_params = match &key.params {
+            JWKParams::EC(ec) => ec,
+            _ => return Err(Error::KeyTypeNotImplemented),
+        };
+        let secret_key = k256::SecretKey::try_from(ec_params)?;
+        let signing_key = k256::ecdsa::SigningKey::from(secret_key);
+        let sig: k256::ecdsa::recoverable::Signature = signing_key.try_sign(&bytes)?;
+        let sig_bytes = &mut sig.as_ref().to_vec();
+        // Recovery ID starts at 27 instead of 0.
+        sig_bytes[64] = sig_bytes[64] + 27;
+        let sig_hex = crate::keccak_hash::bytes_to_lowerhex(sig_bytes);
+        proof.proof_value = Some(sig_hex);
+        Ok(proof)
+    }
+
+    async fn prepare(
+        &self,
+        document: &(dyn LinkedDataDocument + Sync),
+        options: &LinkedDataProofOptions,
+        _public_key: &JWK,
+    ) -> Result<ProofPreparation, Error> {
+        let mut property_set = std::collections::HashMap::new();
+        if let Some(ref eip712_domain) = options.eip712_domain {
+            let info = serde_json::to_value(eip712_domain.clone())?;
+            property_set.insert("eip712Domain".to_string(), info);
+        }
+        let proof = Proof {
+            context: serde_json::json!(crate::jsonld::EIP712SIG_V0_1_CONTEXT),
+            proof_purpose: options.proof_purpose.clone(),
+            verification_method: options.verification_method.clone(),
+            created: Some(options.created.unwrap_or_else(now_ms)),
+            domain: options.domain.clone(),
+            challenge: options.challenge.clone(),
+            property_set: Some(property_set),
+            ..Proof::new("EthereumEip712Signature2021")
+        };
+        let typed_data = TypedData::from_document_and_options_json(document, &proof).await?;
+        Ok(ProofPreparation {
+            proof,
+            jws_header: None,
+            signing_input: SigningInput::TypedData(typed_data),
+        })
+    }
+
+    async fn complete(
+        &self,
+        preparation: ProofPreparation,
+        signature: &str,
+    ) -> Result<Proof, Error> {
+        let mut proof = preparation.proof;
+        proof.proof_value = Some(signature.to_string());
+        Ok(proof)
+    }
+
+    async fn verify(
+        &self,
+        proof: &Proof,
+        document: &(dyn LinkedDataDocument + Sync),
+        resolver: &dyn DIDResolver,
+    ) -> Result<(), Error> {
+        let sig_hex = proof
+            .proof_value
+            .as_ref()
+            .ok_or(Error::MissingProofSignature)?;
+        let verification_method = proof
+            .verification_method
+            .as_ref()
+            .ok_or(Error::MissingVerificationMethod)?;
+        let vm = resolve_vm(&verification_method, resolver).await?;
+        match &vm.type_[..] {
+            "EcdsaSecp256k1VerificationKey2019" => (),
+            "EcdsaSecp256k1RecoveryMethod2020" => (),
+            _ => Err(Error::VerificationMethodMismatch)?,
+        };
+        if !sig_hex.starts_with("0x") {
+            return Err(Error::HexString);
+        }
+        let dec_sig = hex::decode(&sig_hex[2..])?;
+        let rec_id = k256::ecdsa::recoverable::Id::try_from(dec_sig[64] - 27)?;
+        let sig = k256::ecdsa::Signature::try_from(&dec_sig[..64])?;
+        let sig = k256::ecdsa::recoverable::Signature::new(&sig, rec_id)?;
+        let typed_data = TypedData::from_document_and_options_json(document, &proof).await?;
+        let bytes = typed_data.bytes()?;
+        let recovered_key = sig.recover_verify_key(&bytes)?;
+        use crate::jwk::ECParams;
+        let jwk = JWK {
+            params: JWKParams::EC(ECParams::try_from(&k256::PublicKey::from_sec1_bytes(
+                &recovered_key.to_bytes(),
+            )?)?),
+            public_key_use: None,
+            key_operations: None,
+            algorithm: None,
+            key_id: None,
+            x509_url: None,
+            x509_certificate_chain: None,
+            x509_thumbprint_sha1: None,
+            x509_thumbprint_sha256: None,
+        };
+        let account_id_str = vm.blockchain_account_id.ok_or(Error::MissingAccountId)?;
+        let account_id = BlockchainAccountId::from_str(&account_id_str)?;
+        account_id.verify(&jwk)?;
+        Ok(())
+    }
+}
+
 async fn micheline_from_document_and_options(
     document: &(dyn LinkedDataDocument + Sync),
     proof: &Proof,
@@ -1522,6 +1688,10 @@ mod tests {
             };
             dataset.add_statement(statement);
             Ok(dataset)
+        }
+
+        fn to_value(&self) -> Result<Value, Error> {
+            Err(Error::NotImplemented)
         }
     }
 

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -304,6 +304,12 @@ pub struct LinkedDataProofOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Checks to perform
     pub checks: Option<Vec<Check>>,
+    /// Metadata for EthereumEip712Signature2021 (not standard in vc-http-api)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "keccak-hash")]
+    pub eip712_domain: Option<crate::eip712::ProofInfo>,
+    #[cfg(not(feature = "keccak-hash"))]
+    pub eip712_domain: Option<()>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -342,6 +348,7 @@ impl Default for LinkedDataProofOptions {
             challenge: None,
             domain: None,
             checks: Some(vec![Check::Proof]),
+            eip712_domain: None,
         }
     }
 }
@@ -730,6 +737,10 @@ impl LinkedDataDocument for Credential {
         let mut loader = StaticLoader;
         json_to_dataset(&json, more_contexts.as_ref(), false, None, &mut loader).await
     }
+
+    fn to_value(&self) -> Result<Value, Error> {
+        Ok(serde_json::to_value(&self)?)
+    }
 }
 
 impl Presentation {
@@ -964,6 +975,10 @@ impl LinkedDataDocument for Presentation {
         let mut loader = StaticLoader;
         json_to_dataset(&json, more_contexts.as_ref(), false, None, &mut loader).await
     }
+
+    fn to_value(&self) -> Result<Value, Error> {
+        Ok(serde_json::to_value(&self)?)
+    }
 }
 
 macro_rules! assert_local {
@@ -1038,6 +1053,10 @@ impl LinkedDataDocument for Proof {
         };
         let mut loader = StaticLoader;
         json_to_dataset(&json, more_contexts.as_ref(), false, None, &mut loader).await
+    }
+
+    fn to_value(&self) -> Result<Value, Error> {
+        Ok(serde_json::to_value(&self)?)
     }
 }
 
@@ -1400,6 +1419,10 @@ _:c14n0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#asse
                 _parent: Option<&(dyn LinkedDataDocument + Sync)>,
             ) -> Result<DataSet, Error> {
                 Err(Error::NotImplemented)
+            }
+
+            fn to_value(&self) -> Result<Value, Error> {
+                Ok(self.0.clone())
             }
         }
         let parent = ProofContexts(json!(["https://w3id.org/security/v1", DEFAULT_CONTEXT]));


### PR DESCRIPTION
Implement [Ethereum EIP712 Signature 2021](https://uport-project.github.io/ethereum-eip712-signature-2021-spec/).

The Ethereum EIP712 Signature Suite specification is a work item proposal in W3C CCG: https://github.com/w3c-ccg/community/issues/194

This signature suite is like `ssi`'s [Eip712Method2021](https://github.com/spruceid/ssi/pull/99) and [EthereumPersonalSignature2021](https://github.com/spruceid/ssi/pull/212), but uses [EIP-712 structured data](https://eips.ethereum.org/EIPS/eip-712#definition-of-typed-structured-data-%F0%9D%95%8A) as a data model rather than RDF.

A proof option is added, "eip712Domain", for the corresponding proof property from the [specification](https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#ethereum-eip712-signature-2021). This is not ideal because it's a breaking change and not standard in `vc-http-api`, but I don't know how else to pass this information currently. The `eip712Domain` object contains the EIP712 type definitions (`messageSchema`) as a dereferencable URI or object, `domain` object, and `primaryType` string. These three values are meta-data which are combined with the document and proof to create the signing input. After signing, the `eip712Domain` object is placed into the proof object along with the signature (`proofValue`).

Remote loading of type definitions is not implemented currently but some may be bundled in `ssi`. Using the object form of `messageSchema` may therefore be preferred. However, if a document using EthereumEip712Signature2021 with such form is embedded in another one, e.g. a verifiable presentation, the complexity of the types is increased, since a type definition is needed for the type definitions in the embedded message.

A JSON-LD context file is added. Even though this signature suite does not use JSON-LD and the term definitions in the context do not affect signing input, the context file is intended to assist embedding verifiable credentials using this format in verifiable presentations using linked-data-based signature suites. This context file is not from the specification, however.

This signature suite maps currently does not allow arrays of values of different types, so putting objects alongside URIs in `@context` will not work.

I was not able to verify the signature from the specification's test vector [example 5 (non-normative)](https://uport-project.github.io/ethereum-eip712-signature-2021-spec/#example-5); more information may be needed to verify it.

- [x] Add initial scaffolding for signature suite.
- [x] Draft JSON-LD context.
- [x] Implement JSON conversion for `LinkedDataDocument`.
- [x] Support ~~remote and/or~~ bundled loading of type definitions.
- [x] Construct `TypedData` from LinkedDataDocument, proof, and type definitions.
- ~~[ ] Verify test vector from specification.~~
- [x] Add test vector for verifiable credential.
- [x] Disallow properties not in types

### Screenshot

![Signing request in MetaMask](https://demo.spruceid.com/ld/eip712sig-2021/screenshots/signing0.png)