### PR TITLE
Allow returning warnings from proof verification

### DIFF
--- a/src/vc.rs
+++ b/src/vc.rs
@@ -7,7 +7,9 @@ use crate::error::Error;
 use crate::jsonld::{json_to_dataset, StaticLoader};
 use crate::jwk::{JWTKeys, JWK};
 use crate::jws::Header;
-use crate::ldp::{now_ms, LinkedDataDocument, LinkedDataProofs, ProofPreparation};
+use crate::ldp::{
+    now_ms, LinkedDataDocument, LinkedDataProofs, ProofPreparation, VerificationWarnings,
+};
 use crate::one_or_many::OneOrMany;
 use crate::rdf::DataSet;
 
@@ -414,14 +416,18 @@ impl VerificationResult {
     }
 }
 
-impl From<Result<(), Error>> for VerificationResult {
-    fn from(res: Result<(), Error>) -> Self {
-        Self {
-            checks: vec![],
-            warnings: vec![],
-            errors: match res {
-                Ok(_) => vec![],
-                Err(error) => vec![error.to_string()],
+impl From<Result<VerificationWarnings, Error>> for VerificationResult {
+    fn from(res: Result<VerificationWarnings, Error>) -> Self {
+        match res {
+            Ok(warnings) => Self {
+                checks: vec![],
+                warnings,
+                errors: vec![],
+            },
+            Err(error) => Self {
+                checks: vec![],
+                warnings: vec![],
+                errors: vec![error.to_string()],
             },
         }
     }


### PR DESCRIPTION
This changes the LDP verify functions to return an array of verification warnings instead of an empty tuple. These warnings are then passed into the `warnings` array of a `VerificationResult` when verifying a linked data proof.
Some possible uses for warnings for linked data proofs:
- Indicate a proof type is experimental.
- Indicate a proof type or deprecated.
- Indicate a proof object is missing a recommended field.
- Indicate a verification method object is missing a recommended field.

If needed, use of this return type could be extended to the JWS verify functions, public key hash verification functions, and validation functions - basically anywhere `Result<(), Error>` is used currently.

Currently we don't have anything returning warnings, but might want to use it in #237.