### PR TITLE
Improve linked data proof selection

### DIFF
--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -65,12 +65,24 @@ pub fn get_proof_suite(proof_type: &str) -> Result<&(dyn ProofSuite + Sync), Err
         }
         "EcdsaSecp256k1Signature2019" => &EcdsaSecp256k1Signature2019,
         "EcdsaSecp256k1RecoverySignature2020" => &EcdsaSecp256k1RecoverySignature2020,
-        #[cfg(feature = "keccak-hash")]
-        "Eip712Signature2021" => &Eip712Signature2021,
-        #[cfg(feature = "keccak-hash")]
-        "EthereumPersonalSignature2021" => &EthereumPersonalSignature2021,
-        #[cfg(feature = "keccak-hash")]
-        "EthereumEip712Signature2021" => &EthereumEip712Signature2021,
+        "Eip712Signature2021" => {
+            #[cfg(not(feature = "keccak-hash"))]
+            return Err(Error::MissingFeatures("keccak-hash"));
+            #[cfg(feature = "keccak-hash")]
+            &Eip712Signature2021
+        }
+        "EthereumPersonalSignature2021" => {
+            #[cfg(not(feature = "keccak-hash"))]
+            return Err(Error::MissingFeatures("keccak-hash"));
+            #[cfg(feature = "keccak-hash")]
+            &EthereumPersonalSignature2021
+        }
+        "EthereumEip712Signature2021" => {
+            #[cfg(not(feature = "keccak-hash"))]
+            return Err(Error::MissingFeatures("keccak-hash"));
+            #[cfg(feature = "keccak-hash")]
+            &EthereumEip712Signature2021
+        }
         "TezosSignature2021" => &TezosSignature2021,
         "SolanaSignature2021" => &SolanaSignature2021,
         "JsonWebSignature2020" => &JsonWebSignature2020,
@@ -123,11 +135,13 @@ fn pick_proof_suite<'a, 'b>(
         Algorithm::ES256KR => {
             if use_eip712sig(jwk) {
                 #[cfg(not(feature = "keccak-hash"))]
-                return Err(Error::ProofTypeNotImplemented);
+                return Err(Error::MissingFeatures("keccak-hash"));
+                #[cfg(feature = "keccak-hash")]
                 &EthereumEip712Signature2021
             } else if use_epsig(jwk) {
                 #[cfg(not(feature = "keccak-hash"))]
-                return Err(Error::ProofTypeNotImplemented);
+                return Err(Error::MissingFeatures("keccak-hash"));
+                #[cfg(feature = "keccak-hash")]
                 &EthereumPersonalSignature2021
             } else {
                 match verification_method {
@@ -136,7 +150,8 @@ fn pick_proof_suite<'a, 'b>(
                             && vm.ends_with("#Eip712Method2021") =>
                     {
                         #[cfg(not(feature = "keccak-hash"))]
-                        return Err(Error::ProofTypeNotImplemented);
+                        return Err(Error::MissingFeatures("keccak-hash"));
+                        #[cfg(feature = "keccak-hash")]
                         &Eip712Signature2021
                     }
                     _ => &EcdsaSecp256k1RecoverySignature2020,

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -252,7 +252,7 @@ impl ProofPreparation {
 }
 
 fn use_eip712sig(key: &JWK) -> bool {
-    // Use unregistered "signTypedData" key operation value to indicate using EthereumEip712Signature2021, until
+    // deprecated: allow using unregistered "signTypedData" key operation value to indicate using EthereumEip712Signature2021
     if let Some(ref key_ops) = key.key_operations {
         if key_ops.contains(&"signTypedData".to_string()) {
             return true;
@@ -261,18 +261,8 @@ fn use_eip712sig(key: &JWK) -> bool {
     return false;
 }
 
-fn use_eip712vm(options: &LinkedDataProofOptions) -> bool {
-    if let Some(URI::String(ref vm)) = options.verification_method {
-        if vm.ends_with("#Eip712Method2021") {
-            return true;
-        }
-    }
-    return false;
-}
-
 fn use_epsig(key: &JWK) -> bool {
-    // Use unregistered "signPersonalMessage" key operation value to indicate using EthereumPersonalSignature2021, until
-    // LinkedDataProofOptions has type property
+    // deprecated: allow using unregistered "signPersonalMessage" key operation value to indicate using EthereumPersonalSignature2021
     if let Some(ref key_ops) = key.key_operations {
         if key_ops.contains(&"signPersonalMessage".to_string()) {
             return true;

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -100,7 +100,12 @@ fn pick_proof_suite<'a, 'b>(
         Algorithm::RS256 => &RsaSignature2018,
 
         Algorithm::EdDSA => match verification_method {
-            Some(URI::String(ref vm)) if vm.ends_with("#SolanaMethod2021") => &SolanaSignature2021,
+            Some(URI::String(ref vm))
+                if (vm.starts_with("did:sol:") || vm.starts_with("did:pkh:sol:"))
+                    && vm.ends_with("#SolanaMethod2021") =>
+            {
+                &SolanaSignature2021
+            }
             _ => &Ed25519Signature2018,
         },
         Algorithm::EdBlake2b => match verification_method {

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -315,6 +315,10 @@ pub struct JWTClaims {
 /// Reference: vc-http-api
 pub struct LinkedDataProofOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
+    /// The type of the proof. Default is an appropriate proof type corresponding to the verification method.
+    pub type_: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// The URI of the verificationMethod used for the proof. If omitted a default
     /// assertionMethod will be used.
     pub verification_method: Option<URI>,
@@ -381,6 +385,7 @@ impl Default for LinkedDataProofOptions {
             domain: None,
             checks: Some(vec![Check::Proof]),
             eip712_domain: None,
+            type_: None,
         }
     }
 }
@@ -720,6 +725,7 @@ impl Credential {
             domain,
             checks,
             eip712_domain,
+            type_,
         } = options;
         if checks.is_some() {
             return Err(Error::UnencodableOptionClaim("checks".to_string()));
@@ -729,6 +735,9 @@ impl Credential {
         }
         if eip712_domain.is_some() {
             return Err(Error::UnencodableOptionClaim("eip712Domain".to_string()));
+        }
+        if type_.is_some() {
+            return Err(Error::UnencodableOptionClaim("type".to_string()));
         }
         match proof_purpose {
             None => (),
@@ -1157,6 +1166,7 @@ impl Presentation {
             domain,
             checks,
             eip712_domain,
+            type_,
         } = options;
         if checks.is_some() {
             return Err(Error::UnencodableOptionClaim("checks".to_string()));
@@ -1166,6 +1176,9 @@ impl Presentation {
         }
         if eip712_domain.is_some() {
             return Err(Error::UnencodableOptionClaim("eip712Domain".to_string()));
+        }
+        if type_.is_some() {
+            return Err(Error::UnencodableOptionClaim("type".to_string()));
         }
         match proof_purpose {
             None => (),


### PR DESCRIPTION
This refactors `src/ldp.rs` to allow using the proof `type` option, and to remove some duplicated code. The existing way proof types are selected when signing is based on the JWK, and sometimes using the verification method URI as well. The `type` property is allowed as a VC issuance and presentation option in VC HTTP API in https://github.com/w3c-ccg/vc-http-api/pull/197; here it is added as a way to directly request a specific proof type in `ssi`. This reduces the need for additional heuristics or non-standard mechanisms. It enables choosing between proof types when more than one may be valid for the verification method.

In addition to supporting the `type` property, `src/ldp.rs` is refactored to move all the proof type selection into two functions:
- `get_proof_suite`: get a `ProofSuite` struct given a proof type name. Used when the type option is provided when signing/preparing, or when verifying (since the signed proof always has a `type` property).
- `pick_proof_suite`: get a `ProofSuite` given a (public key) JWK and optional verification method URI. This is where things like "given a Ed25519 JWK, use `Ed25519Signature2018`" are set. There is still some DID-method specific logic there. Eventually we might want to dereference the verification method URI here, or call a DID method function; that will require changing the `sign` function to take a DID resolver/method as an argument.

These changes should make it easier to add more proof types, as there will be less places in the code to update.

Additionally, for proof suites that are only available when some cargo feature is enabled (e.g. `keccak-hash`), when that feature is not enabled, instead of treating the implementation as non-existent (resulting in a `ProofTypeNotImplemented` error) return the recently-added `MissingFeatures` error.