### PR TITLE
Misc DID resolution updates

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -137,7 +137,6 @@ impl DIDResolver for DIDEthr {
         };
 
         let doc_meta = DocumentMetadata {
-            created: Some(Utc::now()),
             ..Default::default()
         };
 

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -9,7 +9,7 @@ use ssi::did::{
 };
 use ssi::did_resolve::{
     DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
-    ERROR_NOT_FOUND, TYPE_DID_LD_JSON,
+    ERROR_NOT_FOUND,
 };
 #[cfg(feature = "secp256r1")]
 use ssi::jwk::p256_parse;
@@ -199,11 +199,7 @@ impl DIDResolver for DIDKey {
             ..Default::default()
         };
         (
-            ResolutionMetadata {
-                error: None,
-                content_type: Some(TYPE_DID_LD_JSON.to_string()),
-                property_set: None,
-            },
+            ResolutionMetadata::default(),
             Some(doc),
             Some(DocumentMetadata::default()),
         )

--- a/did-onion/src/lib.rs
+++ b/did-onion/src/lib.rs
@@ -66,7 +66,7 @@ impl DIDResolver for DIDOnion {
         Option<Document>,
         Option<DocumentMetadata>,
     ) {
-        let (res_meta, doc_data, doc_meta_opt) =
+        let (mut res_meta, doc_data, doc_meta_opt) =
             self.resolve_representation(did, input_metadata).await;
         let doc_opt = if doc_data.is_empty() {
             None
@@ -84,6 +84,9 @@ impl DIDResolver for DIDOnion {
                 }
             }
         };
+        // https://www.w3.org/TR/did-core/#did-resolution-metadata
+        // contentType - "MUST NOT be present if the resolve function was called"
+        res_meta.content_type = None;
         (res_meta, doc_opt, doc_meta_opt)
     }
 

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -31,7 +31,6 @@ fn resolution_result(doc: Document) -> ResolutionResult {
         ..Default::default()
     };
     let doc_meta = DocumentMetadata {
-        created: Some(Utc::now()),
         ..Default::default()
     };
     (res_meta, Some(doc), Some(doc_meta))

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -10,7 +10,6 @@ use ssi::did::{
 };
 use ssi::did_resolve::{
     DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
-    TYPE_DID_LD_JSON,
 };
 use ssi::jwk::{Base64urlUInt, OctetParams, Params, JWK};
 
@@ -29,7 +28,6 @@ type ResolutionResult = (
 
 fn resolution_result(doc: Document) -> ResolutionResult {
     let res_meta = ResolutionMetadata {
-        content_type: Some(TYPE_DID_LD_JSON.to_string()),
         ..Default::default()
     };
     let doc_meta = DocumentMetadata {

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -145,7 +145,6 @@ impl DIDResolver for DIDSol {
         };
 
         let doc_meta = DocumentMetadata {
-            created: Some(Utc::now()),
             ..Default::default()
         };
 

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -5,7 +5,7 @@ use ssi::did::{
 };
 use ssi::did_resolve::{
     dereference, DIDResolver, DereferencingInputMetadata, DocumentMetadata, Metadata,
-    ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID, TYPE_DID_LD_JSON,
+    ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
 };
 #[cfg(feature = "secp256r1")]
 use ssi::jwk::p256_parse;
@@ -215,7 +215,6 @@ impl DIDResolver for DIDTz {
         }
 
         let res_meta = ResolutionMetadata {
-            content_type: Some(TYPE_DID_LD_JSON.to_string()),
             ..Default::default()
         };
 

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -219,7 +219,6 @@ impl DIDResolver for DIDTz {
         };
 
         let doc_meta = DocumentMetadata {
-            created: Some(Utc::now()),
             ..Default::default()
         };
 

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -61,7 +61,7 @@ impl DIDResolver for DIDWeb {
         Option<Document>,
         Option<DocumentMetadata>,
     ) {
-        let (res_meta, doc_data, doc_meta_opt) =
+        let (mut res_meta, doc_data, doc_meta_opt) =
             self.resolve_representation(did, input_metadata).await;
         let doc_opt = if doc_data.is_empty() {
             None
@@ -79,6 +79,9 @@ impl DIDResolver for DIDWeb {
                 }
             }
         };
+        // https://www.w3.org/TR/did-core/#did-resolution-metadata
+        // contentType - "MUST NOT be present if the resolve function was called"
+        res_meta.content_type = None;
         (res_meta, doc_opt, doc_meta_opt)
     }
 

--- a/did-webkey/src/lib.rs
+++ b/did-webkey/src/lib.rs
@@ -7,7 +7,6 @@ use sshkeys::PublicKeyKind;
 use ssi::did::{DIDMethod, Document, VerificationMethod, VerificationMethodMap, DIDURL};
 use ssi::did_resolve::{
     DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
-    TYPE_DID_LD_JSON,
 };
 use ssi::ssh::ssh_pkk_to_jwk;
 
@@ -311,11 +310,7 @@ impl DIDResolver for DIDWebKey {
         };
         // TODO: set document created/updated metadata from HTTP headers?
         (
-            ResolutionMetadata {
-                error: None,
-                content_type: Some(TYPE_DID_LD_JSON.to_string()),
-                property_set: None,
-            },
+            ResolutionMetadata::default(),
             Some(doc),
             Some(DocumentMetadata::default()),
         )

--- a/src/did_resolve.rs
+++ b/src/did_resolve.rs
@@ -43,6 +43,7 @@ pub enum Metadata {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolutionInputMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub accept: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version_id: Option<String>,
@@ -84,6 +85,7 @@ pub struct DocumentMetadata {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DereferencingInputMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub accept: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_type: Option<String>,


### PR DESCRIPTION
Various minor improvements for DID resolution and DID URL dereferencing, to comply with [DID Test Suite](https://w3c.github.io/did-test-suite/).

- Metadata updates
  - Fix use of contentType [resolution metadata option](https://www.w3.org/TR/did-core/#did-resolution-metadata), which is required for `resolveRepresentation` and disallowed for `resolve`.
  - Fix skipping the accept property in resolution options and dereferencing options.
  - Set `contentType` metadata option in dereferencing result when selecting fragment from DID document.
- Error code updates.
  - Update error string to camel case, per DID Core updates e.g. https://github.com/w3c/did-core/pull/553.
  - Return `notFound` error code in `did:web` resolution when the HTTP response has a 404 Not Found status, so that we can demonstrate that error code.
  - Return `notFound` error code in DID URL de-referencing when fragment resource/object is not found, matching behavior of other implementations.
  - Pass through resolution error codes in dereferencer.
  - Use `invalidDidUrl` error when parsing DID URL that is not based on a DID, so that we can demonstrate that error code. (Note: more DID URL validation could be done).
