### PR TITLE
Fix did:example:foo and did:example:bar

### DIFF
--- a/tests/did-example-bar.json
+++ b/tests/did-example-bar.json
@@ -1,5 +1,15 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyBase58": "https://w3id.org/security#publicKeyBase58",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
   "id": "did:example:bar",
   "verificationMethod": [
     {
@@ -22,7 +32,7 @@
   "capabilityDelegation": [
     "did:example:bar#key1"
   ],
-  "capabilityInvokation": [
+  "capabilityInvocation": [
     "did:example:bar#key1"
   ]
 }

--- a/tests/did-example-foo.json
+++ b/tests/did-example-foo.json
@@ -1,13 +1,23 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyBase58": "https://w3id.org/security#publicKeyBase58",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
   "id": "did:example:foo",
   "verificationMethod": [
     {
       "id": "did:example:foo#key1",
-      "type": "RSAVerificationKey2018",
+      "type": "JsonWebKey2020",
       "controller": "did:example:foo",
       "publicKeyJwk": {
-        "kid": "rsa2048-2020-08-25",
         "kty": "RSA",
         "n": "ALG1_NjU1eiMpcQoezH1eIZcr2p4gmo7j_exsjqkr05qBHQTn5Rb2dOpEf_Q-nLbeORZOobJH52oNhhuvTQC1R9qOEQkerUIi0aSnDEbQ2BP7YRJnwbw85v1VZDiGH8bviKbqPSf0uVwzQ43M8dr_t6A4efgiB5FOOobxXgr6VEvi_EyUm4F9JI1ZP5uHiG_cIet67Zg-lM_ygbQqOZpkeExLXC2SmHajKd8Aozfk5YB4s_-KFV1mx1HnwhHvKxZ19YkJ6Qx1OPf0ml0KLndYwmnsRZ9uZ_gGvH_G3OVZvuUnkcInR2uhK7xIU739Xc-hqDT6dokb5vsCdYMcFiRGD0",
         "e": "AQAB"
@@ -45,7 +55,7 @@
     "did:example:foo#key2",
     "did:example:foo#key3"
   ],
-  "capabilityInvokation": [
+  "capabilityInvocation": [
     "did:example:foo#key1",
     "did:example:foo#key2",
     "did:example:foo#key3"


### PR DESCRIPTION
- Fix typos
- Use JsonWebKey2020
- Make these DID documents valid JSON-LD
- Remove `kid` from JWK, to allow the verification method's id to be used as `kid`.