### PR TITLE
Correct EIP-155 chain ids

### DIFF
--- a/did-pkh/did-pkh-method-draft.md
+++ b/did-pkh/did-pkh-method-draft.md
@@ -116,7 +116,7 @@ blockchain without a mechanism to override and select alternatives.*
 |`tz` (tz1)|`tezos:mainnet`|Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|https://w3id.org/security#Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|
 |`tz` (tz2)|`tezos:mainnet`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|
 |`tz` (tz3)|`tezos:mainnet`|P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|https://w3id.org/security#P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|
-|`eth`|`eip155:mainnet`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|
+|`eth`|`eip155:1`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|
 |`sol`|`solana`|Ed25519VerificationKey2018|https://w3id.org/security#Ed25519VerificationKey2018|
 |`btc`|`bip122:000000000019d6689c085ae165831e93`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|
 |`doge`|`bip122:1a91e3dace36e2be3bf030a65679fe82`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -193,7 +193,7 @@ async fn resolve_celo(did: &str, account_address: String) -> ResolutionResult {
     );
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: "eip155:mainnet".to_string(),
+        chain_id: "eip155:42220".to_string(),
     };
     let vm_url = DIDURL {
         did: did.to_string(),

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -126,7 +126,7 @@ async fn resolve_eth(did: &str, account_address: String) -> ResolutionResult {
     );
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: "eip155:mainnet".to_string(),
+        chain_id: "eip155:1".to_string(),
     };
     let vm_url = DIDURL {
         did: did.to_string(),

--- a/did-pkh/tests/did-celo.jsonld
+++ b/did-pkh/tests/did-celo.jsonld
@@ -12,7 +12,7 @@
       "id": "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011#Recovery2020",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011",
-      "blockchainAccountId": "0xa0ae58da58dfa46fa55c3b86545e7065f90ff011@eip155:mainnet"
+      "blockchainAccountId": "0xa0ae58da58dfa46fa55c3b86545e7065f90ff011@eip155:42220"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-eth.jsonld
+++ b/did-pkh/tests/did-eth.jsonld
@@ -12,7 +12,7 @@
       "id": "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a#Recovery2020",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a",
-      "blockchainAccountId": "0xb9c5714089478a327f09197987f16f9e5d936e8a@eip155:mainnet"
+      "blockchainAccountId": "0xb9c5714089478a327f09197987f16f9e5d936e8a@eip155:1"
     }
   ],
   "authentication": [


### PR DESCRIPTION
Fix #229

Network names such as "mainnet" may be used in [did:ethr](https://github.com/decentralized-identity/ethr-did-resolver/) DIDs, but just the numeric chain id is supposed to be used in `blockchainAccountId`.

Thanks @oed for pointing this out.

This updates the chain id for `did:pkh:eth` and `did:pkh:celo`.

Sources for 42220 as Celo mainnet Chain ID:
- https://github.com/celo-org/celo-monorepo/blob/c90edf1/packages/docs/getting-started/using-metamask-with-celo/manual-setup.md#adding-a-celo-network-to-metamask
- https://chainlist.org/
