### PR TITLE
Update DID documents JSON-LD context

### DIFF
--- a/contexts/w3c-did-v1.jsonld
+++ b/contexts/w3c-did-v1.jsonld
@@ -1,86 +1,57 @@
 {
   "@context": {
-    "@version": 1.1,
+    "@protected": true,
     "id": "@id",
     "type": "@type",
-    "dc": "http://purl.org/dc/terms/",
-    "schema": "http://schema.org/",
-    "sec": "https://w3id.org/security#",
-    "didv": "https://w3id.org/did#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
-    "Ed25519Signature2018": "sec:Ed25519Signature2018",
-    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
-    "JsonWebKey2020": "sec:JsonWebKey2020",
-    "JsonWebSignature2020": "sec:JsonWebSignature2020",
-    "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
-    "SchnorrSecp256k1VerificationKey2019": "sec:SchnorrSecp256k1VerificationKey2019",
-    "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
-    "ServiceEndpointProxyService": "didv:ServiceEndpointProxyService",
+
     "alsoKnownAs": {
       "@id": "https://www.w3.org/ns/activitystreams#alsoKnownAs",
-      "@type": "@id",
-      "@container": "@set"
+      "@type": "@id"
     },
     "assertionMethod": {
-      "@id": "sec:assertionMethod",
+      "@id": "https://w3id.org/security#assertionMethod",
       "@type": "@id",
       "@container": "@set"
     },
     "authentication": {
-      "@id": "sec:authenticationMethod",
+      "@id": "https://w3id.org/security#authenticationMethod",
       "@type": "@id",
       "@container": "@set"
     },
     "capabilityDelegation": {
-      "@id": "sec:capabilityDelegationMethod",
+      "@id": "https://w3id.org/security#capabilityDelegationMethod",
       "@type": "@id",
       "@container": "@set"
     },
     "capabilityInvocation": {
-      "@id": "sec:capabilityInvocationMethod",
+      "@id": "https://w3id.org/security#capabilityInvocationMethod",
       "@type": "@id",
       "@container": "@set"
     },
     "controller": {
-      "@id": "sec:controller",
+      "@id": "https://w3id.org/security#controller",
       "@type": "@id"
     },
-    "created": {
-      "@id": "dc:created",
-      "@type": "xsd:dateTime"
-    },
-    "blockchainAccountId": "sec:blockchainAccountId",
     "keyAgreement": {
-      "@id": "sec:keyAgreementMethod",
+      "@id": "https://w3id.org/security#keyAgreementMethod",
       "@type": "@id",
       "@container": "@set"
-    },
-    "publicKey": {
-      "@id": "sec:publicKey",
-      "@type": "@id",
-      "@container": "@set"
-    },
-    "publicKeyBase58": "sec:publicKeyBase58",
-    "publicKeyJwk": {
-      "@id": "sec:publicKeyJwk",
-      "@type": "@json"
     },
     "service": {
-      "@id": "didv:service",
+      "@id": "https://www.w3.org/ns/did#service",
       "@type": "@id",
-      "@container": "@set"
-    },
-    "serviceEndpoint": {
-      "@id": "didv:serviceEndpoint",
-      "@type": "@id"
-    },
-    "updated": {
-      "@id": "dc:modified",
-      "@type": "xsd:dateTime"
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "serviceEndpoint": {
+          "@id": "https://www.w3.org/ns/did#serviceEndpoint",
+          "@type": "@id"
+        }
+      }
     },
     "verificationMethod": {
-      "@id": "sec:verificationMethod",
+      "@id": "https://w3id.org/security#verificationMethod",
       "@type": "@id"
     }
   }

--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 use chrono::prelude::*;
+use serde_json::Value;
+use std::collections::BTreeMap;
 
 use ssi::caip10::BlockchainAccountId;
 use ssi::did::{
@@ -68,6 +70,20 @@ impl DIDResolver for DIDEthr {
             }
         };
 
+        let mut context = BTreeMap::new();
+        context.insert(
+            "blockchainAccountId".to_string(),
+            Value::String("https://w3id.org/security#blockchainAccountId".to_string()),
+        );
+        context.insert(
+            "EcdsaSecp256k1RecoveryMethod2020".to_string(),
+            Value::String("https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020".to_string()),
+        );
+        context.insert(
+            "Eip712Method2021".to_string(),
+            Value::String("https://w3id.org/security#Eip712Method2021".to_string()),
+        );
+
         let blockchain_account_id = BlockchainAccountId {
             account_address: address,
             chain_id: format!("eip155:{}", chain_id),
@@ -98,7 +114,10 @@ impl DIDResolver for DIDEthr {
         });
 
         let doc = Document {
-            context: Contexts::One(Context::URI(DEFAULT_CONTEXT.to_string())),
+            context: Contexts::Many(vec![
+                Context::URI(DEFAULT_CONTEXT.to_string()),
+                Context::Object(context),
+            ]),
             id: did.to_string(),
             authentication: Some(vec![
                 VerificationMethod::DIDURL(vm_didurl.clone()),
@@ -196,7 +215,14 @@ mod tests {
         assert_eq!(
             serde_json::to_value(doc).unwrap(),
             json!({
-              "@context": "https://www.w3.org/ns/did/v1",
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+                  "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020",
+                  "Eip712Method2021": "https://w3id.org/security#Eip712Method2021"
+                }
+              ],
               "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
               "verificationMethod": [{
                 "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller",

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1.0"
 multibase = "0.8"
 k256 = { version = "0.8", optional = true, features = ["zeroize", "ecdsa"] }
 p256 = { version = "0.8", optional = true, features = ["zeroize", "ecdsa"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/did-pkh/tests/did-btc.jsonld
+++ b/did-pkh/tests/did-btc.jsonld
@@ -1,5 +1,11 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
   "id": "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6",
   "verificationMethod": [
     {
@@ -16,4 +22,3 @@
     "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6#blockchainAccountId"
   ]
 }
-

--- a/did-pkh/tests/did-doge.jsonld
+++ b/did-pkh/tests/did-doge.jsonld
@@ -1,5 +1,11 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
   "id": "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
   "verificationMethod": [
     {

--- a/did-pkh/tests/did-eth.jsonld
+++ b/did-pkh/tests/did-eth.jsonld
@@ -1,5 +1,11 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020"
+    }
+  ],
   "id": "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a",
   "verificationMethod": [
     {

--- a/did-pkh/tests/did-sol.jsonld
+++ b/did-pkh/tests/did-sol.jsonld
@@ -1,27 +1,41 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      },
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "SolanaMethod2021": "https://w3id.org/security#SolanaMethod2021"
+    }
+  ],
   "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-  "verificationMethod": [{
-    "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
-    "type": "Ed25519VerificationKey2018",
-    "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-    "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
-    "publicKeyJwk": {
-      "kty": "OKP",
-      "crv": "Ed25519",
-      "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
+  "verificationMethod": [
+    {
+      "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
+      }
+    },
+    {
+      "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
+      "type": "SolanaMethod2021",
+      "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
+      }
     }
-  }, {
-    "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
-    "type": "SolanaMethod2021",
-    "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-    "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
-    "publicKeyJwk": {
-      "kty": "OKP",
-      "crv": "Ed25519",
-      "x": "qDkywhH-S6nNxQhA6SHKsoFW7A2gX-X0b3TtwVBMHm8"
-    }
-  }],
+  ],
   "authentication": [
     "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
     "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021"
@@ -31,4 +45,3 @@
     "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021"
   ]
 }
-

--- a/did-pkh/tests/did-tz1.jsonld
+++ b/did-pkh/tests/did-tz1.jsonld
@@ -1,5 +1,12 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021": "https://w3id.org/security#Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
   "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
   "verificationMethod": [
     {

--- a/did-pkh/tests/did-tz2.jsonld
+++ b/did-pkh/tests/did-tz2.jsonld
@@ -1,5 +1,12 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "EcdsaSecp256k1RecoveryMethod2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
   "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
   "verificationMethod": [
     {

--- a/did-pkh/tests/did-tz3.jsonld
+++ b/did-pkh/tests/did-tz3.jsonld
@@ -1,5 +1,12 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021": "https://w3id.org/security#P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
+      "TezosMethod2021": "https://w3id.org/security#TezosMethod2021"
+    }
+  ],
   "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
   "verificationMethod": [
     {

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 use chrono::prelude::*;
+use serde_json::Value;
+use std::collections::BTreeMap;
 
 use ssi::caip10::BlockchainAccountId;
 use ssi::did::{
@@ -52,6 +54,26 @@ impl DIDResolver for DIDSol {
                 )
             }
         };
+        let mut context = BTreeMap::new();
+        context.insert(
+            "blockchainAccountId".to_string(),
+            Value::String("https://w3id.org/security#blockchainAccountId".to_string()),
+        );
+        context.insert(
+            "publicKeyJwk".to_string(),
+            serde_json::json!({
+                "@id": "https://w3id.org/security#publicKeyJwk",
+                "@type": "@json"
+            }),
+        );
+        context.insert(
+            "Ed25519VerificationKey2018".to_string(),
+            Value::String("https://w3id.org/security#Ed25519VerificationKey2018".to_string()),
+        );
+        context.insert(
+            "SolanaMethod2021".to_string(),
+            Value::String("https://w3id.org/security#SolanaMethod2021".to_string()),
+        );
         let blockchain_account_id = BlockchainAccountId {
             account_address: address,
             chain_id: "solana".to_string(), // TODO: standardize
@@ -99,7 +121,10 @@ impl DIDResolver for DIDSol {
         });
 
         let doc = Document {
-            context: Contexts::One(Context::URI(DEFAULT_CONTEXT.to_string())),
+            context: Contexts::Many(vec![
+                Context::URI(DEFAULT_CONTEXT.to_string()),
+                Context::Object(context),
+            ]),
             id: did.to_string(),
             authentication: Some(vec![
                 VerificationMethod::DIDURL(vm_didurl.clone()),

--- a/did-sol/tests/did.jsonld
+++ b/did-sol/tests/did.jsonld
@@ -1,5 +1,16 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "blockchainAccountId": "https://w3id.org/security#blockchainAccountId",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      },
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "SolanaMethod2021": "https://w3id.org/security#SolanaMethod2021"
+    }
+  ],
   "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
   "verificationMethod": [{
     "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",


### PR DESCRIPTION
Fix #173

- Update DID Core context
- Add term definitions to local context for terms that are no longer defined in the DID Core context:
  - publicKeyJwk
  - blockchainAccountId
  - verification method types
- Add term definitions for custom proof types
- Add JSON-LD context for `did:key` implementation

With these changes, DID documents generated by `ssi` should be valid JSON-LD - even though we don't actually use them as such.