### PR TITLE
Use CAIP-26 for Tezos chain IDs

### DIFF
--- a/did-pkh/did-pkh-method-draft.md
+++ b/did-pkh/did-pkh-method-draft.md
@@ -114,9 +114,9 @@ blockchain without a mechanism to override and select alternatives.*
 
 |network id|CAIP-2 chain id|verification method type|URL for context definition|
 |---|---|---|---|
-|`tz` (tz1)|`tezos:mainnet`|Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|https://w3id.org/security#Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|
-|`tz` (tz2)|`tezos:mainnet`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|
-|`tz` (tz3)|`tezos:mainnet`|P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|https://w3id.org/security#P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|
+|`tz` (tz1)|`tezos:NetXdQprcVkpaWU`|Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|https://w3id.org/security#Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|
+|`tz` (tz2)|`tezos:NetXdQprcVkpaWU`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|
+|`tz` (tz3)|`tezos:NetXdQprcVkpaWU`|P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|https://w3id.org/security#P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021|
 |`eth`|`eip155:1`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|
 |`celo`|`eip155:42220`|EcdsaSecp256k1RecoveryMethod2020|https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020|
 |`sol`|`solana`|Ed25519VerificationKey2018|https://w3id.org/security#Ed25519VerificationKey2018|

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -17,6 +17,9 @@ use ssi::jwk::{Base64urlUInt, OctetParams, Params, JWK};
 const CHAIN_ID_BITCOIN_MAINNET: &str = "bip122:000000000019d6689c085ae165831e93";
 const CHAIN_ID_DOGECOIN_MAINNET: &str = "bip122:1a91e3dace36e2be3bf030a65679fe82";
 
+// https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-26.md
+const CHAIN_ID_TEZOS_MAINNET: &str = "tezos:NetXdQprcVkpaWU";
+
 /// did:pkh DID Method
 pub struct DIDPKH;
 
@@ -52,7 +55,7 @@ async fn resolve_tz(did: &str, account_address: String) -> ResolutionResult {
     };
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: "tezos:mainnet".to_string(),
+        chain_id: CHAIN_ID_TEZOS_MAINNET.to_string(),
     };
     let mut context = BTreeMap::new();
     context.insert(

--- a/did-pkh/tests/did-tz1.jsonld
+++ b/did-pkh/tests/did-tz1.jsonld
@@ -13,13 +13,13 @@
       "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
       "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
       "controller": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-      "blockchainAccountId": "tezos:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
     },
     {
       "id": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#TezosMethod2021",
       "type": "TezosMethod2021",
       "controller": "did:pkh:tz:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-      "blockchainAccountId": "tezos:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-tz2.jsonld
+++ b/did-pkh/tests/did-tz2.jsonld
@@ -13,13 +13,13 @@
       "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
       "controller": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
-      "blockchainAccountId": "tezos:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
     },
     {
       "id": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#TezosMethod2021",
       "type": "TezosMethod2021",
       "controller": "did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
-      "blockchainAccountId": "tezos:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
     }
   ],
   "authentication": [

--- a/did-pkh/tests/did-tz3.jsonld
+++ b/did-pkh/tests/did-tz3.jsonld
@@ -13,13 +13,13 @@
       "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
       "type": "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
       "controller": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
-      "blockchainAccountId": "tezos:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
     },
     {
       "id": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#TezosMethod2021",
       "type": "TezosMethod2021",
       "controller": "did:pkh:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
-      "blockchainAccountId": "tezos:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
+      "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
     }
   ],
   "authentication": [

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -53,12 +53,25 @@ impl DIDResolver for DIDTz {
         Option<DocumentMetadata>,
     ) {
         let (network, address) = match did.split(':').collect::<Vec<&str>>().as_slice() {
-            ["did", "tz", address] if address.len() == 36 => {
-                ("mainnet".to_string(), address.to_string())
-            }
+            ["did", "tz", address] if address.len() == 36 => ("mainnet", address.to_string()),
             ["did", "tz", network, address] if address.len() == 36 => {
-                (network.to_string(), address.to_string())
+                (*network, address.to_string())
             }
+            _ => {
+                return (
+                    ResolutionMetadata::from_error(&ERROR_INVALID_DID),
+                    None,
+                    None,
+                )
+            }
+        };
+        // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-26.md
+        let genesis_block_hash = match network {
+            "mainnet" => "NetXdQprcVkpaWU",
+            "delphinet" => "NetXm8tYqnMWky1",
+            "granadanet" => "NetXz969SFaFn8k",
+            "edonet" => "NetXSgo1ZT2DRUG",
+            "florencenet" => "NetXxkAx4woPLyu",
             _ => {
                 return (
                     ResolutionMetadata::from_error(&ERROR_INVALID_DID),
@@ -112,7 +125,7 @@ impl DIDResolver for DIDTz {
             proof_type,
             proof_type_iri,
             &address,
-            &network,
+            &genesis_block_hash,
             public_key,
         );
 
@@ -323,7 +336,7 @@ impl DIDTz {
         proof_type: &str,
         proof_type_iri: &str,
         address: &str,
-        network: &str,
+        genesis_block_hash: &str,
         public_key: Option<String>,
     ) -> Document {
         let mut context = BTreeMap::new();
@@ -352,7 +365,11 @@ impl DIDTz {
                 id: String::from(vm_didurl.clone()),
                 type_: proof_type.to_string(),
                 controller: did.to_string(),
-                blockchain_account_id: Some(format!("tezos:{}:{}", network, address.to_string())),
+                blockchain_account_id: Some(format!(
+                    "tezos:{}:{}",
+                    genesis_block_hash,
+                    address.to_string()
+                )),
                 ..Default::default()
             })]),
             authentication: match public_key {
@@ -514,7 +531,7 @@ mod tests {
     const TZ1_JSON: &'static str = "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"GvidwVqGgicuL68BRM89OOtDzK1gjs8IqUXFkjKkm8Iwg18slw==\",\"d\":\"K44dAtJ-MMl-JKuOupfcGRPI5n3ZVH_Gk65c6Rcgn_IV28987PMw_b6paCafNOBOi5u-FZMgGJd3mc5MkfxfwjCrXQM-\"}";
 
     const LIVE_TZ1: &str = "tz1giDGsifWB9q9siekCKQaJKrmC9da5M43J";
-    const LIVE_NETWORK: &str = "mainnet";
+    const LIVE_NETWORK: &str = "NetXdQprcVkpaWU";
     const JSON_PATCH: &str = r#"{"ietf-json-patch": [
                                     {
                                         "op": "add",
@@ -580,7 +597,7 @@ mod tests {
                 "id": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId",
                 "type": "Ed25519PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
                 "controller": "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-                "blockchainAccountId": "tezos:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
+                "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"
               }],
               "authentication": [
                 "did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8#blockchainAccountId"
@@ -618,7 +635,7 @@ mod tests {
                 "id": "did:tz:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId",
                 "type": "EcdsaSecp256k1RecoveryMethod2020",
                 "controller": "did:tz:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
-                "blockchainAccountId": "tezos:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
+                "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
               }],
               "authentication": [
                 "did:tz:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq#blockchainAccountId"
@@ -1012,7 +1029,7 @@ mod tests {
                 "id": "did:tz:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId",
                 "type": "P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021",
                 "controller": "did:tz:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
-                "blockchainAccountId": "tezos:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
+                "blockchainAccountId": "tezos:NetXdQprcVkpaWU:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"
               }],
               "authentication": [
                 "did:tz:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX#blockchainAccountId"

--- a/src/caip10.rs
+++ b/src/caip10.rs
@@ -184,9 +184,10 @@ mod tests {
           "x": "G80iskrv_nE69qbGLSpeOHJgmV4MKIzsy5l5iT6pCww"
         }))
         .unwrap();
-        let account_id =
-            BlockchainAccountId::from_str("tezos:mainnet:tz1NcJyMQzUw7h85baBA6vwRGmpwPnM1fz83")
-                .unwrap();
+        let account_id = BlockchainAccountId::from_str(
+            "tezos:NetXdQprcVkpaWU:tz1NcJyMQzUw7h85baBA6vwRGmpwPnM1fz83",
+        )
+        .unwrap();
         account_id.verify(&jwk).unwrap();
     }
 }


### PR DESCRIPTION
Similar to #230: network names such as "mainnet" are a feature of `did:tz`, but the CAIP-2 chain ID just uses genesis block hashes: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-26.md

We can also see this in @ceramicnetwork (@oed)'s implementation of `did:pkh`: https://github.com/ceramicnetwork/js-ceramic/pull/1624/files#diff-34ce618f7c8da7c8a1ef0e286005e60d6c0b1ca85a28c4ac7d3ebe3affd03ffcR177

This PR updates use of blockchainAccountId/CAIP-10 for Tezos to follow CAIP-26, using `genesis-block-hash` as the Tezos chain identifier
- Update test in caip10.rs
- Update `did:pkh` specification draft and implementation to use the genesis hash for Tezos mainnet.
- Update `did:tz` to convert network names to genesis block hashes.

This results in `did:tz` only allowing `mainnet` and `delphinet` as network ids, since those are the only ones for which I could find genesis block hashes. More could be added, and/or `did:tz` could allow using genesis block hashes also (e.g. passing through strings that look like they are genesis block hashes).