### PR TITLE
Support new CAIP-10 format for blockchainAccountId

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -227,12 +227,12 @@ mod tests {
                 "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller",
                 "type": "EcdsaSecp256k1RecoveryMethod2020",
                 "controller": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
-                "blockchainAccountId": "0xb9c5714089478a327f09197987f16f9e5d936e8a@eip155:1"
+                "blockchainAccountId": "eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a"
               }, {
                 "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#Eip712Method2021",
                 "type": "Eip712Method2021",
                 "controller": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
-                "blockchainAccountId": "0xb9c5714089478a327f09197987f16f9e5d936e8a@eip155:1"
+                "blockchainAccountId": "eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a"
               }],
               "authentication": [
                 "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#controller",

--- a/did-pkh/tests/did-btc.jsonld
+++ b/did-pkh/tests/did-btc.jsonld
@@ -12,7 +12,7 @@
       "id": "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6#blockchainAccountId",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6",
-      "blockchainAccountId": "128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6@bip122:000000000019d6689c085ae165831e93"
+      "blockchainAccountId": "bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-celo.jsonld
+++ b/did-pkh/tests/did-celo.jsonld
@@ -12,7 +12,7 @@
       "id": "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011#Recovery2020",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011",
-      "blockchainAccountId": "0xa0ae58da58dfa46fa55c3b86545e7065f90ff011@eip155:42220"
+      "blockchainAccountId": "eip155:42220:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-doge.jsonld
+++ b/did-pkh/tests/did-doge.jsonld
@@ -12,7 +12,7 @@
       "id": "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L#blockchainAccountId",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
-      "blockchainAccountId": "DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L@bip122:1a91e3dace36e2be3bf030a65679fe82"
+      "blockchainAccountId": "bip122:1a91e3dace36e2be3bf030a65679fe82:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-eth.jsonld
+++ b/did-pkh/tests/did-eth.jsonld
@@ -12,7 +12,7 @@
       "id": "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a#Recovery2020",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a",
-      "blockchainAccountId": "0xb9c5714089478a327f09197987f16f9e5d936e8a@eip155:1"
+      "blockchainAccountId": "eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-sol.jsonld
+++ b/did-pkh/tests/did-sol.jsonld
@@ -17,7 +17,7 @@
       "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
       "type": "Ed25519VerificationKey2018",
       "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-      "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
+      "blockchainAccountId": "solana:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
       "publicKeyJwk": {
         "kty": "OKP",
         "crv": "Ed25519",
@@ -28,7 +28,7 @@
       "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
       "type": "SolanaMethod2021",
       "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-      "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
+      "blockchainAccountId": "solana:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
       "publicKeyJwk": {
         "kty": "OKP",
         "crv": "Ed25519",

--- a/did-pkh/tests/did-tz1.jsonld
+++ b/did-pkh/tests/did-tz1.jsonld
@@ -13,13 +13,13 @@
       "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
       "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
       "controller": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-      "blockchainAccountId": "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8@tezos:mainnet"
+      "blockchainAccountId": "tezos:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
     },
     {
       "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021",
       "type": "TezosMethod2021",
       "controller": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-      "blockchainAccountId": "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8@tezos:mainnet"
+      "blockchainAccountId": "tezos:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-tz2.jsonld
+++ b/did-pkh/tests/did-tz2.jsonld
@@ -13,13 +13,13 @@
       "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
-      "blockchainAccountId": "tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq@tezos:mainnet"
+      "blockchainAccountId": "tezos:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
     },
     {
       "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021",
       "type": "TezosMethod2021",
       "controller": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
-      "blockchainAccountId": "tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq@tezos:mainnet"
+      "blockchainAccountId": "tezos:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-tz3.jsonld
+++ b/did-pkh/tests/did-tz3.jsonld
@@ -13,13 +13,13 @@
       "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
       "type": "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
       "controller": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
-      "blockchainAccountId": "tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX@tezos:mainnet"
+      "blockchainAccountId": "tezos:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
     },
     {
       "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021",
       "type": "TezosMethod2021",
       "controller": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
-      "blockchainAccountId": "tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX@tezos:mainnet"
+      "blockchainAccountId": "tezos:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
     }
   ],
   "authentication": [

--- a/did-sol/tests/did.jsonld
+++ b/did-sol/tests/did.jsonld
@@ -16,7 +16,7 @@
     "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
     "type": "Ed25519VerificationKey2018",
     "controller": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-    "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
+    "blockchainAccountId": "solana:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
     "publicKeyJwk": {
       "kty": "OKP",
       "crv": "Ed25519",
@@ -26,7 +26,7 @@
     "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
     "type": "SolanaMethod2021",
     "controller": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-    "blockchainAccountId": "CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev@solana",
+    "blockchainAccountId": "solana:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
     "publicKeyJwk": {
       "kty": "OKP",
       "crv": "Ed25519",

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -352,7 +352,7 @@ impl DIDTz {
                 id: String::from(vm_didurl.clone()),
                 type_: proof_type.to_string(),
                 controller: did.to_string(),
-                blockchain_account_id: Some(format!("{}@tezos:{}", address.to_string(), network)),
+                blockchain_account_id: Some(format!("tezos:{}:{}", network, address.to_string())),
                 ..Default::default()
             })]),
             authentication: match public_key {
@@ -580,7 +580,7 @@ mod tests {
                 "id": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
                 "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
                 "controller": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-                "blockchainAccountId": "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8@tezos:mainnet"
+                "blockchainAccountId": "tezos:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
               }],
               "authentication": [
                 "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId"
@@ -618,7 +618,7 @@ mod tests {
                 "id": "did:tz:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
                 "type": "EcdsaSecp256k1RecoveryMethod2020",
                 "controller": "did:tz:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
-                "blockchainAccountId": "tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq@tezos:mainnet"
+                "blockchainAccountId": "tezos:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
               }],
               "authentication": [
                 "did:tz:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId"
@@ -1012,7 +1012,7 @@ mod tests {
                 "id": "did:tz:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
                 "type": "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
                 "controller": "did:tz:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
-                "blockchainAccountId": "tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX@tezos:mainnet"
+                "blockchainAccountId": "tezos:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
               }],
               "authentication": [
                 "did:tz:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId"
@@ -1037,7 +1037,7 @@ mod tests {
             "id": format!("{}#blockchainAccountId", did),
             "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
             "controller": did,
-            "blockchainAccountId": format!("{}@tezos:{}", address, "sandbox"),
+            "blockchainAccountId": format!("tezos:sandbox:{}", address),
             "publicKeyBase58": pk
           }],
           "service": [{
@@ -1084,7 +1084,7 @@ mod tests {
             "id": format!("{}#blockchainAccountId", did),
             "type": "EcdsaSecp256k1RecoveryMethod2020",
             "controller": did,
-            "blockchainAccountId": format!("{}@tezos:{}", address, "sandbox"),
+            "blockchainAccountId": format!("tezos:sandbox:{}", address),
             "publicKeyBase58": pk
           }],
           "service": [{
@@ -1146,7 +1146,7 @@ mod tests {
             "id": format!("{}#blockchainAccountId", did),
             "type": "JsonWebKey2020",
             "controller": did,
-            "blockchainAccountId": format!("{}@tezos:{}", address, "sandbox"),
+            "blockchainAccountId": format!("tezos:sandbox:{}", address),
             "publicKeyBase58": pk
           }],
           "service": [{
@@ -1240,7 +1240,7 @@ mod tests {
                 VerificationMethod::Map(VerificationMethodMap {
                     id: format!("{}#blockchainAccountId", live_did),
                     type_: "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021".to_string(),
-                    blockchain_account_id: Some(format!("{}@tezos:{}", LIVE_TZ1, LIVE_NETWORK)),
+                    blockchain_account_id: Some(format!("tezos:{}:{}", LIVE_NETWORK, LIVE_TZ1)),
                     controller: live_did.clone(),
                     property_set: Some(Map::new()), // TODO should be None
                     ..Default::default()


### PR DESCRIPTION
`blockchainAccountId` has a new syntax: https://github.com/w3c-ccg/security-vocab/pull/118

Fix #243

Support the old way also, for backwards-compatibility.