### PR TITLE
Use URI type for verificationMethod option

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -281,9 +281,10 @@ mod tests {
         vc.validate_unsigned().unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
         if eip712 {
-            issue_options.verification_method = Some(did.to_string() + "#Eip712Method2021");
+            issue_options.verification_method =
+                Some(URI::String(did.to_string() + "#Eip712Method2021"));
         } else {
-            issue_options.verification_method = Some(did.to_string() + "#controller");
+            issue_options.verification_method = Some(URI::String(did.to_string() + "#controller"));
         }
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
@@ -331,7 +332,7 @@ mod tests {
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
-        vp_issue_options.verification_method = Some(did.to_string() + "#controller");
+        vp_issue_options.verification_method = Some(URI::String(did.to_string() + "#controller"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
         vp.add_proof(vp_proof);

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -392,7 +392,7 @@ mod tests {
         let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
         vc.issuer = Some(Issuer::URI(URI::String(did.clone())));
-        issue_options.verification_method = Some(verification_method);
+        issue_options.verification_method = Some(URI::String(verification_method));
         let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
@@ -427,7 +427,7 @@ mod tests {
 
         let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(verification_method);
+        issue_options.verification_method = Some(URI::String(verification_method));
         let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
@@ -462,7 +462,7 @@ mod tests {
 
         let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(verification_method);
+        issue_options.verification_method = Some(URI::String(verification_method));
         let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
         .unwrap();
         vc.validate_unsigned().unwrap();
         let issue_options = LinkedDataProofOptions {
-            verification_method: Some(did.to_string() + vm_relative_url),
+            verification_method: Some(URI::String(did.to_string() + vm_relative_url)),
             eip712_domain: eip712_domain_opt,
             ..Default::default()
         };
@@ -730,7 +730,7 @@ mod tests {
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
-        vp_issue_options.verification_method = Some(did.to_string() + vm_relative_url);
+        vp_issue_options.verification_method = Some(URI::String(did.to_string() + vm_relative_url));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         vp_issue_options.eip712_domain = vp_eip712_domain_opt;
         // let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
@@ -783,7 +783,7 @@ mod tests {
         .unwrap();
         vc.validate_unsigned().unwrap();
         let issue_options = LinkedDataProofOptions {
-            verification_method: Some(did.to_string() + vm_relative_url),
+            verification_method: Some(URI::String(did.to_string() + vm_relative_url)),
             ..Default::default()
         };
         eprintln!("vm {:?}", issue_options.verification_method);
@@ -843,7 +843,7 @@ mod tests {
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
-        vp_issue_options.verification_method = Some(did.to_string() + vm_relative_url);
+        vp_issue_options.verification_method = Some(URI::String(did.to_string() + vm_relative_url));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
 
         let prep = proof_suite

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -262,9 +262,10 @@ mod tests {
         vc.validate_unsigned().unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
         if solvm {
-            issue_options.verification_method = Some(did.to_string() + "#SolanaMethod2021");
+            issue_options.verification_method =
+                Some(URI::String(did.to_string() + "#SolanaMethod2021"));
         } else {
-            issue_options.verification_method = Some(did.to_string() + "#controller");
+            issue_options.verification_method = Some(URI::String(did.to_string() + "#controller"));
         }
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
@@ -312,7 +313,7 @@ mod tests {
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
-        vp_issue_options.verification_method = Some(did.to_string() + "#controller");
+        vp_issue_options.verification_method = Some(URI::String(did.to_string() + "#controller"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
         vp.add_proof(vp_proof);

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -670,7 +670,8 @@ mod tests {
         // };
         let did = "did:tz:delphinet:tz1WvvbEGpBXGeTVbLiR6DYBe1izmgiYuZbq".to_string();
         let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(did.to_string() + "#blockchainAccountId");
+        issue_options.verification_method =
+            Some(URI::String(did.to_string() + "#blockchainAccountId"));
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
         // let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
@@ -782,7 +783,8 @@ mod tests {
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
-        vp_issue_options.verification_method = Some(did.to_string() + "#blockchainAccountId");
+        vp_issue_options.verification_method =
+            Some(URI::String(did.to_string() + "#blockchainAccountId"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         eprintln!("vp: {}", serde_json::to_string_pretty(&vp).unwrap());
         // let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
@@ -902,7 +904,8 @@ mod tests {
         .unwrap();
         vc.validate_unsigned().unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(did.to_string() + "#blockchainAccountId");
+        issue_options.verification_method =
+            Some(URI::String(did.to_string() + "#blockchainAccountId"));
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
         let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
@@ -949,7 +952,8 @@ mod tests {
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
-        vp_issue_options.verification_method = Some(did.to_string() + "#blockchainAccountId");
+        vp_issue_options.verification_method =
+            Some(URI::String(did.to_string() + "#blockchainAccountId"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         eprintln!("vp: {}", serde_json::to_string_pretty(&vp).unwrap());
         let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
@@ -1296,7 +1300,8 @@ mod tests {
         .unwrap();
         vc.validate_unsigned().unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(did.to_string() + "#blockchainAccountId");
+        issue_options.verification_method =
+            Some(URI::String(did.to_string() + "#blockchainAccountId"));
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
         let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
@@ -1343,7 +1348,8 @@ mod tests {
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
-        vp_issue_options.verification_method = Some(did.to_string() + "#blockchainAccountId");
+        vp_issue_options.verification_method =
+            Some(URI::String(did.to_string() + "#blockchainAccountId"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         eprintln!("vp: {}", serde_json::to_string_pretty(&vp).unwrap());
         let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -302,7 +302,7 @@ mod tests {
         let key_str = include_str!("../../tests/ed25519-2020-10-18.json");
         let key: JWK = serde_json::from_str(key_str).unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some("did:web:localhost#key1".to_string());
+        issue_options.verification_method = Some(URI::String("did:web:localhost#key1".to_string()));
         let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -18,7 +18,7 @@ async fn main() {
     let mut vc: ssi::vc::Credential = serde_json::from_value(vc).unwrap();
     let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
     let verification_method = "did:example:foo#key1".to_string();
-    proof_options.verification_method = Some(verification_method);
+    proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
     let proof_format = std::env::args().skip(1).next();
     match &proof_format.unwrap()[..] {
         "ldp" => {

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -39,7 +39,7 @@ async fn main() {
     let mut vp: ssi::vc::Presentation = serde_json::from_value(vp).unwrap();
     let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
     let verification_method = "did:example:foo#key2".to_string();
-    proof_options.verification_method = Some(verification_method);
+    proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
     proof_options.proof_purpose = Some(ssi::vc::ProofPurpose::Authentication);
     proof_options.challenge = Some("example".to_string());
 

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -24,7 +24,7 @@ use crate::jwk::{Algorithm, OctetParams as JWKOctetParams, Params as JWKParams, 
 use crate::jws::Header;
 use crate::rdf::DataSet;
 use crate::urdna2015;
-use crate::vc::{LinkedDataProofOptions, Proof};
+use crate::vc::{LinkedDataProofOptions, Proof, URI};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -191,7 +191,7 @@ fn use_eip712sig(key: &JWK) -> bool {
 }
 
 fn use_eip712vm(options: &LinkedDataProofOptions) -> bool {
-    if let Some(ref vm) = options.verification_method {
+    if let Some(URI::String(ref vm)) = options.verification_method {
         if vm.ends_with("#Eip712Method2021") {
             return true;
         }
@@ -253,7 +253,7 @@ impl LinkedDataProofs {
                 x509_thumbprint_sha256: _,
             } => match &curve[..] {
                 "Ed25519" => {
-                    if let Some(ref vm) = options.verification_method {
+                    if let Some(URI::String(ref vm)) = options.verification_method {
                         if vm.ends_with("#TezosMethod2021") {
                             return TezosSignature2021
                                 .sign(document, options, &key, extra_proof_properties)
@@ -321,7 +321,7 @@ impl LinkedDataProofs {
                                 .sign(document, options, &key, extra_proof_properties)
                                 .await;
                         } else {
-                            if let Some(ref vm) = options.verification_method {
+                            if let Some(URI::String(ref vm)) = options.verification_method {
                                 if vm.ends_with("#TezosMethod2021") {
                                     return TezosSignature2021
                                         .sign(document, options, &key, extra_proof_properties)
@@ -334,7 +334,7 @@ impl LinkedDataProofs {
                         }
                     }
                     "P-256" => {
-                        if let Some(ref vm) = options.verification_method {
+                        if let Some(URI::String(ref vm)) = options.verification_method {
                             if vm.ends_with("#TezosMethod2021") {
                                 return TezosSignature2021
                                     .sign(document, options, &key, extra_proof_properties)
@@ -375,7 +375,7 @@ impl LinkedDataProofs {
                     .await
             }
             Algorithm::EdDSA => {
-                if let Some(ref vm) = options.verification_method {
+                if let Some(URI::String(ref vm)) = options.verification_method {
                     if vm.ends_with("#SolanaMethod2021") {
                         return SolanaSignature2021
                             .prepare(document, options, public_key, extra_proof_properties)
@@ -387,7 +387,7 @@ impl LinkedDataProofs {
                     .await;
             }
             Algorithm::EdBlake2b => {
-                if let Some(ref vm) = options.verification_method {
+                if let Some(URI::String(ref vm)) = options.verification_method {
                     if vm.ends_with("#TezosMethod2021") {
                         return TezosSignature2021
                             .prepare(document, options, public_key, extra_proof_properties)
@@ -406,7 +406,7 @@ impl LinkedDataProofs {
                     .await;
             }
             Algorithm::ESBlake2b => {
-                if let Some(ref vm) = options.verification_method {
+                if let Some(URI::String(ref vm)) = options.verification_method {
                     if vm.ends_with("#TezosMethod2021") {
                         return TezosSignature2021
                             .prepare(document, options, public_key, extra_proof_properties)
@@ -425,7 +425,7 @@ impl LinkedDataProofs {
                     .await;
             }
             Algorithm::ESBlake2bK => {
-                if let Some(ref vm) = options.verification_method {
+                if let Some(URI::String(ref vm)) = options.verification_method {
                     if vm.ends_with("#TezosMethod2021") {
                         return TezosSignature2021
                             .prepare(document, options, public_key, extra_proof_properties)
@@ -1911,7 +1911,7 @@ mod tests {
         key.algorithm = Some(Algorithm::ES256KR);
         let vm = format!("{}#Recovery2020", "did:example:foo");
         let issue_options = LinkedDataProofOptions {
-            verification_method: Some(vm),
+            verification_method: Some(URI::String(vm)),
             ..Default::default()
         };
         let doc = ExampleDocument;
@@ -1926,7 +1926,7 @@ mod tests {
         key.algorithm = Some(Algorithm::EdBlake2b);
         let vm = format!("{}#TezosMethod2021", "did:example:foo");
         let issue_options = LinkedDataProofOptions {
-            verification_method: Some(vm),
+            verification_method: Some(URI::String(vm)),
             ..Default::default()
         };
         let doc = ExampleDocument;
@@ -1944,7 +1944,7 @@ mod tests {
         key.algorithm = Some(Algorithm::ESBlake2bK);
         let vm = format!("{}#TezosMethod2021", "did:example:foo");
         let issue_options = LinkedDataProofOptions {
-            verification_method: Some(vm),
+            verification_method: Some(URI::String(vm)),
             ..Default::default()
         };
         let doc = ExampleDocument;

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -460,6 +460,13 @@ impl TryFrom<String> for URI {
     }
 }
 
+impl FromStr for URI {
+    type Err = Error;
+    fn from_str(uri: &str) -> Result<Self, Self::Err> {
+        URI::try_from(String::from(uri))
+    }
+}
+
 impl From<URI> for String {
     fn from(uri: URI) -> String {
         let URI::String(string) = uri;

--- a/src/zcap.rs
+++ b/src/zcap.rs
@@ -451,7 +451,7 @@ mod tests {
         let alice_did = "did:example:foo";
         let alice_vm = format!("{}#key2", alice_did);
         let alice: JWK = JWK {
-            key_id: Some(alice_vm),
+            key_id: Some(alice_vm.clone()),
             ..serde_json::from_str(include_str!("../tests/ed25519-2020-10-18.json")).unwrap()
         };
 
@@ -463,7 +463,7 @@ mod tests {
         };
 
         let del: Delegation<(), DefaultProps<Actions>> = Delegation {
-            invoker: Some(URI::String(bob_vm)),
+            invoker: Some(URI::String(bob_vm.clone())),
             ..Delegation::new(
                 URI::String("urn:a_urn".into()),
                 URI::String("kepler://alices_orbit".into()),
@@ -491,12 +491,12 @@ mod tests {
         }
 
         let ldpo_alice = LinkedDataProofOptions {
-            verification_method: alice.key_id.clone(),
+            verification_method: Some(URI::String(alice_vm.clone())),
             proof_purpose: Some(ProofPurpose::CapabilityDelegation),
             ..Default::default()
         };
         let ldpo_bob = LinkedDataProofOptions {
-            verification_method: bob.key_id.clone(),
+            verification_method: Some(URI::String(bob_vm.clone())),
             proof_purpose: Some(ProofPurpose::CapabilityInvocation),
             ..Default::default()
         };


### PR DESCRIPTION
Use URI type in proof options for verificationMethod. This means that the verificationMethod option, such as for credential issuance and verification, will be fallibly converted to the URI type, to preventing non-URI use of the option. Currently the URI validation is incomplete as it just checks that the string contains ":", but this is enough for the test case in `vc-http-api`, and can be further improved. This also doesn't validate dereferencing the verification method URI during issuance; that is not required currently but we might want to consider doing so.

This is a breaking change and requires a corresponding change in `didkit`: https://github.com/spruceid/didkit/pull/184

Close #144