### PR TITLE
Pass resolver option in issue/prepare

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -288,7 +288,10 @@ mod tests {
         }
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
-        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        let proof = vc
+            .generate_proof(&key, &issue_options, &DIDEthr)
+            .await
+            .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
@@ -306,7 +309,7 @@ mod tests {
         let other_key = JWK::generate_ed25519().unwrap();
         use ssi::ldp::ProofSuite;
         let proof_bad = ssi::ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
-            .sign(&vc_no_proof, &issue_options, &other_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDEthr, &other_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
@@ -334,7 +337,10 @@ mod tests {
         vp.holder = Some(URI::String(did.to_string()));
         vp_issue_options.verification_method = Some(URI::String(did.to_string() + "#controller"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
-        let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
+        let vp_proof = vp
+            .generate_proof(&key, &vp_issue_options, &DIDEthr)
+            .await
+            .unwrap();
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -393,7 +393,10 @@ mod tests {
         let mut issue_options = LinkedDataProofOptions::default();
         vc.issuer = Some(Issuer::URI(URI::String(did.clone())));
         issue_options.verification_method = Some(URI::String(verification_method));
-        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        let proof = vc
+            .generate_proof(&key, &issue_options, &DIDKey)
+            .await
+            .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
@@ -428,7 +431,10 @@ mod tests {
         let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String(verification_method));
-        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        let proof = vc
+            .generate_proof(&key, &issue_options, &DIDKey)
+            .await
+            .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
@@ -463,7 +469,10 @@ mod tests {
         let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String(verification_method));
-        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        let proof = vc
+            .generate_proof(&key, &issue_options, &DIDKey)
+            .await
+            .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -743,7 +743,7 @@ mod tests {
         // Sign with proof suite directly because there is not currently a way to do it
         // for Eip712Signature2021 in did-pkh otherwise.
         let proof = proof_suite
-            .sign(&vc, &issue_options, &key, None)
+            .sign(&vc, &issue_options, &DIDPKH, &key, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
@@ -762,7 +762,7 @@ mod tests {
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let proof_bad = proof_suite
-            .sign(&vc_no_proof, &issue_options, &wrong_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDPKH, &wrong_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
@@ -797,7 +797,7 @@ mod tests {
         vp_issue_options.eip712_domain = vp_eip712_domain_opt;
         // let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
         let vp_proof = proof_suite
-            .sign(&vp, &vp_issue_options, &key, None)
+            .sign(&vp, &vp_issue_options, &DIDPKH, &key, None)
             .await
             .unwrap();
         vp.add_proof(vp_proof);
@@ -851,7 +851,7 @@ mod tests {
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
         let prep = proof_suite
-            .prepare(&vc, &issue_options, &key, None)
+            .prepare(&vc, &issue_options, &DIDPKH, &key, None)
             .await
             .unwrap();
 
@@ -875,7 +875,7 @@ mod tests {
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let proof_bad = proof_suite
-            .sign(&vc_no_proof, &issue_options, &wrong_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDPKH, &wrong_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
@@ -909,7 +909,7 @@ mod tests {
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
 
         let prep = proof_suite
-            .prepare(&vp, &vp_issue_options, &key, None)
+            .prepare(&vp, &vp_issue_options, &DIDPKH, &key, None)
             .await
             .unwrap();
         let sig = sign_tezos(&prep, algorithm, &key);

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -269,7 +269,10 @@ mod tests {
         }
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
-        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        let proof = vc
+            .generate_proof(&key, &issue_options, &DIDSol)
+            .await
+            .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
@@ -287,7 +290,7 @@ mod tests {
         let other_key = JWK::generate_ed25519().unwrap();
         use ssi::ldp::ProofSuite;
         let proof_bad = ssi::ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
-            .sign(&vc_no_proof, &issue_options, &other_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDSol, &other_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
@@ -315,7 +318,10 @@ mod tests {
         vp.holder = Some(URI::String(did.to_string()));
         vp_issue_options.verification_method = Some(URI::String(did.to_string() + "#controller"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
-        let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
+        let vp_proof = vp
+            .generate_proof(&key, &vp_issue_options, &DIDSol)
+            .await
+            .unwrap();
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -691,7 +691,7 @@ mod tests {
             Some(URI::String(did.to_string() + "#blockchainAccountId"));
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
-        // let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        // let proof = vc.generate_proof(&key, &issue_options, &DIDTZ).await.unwrap();
         let proof_str = r###"
 {
   "@context": {
@@ -774,7 +774,7 @@ mod tests {
         let other_key = JWK::generate_ed25519().unwrap();
         use ssi::ldp::ProofSuite;
         let proof_bad = ssi::ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
-            .sign(&vc_no_proof, &issue_options, &other_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDTZ, &other_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
@@ -804,7 +804,7 @@ mod tests {
             Some(URI::String(did.to_string() + "#blockchainAccountId"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         eprintln!("vp: {}", serde_json::to_string_pretty(&vp).unwrap());
-        // let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
+        // let vp_proof = vp.generate_proof(&key, &vp_issue_options, &DIDTZ).await.unwrap();
         let vp_proof_str = r###"
 {
   "@context": {
@@ -925,7 +925,10 @@ mod tests {
             Some(URI::String(did.to_string() + "#blockchainAccountId"));
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
-        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        let proof = vc
+            .generate_proof(&key, &issue_options, &DIDTZ)
+            .await
+            .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
@@ -943,7 +946,7 @@ mod tests {
         let other_key = JWK::generate_ed25519().unwrap();
         use ssi::ldp::ProofSuite;
         let proof_bad = ssi::ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
-            .sign(&vc_no_proof, &issue_options, &other_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDTZ, &other_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
@@ -973,7 +976,10 @@ mod tests {
             Some(URI::String(did.to_string() + "#blockchainAccountId"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         eprintln!("vp: {}", serde_json::to_string_pretty(&vp).unwrap());
-        let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
+        let vp_proof = vp
+            .generate_proof(&key, &vp_issue_options, &DIDTZ)
+            .await
+            .unwrap();
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();
@@ -1321,7 +1327,10 @@ mod tests {
             Some(URI::String(did.to_string() + "#blockchainAccountId"));
         eprintln!("vm {:?}", issue_options.verification_method);
         let vc_no_proof = vc.clone();
-        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        let proof = vc
+            .generate_proof(&key, &issue_options, &DIDTZ)
+            .await
+            .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
@@ -1339,7 +1348,7 @@ mod tests {
         let other_key = JWK::generate_p256().unwrap();
         use ssi::ldp::ProofSuite;
         let proof_bad = ssi::ldp::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021
-            .sign(&vc_no_proof, &issue_options, &other_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDTZ, &other_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
@@ -1369,7 +1378,10 @@ mod tests {
             Some(URI::String(did.to_string() + "#blockchainAccountId"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         eprintln!("vp: {}", serde_json::to_string_pretty(&vp).unwrap());
-        let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
+        let vp_proof = vp
+            .generate_proof(&key, &vp_issue_options, &DIDTZ)
+            .await
+            .unwrap();
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -303,7 +303,10 @@ mod tests {
         let key: JWK = serde_json::from_str(key_str).unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String("did:web:localhost#key1".to_string()));
-        let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
+        let proof = vc
+            .generate_proof(&key, &issue_options, &DIDWeb)
+            .await
+            .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -197,6 +197,7 @@ pub trait ProofSuite {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error>;
@@ -205,6 +206,7 @@ pub trait ProofSuite {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error>;
@@ -283,6 +285,7 @@ impl LinkedDataProofs {
     pub async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -295,7 +298,7 @@ impl LinkedDataProofs {
             pick_proof_suite(key, options.verification_method.as_ref())?
         };
         suite
-            .sign(document, options, &key, extra_proof_properties)
+            .sign(document, options, resolver, &key, extra_proof_properties)
             .await
     }
 
@@ -304,6 +307,7 @@ impl LinkedDataProofs {
     pub async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -316,7 +320,13 @@ impl LinkedDataProofs {
             pick_proof_suite(public_key, options.verification_method.as_ref())?
         };
         suite
-            .prepare(document, options, public_key, extra_proof_properties)
+            .prepare(
+                document,
+                options,
+                resolver,
+                public_key,
+                extra_proof_properties,
+            )
             .await
     }
 
@@ -421,6 +431,7 @@ async fn to_jws_payload(
 async fn sign(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
+    _resolver: &dyn DIDResolver,
     key: &JWK,
     type_: &str,
     algorithm: Algorithm,
@@ -452,6 +463,7 @@ async fn sign_proof(
 async fn prepare(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
+    _resolver: &dyn DIDResolver,
     public_key: &JWK,
     type_: &str,
     algorithm: Algorithm,
@@ -519,12 +531,14 @@ impl ProofSuite for RsaSignature2018 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
         sign(
             document,
             options,
+            resolver,
             key,
             "RsaSignature2018",
             Algorithm::RS256,
@@ -536,12 +550,14 @@ impl ProofSuite for RsaSignature2018 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         prepare(
             document,
             options,
+            resolver,
             public_key,
             "RsaSignature2018",
             Algorithm::RS256,
@@ -574,12 +590,14 @@ impl ProofSuite for Ed25519Signature2018 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
         sign(
             document,
             options,
+            resolver,
             key,
             "Ed25519Signature2018",
             Algorithm::EdDSA,
@@ -591,12 +609,14 @@ impl ProofSuite for Ed25519Signature2018 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         prepare(
             document,
             options,
+            resolver,
             public_key,
             "Ed25519Signature2018",
             Algorithm::EdDSA,
@@ -629,12 +649,14 @@ impl ProofSuite for EcdsaSecp256k1Signature2019 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
         sign(
             document,
             options,
+            resolver,
             key,
             "EcdsaSecp256k1Signature2019",
             Algorithm::ES256K,
@@ -646,12 +668,14 @@ impl ProofSuite for EcdsaSecp256k1Signature2019 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         prepare(
             document,
             options,
+            resolver,
             public_key,
             "EcdsaSecp256k1Signature2019",
             Algorithm::ES256K,
@@ -684,6 +708,7 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -708,6 +733,7 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -764,6 +790,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -794,6 +821,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -862,6 +890,7 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -891,6 +920,7 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -960,6 +990,7 @@ impl ProofSuite for Eip712Signature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -991,6 +1022,7 @@ impl ProofSuite for Eip712Signature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1081,6 +1113,7 @@ impl ProofSuite for EthereumEip712Signature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1120,6 +1153,7 @@ impl ProofSuite for EthereumEip712Signature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1223,6 +1257,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1256,6 +1291,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1374,6 +1410,7 @@ impl ProofSuite for TezosSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1409,6 +1446,7 @@ impl ProofSuite for TezosSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1512,6 +1550,7 @@ impl ProofSuite for SolanaSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1534,6 +1573,7 @@ impl ProofSuite for SolanaSignature2021 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1599,12 +1639,14 @@ impl ProofSuite for EcdsaSecp256r1Signature2019 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
         sign(
             document,
             options,
+            resolver,
             key,
             "EcdsaSecp256r1Signature2019",
             Algorithm::ES256,
@@ -1616,12 +1658,14 @@ impl ProofSuite for EcdsaSecp256r1Signature2019 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         prepare(
             document,
             options,
+            resolver,
             public_key,
             "EcdsaSecp256r1Signature2019",
             Algorithm::ES256,
@@ -1655,6 +1699,7 @@ impl ProofSuite for JsonWebSignature2020 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1672,6 +1717,7 @@ impl ProofSuite for JsonWebSignature2020 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1789,6 +1835,7 @@ impl JsonWebSignature2020 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::did::example::DIDExample;
     use crate::jsonld::CREDENTIALS_V1_CONTEXT;
 
     struct ExampleDocument;
@@ -1833,8 +1880,9 @@ mod tests {
             verification_method: Some(URI::String(vm)),
             ..Default::default()
         };
+        let resolver = DIDExample;
         let doc = ExampleDocument;
-        let _proof = LinkedDataProofs::sign(&doc, &issue_options, &key, None)
+        let _proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &key, None)
             .await
             .unwrap();
     }
@@ -1850,7 +1898,8 @@ mod tests {
             ..Default::default()
         };
         let doc = ExampleDocument;
-        let proof = LinkedDataProofs::sign(&doc, &issue_options, &key, None)
+        let resolver = DIDExample;
+        let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &key, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string(&proof).unwrap());
@@ -1869,7 +1918,8 @@ mod tests {
             ..Default::default()
         };
         let doc = ExampleDocument;
-        let proof = LinkedDataProofs::sign(&doc, &issue_options, &key, None)
+        let resolver = DIDExample;
+        let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &key, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string(&proof).unwrap());
@@ -1886,7 +1936,8 @@ mod tests {
             ..Default::default()
         };
         let doc = ExampleDocument;
-        let _proof = LinkedDataProofs::sign(&doc, &issue_options, &key)
+        let resolver = DIDExample;
+        let _proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &key)
             .await
             .unwrap();
     }

--- a/src/zcap.rs
+++ b/src/zcap.rs
@@ -149,6 +149,7 @@ where
         &self,
         jwk: &JWK,
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         capability_chain: &[&str],
     ) -> Result<Proof, Error> {
         let mut ps = Map::<String, Value>::new();
@@ -156,7 +157,7 @@ where
             "capabilityChain".into(),
             serde_json::to_value(capability_chain)?,
         );
-        LinkedDataProofs::sign(self, options, jwk, Some(ps)).await
+        LinkedDataProofs::sign(self, options, resolver, jwk, Some(ps)).await
     }
 
     /// Prepare to generate a linked data proof. Returns the signing input for the caller to sign
@@ -165,6 +166,7 @@ where
         &self,
         public_key: &JWK,
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         capability_chain: &[&str],
     ) -> Result<ProofPreparation, Error> {
         let mut ps = Map::<String, Value>::new();
@@ -172,7 +174,7 @@ where
             "capabilityChain".into(),
             serde_json::to_value(capability_chain)?,
         );
-        LinkedDataProofs::prepare(self, options, public_key, Some(ps)).await
+        LinkedDataProofs::prepare(self, options, resolver, public_key, Some(ps)).await
     }
 
     pub fn set_proof(self, proof: Proof) -> Self {
@@ -287,11 +289,12 @@ where
         &self,
         jwk: &JWK,
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         target: &URI,
     ) -> Result<Proof, Error> {
         let mut ps = Map::<String, Value>::new();
         ps.insert("capability".into(), serde_json::to_value(target)?);
-        LinkedDataProofs::sign(self, options, jwk, Some(ps)).await
+        LinkedDataProofs::sign(self, options, resolver, jwk, Some(ps)).await
     }
 
     /// Prepare to generate a linked data proof. Returns the signing input for the caller to sign
@@ -300,11 +303,12 @@ where
         &self,
         public_key: &JWK,
         options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
         target: &URI,
     ) -> Result<ProofPreparation, Error> {
         let mut ps = Map::<String, Value>::new();
         ps.insert("capability".into(), serde_json::to_value(target)?);
-        LinkedDataProofs::prepare(self, options, public_key, Some(ps)).await
+        LinkedDataProofs::prepare(self, options, resolver, public_key, Some(ps)).await
     }
 
     pub fn set_proof(self, proof: Proof) -> Self {
@@ -496,12 +500,16 @@ mod tests {
             proof_purpose: Some(ProofPurpose::CapabilityInvocation),
             ..Default::default()
         };
-        let signed_del = del
-            .clone()
-            .set_proof(del.generate_proof(&alice, &ldpo_alice, &[]).await.unwrap());
-        let signed_inv = inv
-            .clone()
-            .set_proof(inv.generate_proof(&bob, &ldpo_bob, &del.id).await.unwrap());
+        let signed_del = del.clone().set_proof(
+            del.generate_proof(&alice, &ldpo_alice, &dk, &[])
+                .await
+                .unwrap(),
+        );
+        let signed_inv = inv.clone().set_proof(
+            inv.generate_proof(&bob, &ldpo_bob, &dk, &del.id)
+                .await
+                .unwrap(),
+        );
 
         // happy path
         let s_d_v = signed_del.verify(None, &dk).await;
@@ -535,7 +543,7 @@ mod tests {
             ..del.clone()
         };
         let proof = wrong_del
-            .generate_proof(&alice, &ldpo_alice, &[])
+            .generate_proof(&alice, &ldpo_alice, &dk, &[])
             .await
             .unwrap();
         let signed_wrong_del = wrong_del.set_proof(proof);

--- a/vc-test/src/main.rs
+++ b/vc-test/src/main.rs
@@ -1,3 +1,4 @@
+use ssi::did::example::DIDExample;
 use ssi::jwk::JWTKeys;
 use ssi::jwk::JWK;
 use ssi::vc::Credential;
@@ -25,6 +26,7 @@ fn take_key(keys: &JWTKeys) -> &JWK {
 }
 
 async fn generate_jwt(data: &String, keys: &JWTKeys, aud: &String, sign: bool) -> String {
+    let resolver = DIDExample;
     let vc = Credential::from_json_unsigned(data).unwrap();
     let options = LinkedDataProofOptions {
         domain: Some(aud.to_string()),
@@ -33,7 +35,7 @@ async fn generate_jwt(data: &String, keys: &JWTKeys, aud: &String, sign: bool) -
         ..Default::default()
     };
     let jwk_opt = if sign { Some(take_key(keys)) } else { None };
-    vc.generate_jwt(jwk_opt, &options).await.unwrap()
+    vc.generate_jwt(jwk_opt, &options, &resolver).await.unwrap()
 }
 
 fn decode_jwt_unsigned(data: &String) -> String {
@@ -48,6 +50,7 @@ fn generate_presentation(data: &String) -> String {
 }
 
 async fn generate_jwt_presentation(data: &String, keys: &JWTKeys, aud: &String) -> String {
+    let resolver = DIDExample;
     let vp = Presentation::from_json_unsigned(data).unwrap();
     let options = LinkedDataProofOptions {
         domain: Some(aud.to_string()),
@@ -57,7 +60,9 @@ async fn generate_jwt_presentation(data: &String, keys: &JWTKeys, aud: &String) 
         ..Default::default()
     };
     let jwk = take_key(keys);
-    vp.generate_jwt(Some(jwk), &options).await.unwrap()
+    vp.generate_jwt(Some(jwk), &options, &resolver)
+        .await
+        .unwrap()
 }
 
 fn read_file(filename: &String) -> String {


### PR DESCRIPTION
Factored out of #253. Changes function type signatures to pass DID resolver to linked data proof issue and prepare functions.