### PR TITLE
Update W3C Software and Document Short Notice

### DIFF
--- a/contexts/LICENSES.md
+++ b/contexts/LICENSES.md
@@ -13,7 +13,7 @@ Vaccination Certificate Vocabulary: https://w3c-ccg.github.io/vaccination-vocab
 Traceability Vocabulary: https://github.com/w3c-ccg/traceability-vocab  
 Citizenship Vocabulary: https://github.com/w3c-ccg/citizenship-vocab/
 
-Copyright © 2018-2021 World Wide Web Consortium, (Massachusetts Institute of Technology, European Research Consortium for Informatics and Mathematics, Keio University, Beihang). All Rights Reserved. This work is distributed under the [W3C® Software License][1] in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Copyright © 2018-2021 World Wide Web Consortium, (Massachusetts Institute of Technology, European Research Consortium for Informatics and Mathematics, Keio University, Beihang). All Rights Reserved. This work is distributed under the [W3C® Software and Document License][1] in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 [1]: http://www.w3.org/Consortium/Legal/copyright-software
 


### PR DESCRIPTION
Short notice was changed ("edited for clarity 7 April, 2021") "Software License" → "Software and Document License":
- Before: https://web.archive.org/web/20210228152304/https://www.w3.org/Consortium/Legal/2015/copyright-software-short-notice.html
- After: https://web.archive.org/web/20210411060228/https://www.w3.org/Consortium/Legal/2015/copyright-software-short-notice.html