### PR TITLE
RevocationList2020 and credentialStatus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ p256 = { version = "0.8", optional = true, features = ["zeroize", "ecdsa"] }
 ssi-contexts = { version = "0.1.0", path = "contexts/" }
 ripemd160 = { version = "0.9", optional = true }
 sshkeys = "0.3"
+reqwest = { version = "0.11", features = ["json"] }
+flate2 = "1.0"
+bitvec = "0.20"
 
 # dependencies for json-ld
 log = "^0.4"
@@ -75,7 +78,6 @@ mown = "^0.2"
 #iref = "^1.4.3"
 #futures = "^0.3"
 once_cell = "^1.4"
-reqwest = { version = "^0.10", optional = true }
 langtag = "^0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/examples/issue-revocation-list.rs
+++ b/examples/issue-revocation-list.rs
@@ -1,0 +1,38 @@
+// To generate test vectors:
+// cargo run --example issue-revocation-list > tests/revocationList.json
+
+#[async_std::main]
+async fn main() {
+    let key_str = include_str!("../tests/rsa2048-2020-08-25.json");
+    use ssi::vc::{Credential, Issuer, URI};
+    use std::convert::TryFrom;
+    let key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
+    let resolver = &ssi::did::example::DIDExample;
+    use ssi::revocation::{
+        RevocationList2020, RevocationList2020Credential, RevocationList2020Subject,
+    };
+    let mut rl = RevocationList2020::default();
+    rl.set_status(1, true).unwrap();
+    let rl_vc = RevocationList2020Credential {
+        issuer: Issuer::URI(URI::String("did:example:foo".to_string())),
+        id: URI::String("https://example.test/revocationList.json".to_string()),
+        credential_subject: RevocationList2020Subject::RevocationList2020(rl),
+        more_properties: serde_json::Value::Null,
+    };
+    let mut vc = Credential::try_from(rl_vc).unwrap();
+    vc.issuance_date = Some(ssi::vc::VCDateTime::from(ssi::ldp::now_ms()));
+    let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
+    let verification_method = "did:example:foo#key1".to_string();
+    proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
+    let proof = vc
+        .generate_proof(&key, &proof_options, resolver)
+        .await
+        .unwrap();
+    vc.add_proof(proof);
+    let result = vc.verify(None, resolver).await;
+    if result.errors.len() > 0 {
+        panic!("verify failed: {:#?}", result);
+    }
+    let stdout_writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(stdout_writer, &vc).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod keccak_hash;
 pub mod ldp;
 pub mod one_or_many;
 pub mod rdf;
+pub mod revocation;
 #[cfg(feature = "ripemd160")]
 pub mod ripemd;
 pub mod soltx;

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -1,0 +1,488 @@
+use crate::did_resolve::DIDResolver;
+use crate::jsonld::REVOCATION_LIST_2020_V1_CONTEXT;
+use crate::one_or_many::OneOrMany;
+use crate::vc::{Credential, CredentialStatus, Issuer, VerificationResult, URI};
+use async_trait::async_trait;
+use bitvec::prelude::Lsb0;
+use bitvec::slice::BitSlice;
+use bitvec::vec::BitVec;
+use core::convert::TryFrom;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+type URL = String;
+
+/// Minimum length of a revocation list bitstring
+/// <https://w3c-ccg.github.io/vc-status-rl-2020/#revocation-bitstring-length>
+pub const MIN_BITSTRING_LENGTH: usize = 131072;
+
+const EMPTY_RLIST: &str = "H4sIAAAAAAAA_-3AMQEAAADCoPVPbQwfKAAAAAAAAAAAAAAAAAAAAOBthtJUqwBAAAA";
+
+/// Credential Status object for use in a Verifiable Credential.
+/// <https://w3c-ccg.github.io/vc-status-rl-2020/#revocationlist2020status>
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RevocationList2020Status {
+    /// URL for status information of the verifiable credential - but not the URL of the revocation
+    /// list.
+    pub id: URI,
+    /// Index of this credential's status in the revocation list credential
+    pub revocation_list_index: RevocationListIndex,
+    /// URL to a [RevocationList2020Credential]
+    pub revocation_list_credential: URL,
+}
+
+/// Integer identifying a bit position of the revocation status of a verifiable credential in a
+/// revocation list, e.g. in a [RevocationList2020].
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
+pub struct RevocationListIndex(usize);
+
+/// Verifiable Credential of type RevocationList2020Credential.
+/// <https://w3c-ccg.github.io/vc-status-rl-2020/#revocationlist2020credential>
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RevocationList2020Credential {
+    pub id: URI,
+    pub issuer: Issuer,
+    pub credential_subject: RevocationList2020Subject,
+    #[serde(flatten)]
+    pub more_properties: Value,
+}
+
+/// [Credential subject](https://www.w3.org/TR/vc-data-model/#credential-subject) of a [RevocationList2020Credential]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+pub enum RevocationList2020Subject {
+    RevocationList2020(RevocationList2020),
+}
+
+/// Credential subject of type RevocationList2020, expected to be used in a Verifiable Credential of type [RevocationList2020Credential]
+/// <https://w3c-ccg.github.io/vc-status-rl-2020/#revocationlist2020credential>
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RevocationList2020 {
+    pub encoded_list: EncodedList,
+    #[serde(flatten)]
+    pub more_properties: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct EncodedList(pub String);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+pub enum RevocationSubject {
+    RevocationList2020(RevocationList2020),
+}
+
+/// A decoded [revocation list][EncodedList].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct List(pub Vec<u8>);
+
+impl TryFrom<String> for RevocationListIndex {
+    type Error = std::num::ParseIntError;
+    fn try_from(string: String) -> Result<Self, Self::Error> {
+        Ok(Self(string.parse()?))
+    }
+}
+
+impl From<RevocationListIndex> for String {
+    fn from(idx: RevocationListIndex) -> String {
+        idx.0.to_string()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum SetStatusError {
+    #[error("Encode list: {0}")]
+    Encode(#[from] EncodeListError),
+    #[error("Decode list: {0}")]
+    Decode(#[from] DecodeListError),
+    #[error("Out of bounds: bitstring index {0} but length is {1}")]
+    OutOfBounds(usize, usize),
+    #[error("Revocation list bitstring is too large for BitVec: {0}")]
+    ListTooLarge(usize),
+    #[error("Revocation list bitstring is too small: {0}. Minimum: {1}")]
+    ListTooSmall(usize, usize),
+}
+
+impl RevocationList2020 {
+    /// Set the revocation status for a given index in the list.
+    pub fn set_status(&mut self, index: usize, revoked: bool) -> Result<(), SetStatusError> {
+        let mut list = List::try_from(&self.encoded_list)?;
+        let bitstring_len = list.0.len() * 8;
+        let mut bitstring = BitVec::<Lsb0, u8>::try_from_vec(list.0)
+            .map_err(|_| SetStatusError::ListTooLarge(bitstring_len))?;
+        if bitstring_len < MIN_BITSTRING_LENGTH {
+            return Err(SetStatusError::ListTooSmall(
+                bitstring_len,
+                MIN_BITSTRING_LENGTH,
+            ));
+        }
+        if let Some(mut bitref) = bitstring.get_mut(index) {
+            *bitref = revoked;
+        } else {
+            return Err(SetStatusError::OutOfBounds(index, bitstring_len));
+        }
+        list.0 = bitstring.into_vec();
+        self.encoded_list = EncodedList::try_from(&list)?;
+        Ok(())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ListIterDecodeError {
+    #[error("Unable to reference indexes: {0}")]
+    BitSpan(#[from] bitvec::ptr::BitSpanError<u8>),
+    #[error("Revocation list bitstring is too small: {0}. Minimum: {1}")]
+    ListTooSmall(usize, usize),
+}
+
+impl List {
+    /// Get an array of indices in the revocation list for credentials that are revoked.
+    pub fn iter_revoked_indexes(
+        &self,
+    ) -> Result<bitvec::slice::IterOnes<Lsb0, u8>, ListIterDecodeError> {
+        let bitstring = BitSlice::<Lsb0, u8>::from_slice(&self.0[..])?;
+        if bitstring.len() < MIN_BITSTRING_LENGTH {
+            return Err(ListIterDecodeError::ListTooSmall(
+                bitstring.len(),
+                MIN_BITSTRING_LENGTH,
+            ));
+        }
+        Ok(bitstring.iter_ones())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DecodeListError {
+    #[error("Base64url: {0}")]
+    Build(#[from] base64::DecodeError),
+    #[error("Decompression: {0}")]
+    Decompress(#[from] std::io::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum EncodeListError {
+    #[error("Compression: {0}")]
+    Compress(#[from] std::io::Error),
+}
+
+impl Default for EncodedList {
+    /// Generate a 16KB list of zeros.
+    fn default() -> Self {
+        Self(EMPTY_RLIST.to_string())
+    }
+}
+
+impl TryFrom<&EncodedList> for List {
+    type Error = DecodeListError;
+    fn try_from(encoded_list: &EncodedList) -> Result<Self, Self::Error> {
+        let string = &encoded_list.0;
+        let bytes = base64::decode_config(string, base64::URL_SAFE)?;
+        let mut data = Vec::new();
+        use flate2::bufread::GzDecoder;
+        use std::io::Read;
+        GzDecoder::new(bytes.as_slice()).read_to_end(&mut data)?;
+        Ok(Self(data))
+        // TODO: streaming decode the revocation list, for less memory use for large bitvecs.
+    }
+}
+
+impl TryFrom<&List> for EncodedList {
+    type Error = EncodeListError;
+    fn try_from(list: &List) -> Result<Self, Self::Error> {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+        let mut e = GzEncoder::new(Vec::new(), Compression::default());
+        e.write_all(&list.0)?;
+        let bytes = e.finish()?;
+        let string = base64::encode_config(bytes, base64::URL_SAFE_NO_PAD);
+        Ok(EncodedList(string))
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl CredentialStatus for RevocationList2020Status {
+    /// Validate a credential's revocation status according to [Revocation List 2020](https://w3c-ccg.github.io/vc-status-rl-2020/#validate-algorithm).
+    async fn check(
+        &self,
+        credential: &Credential,
+        resolver: &dyn DIDResolver,
+    ) -> VerificationResult {
+        let mut result = VerificationResult::new();
+        // TODO: prefix errors or change return type
+        let issuer_id = match &credential.issuer {
+            Some(issuer) => issuer.get_id().clone(),
+            None => {
+                return result.with_error("Credential is missing issuer".to_string());
+            }
+        };
+        if !credential
+            .context
+            .contains_uri(REVOCATION_LIST_2020_V1_CONTEXT)
+        {
+            // TODO: support JSON-LD credentials defining the terms elsewhere.
+            return result.with_error(format!(
+                "Missing expected context URI {} for RevocationList2020",
+                REVOCATION_LIST_2020_V1_CONTEXT
+            ));
+        }
+        if self.id == URI::String(self.revocation_list_credential.clone()) {
+            return result.with_error(format!(
+                "Expected revocationListCredential to be different from status id: {}",
+                self.id
+            ));
+        }
+        let revocation_list_credential =
+            match load_credential(&self.revocation_list_credential).await {
+                Ok(credential) => credential,
+                Err(e) => {
+                    return result.with_error(format!(
+                        "Unable to fetch revocation list credential: {}",
+                        e.to_string()
+                    ));
+                }
+            };
+        let list_issuer_id = match &revocation_list_credential.issuer {
+            Some(issuer) => issuer.get_id().clone(),
+            None => {
+                return result.with_error(format!("Revocation list credential is missing issuer"));
+            }
+        };
+        if issuer_id != list_issuer_id {
+            return result.with_error(format!(
+                "Revocation list issuer mismatch. Credential: {}, Revocation list: {}",
+                issuer_id, list_issuer_id
+            ));
+        }
+
+        match revocation_list_credential.validate() {
+            Err(e) => {
+                return result.with_error(format!("Invalid list credential: {}", e.to_string()));
+            }
+            Ok(()) => {}
+        }
+        let vc_result = revocation_list_credential.verify(None, resolver).await;
+        for warning in vc_result.warnings {
+            result
+                .warnings
+                .push(format!("Revocation list: {}", warning));
+        }
+        for error in vc_result.errors {
+            result.errors.push(format!("Revocation list: {}", error));
+            return result;
+        }
+        // Note: vc_result.checks is not checked here. It is assumed that default checks passed.
+
+        let revocation_list_credential =
+            match RevocationList2020Credential::try_from(revocation_list_credential) {
+                Ok(credential) => credential,
+                Err(e) => {
+                    return result.with_error(format!(
+                        "Unable to parse revocation list credential: {}",
+                        e.to_string()
+                    ));
+                }
+            };
+        if revocation_list_credential.id != URI::String(self.revocation_list_credential.to_string())
+        {
+            return result.with_error(format!(
+                "Revocation list credential id mismatch. revocationListCredential: {}, id: {}",
+                self.revocation_list_credential, revocation_list_credential.id
+            ));
+        }
+        let RevocationList2020Subject::RevocationList2020(revocation_list) =
+            revocation_list_credential.credential_subject;
+
+        let list = match List::try_from(&revocation_list.encoded_list) {
+            Ok(list) => list,
+            Err(e) => {
+                return result.with_error(format!(
+                    "Unable to decode revocation list: {}",
+                    e.to_string()
+                ))
+            }
+        };
+        let credential_index = self.revocation_list_index.0;
+        use bitvec::prelude::*;
+        let bitstring = match BitVec::<Lsb0, u8>::try_from_vec(list.0) {
+            Ok(bitstring) => bitstring,
+            Err(list) => {
+                return result.with_error(format!(
+                    "Revocation list is too large for bitvec: {}",
+                    list.len()
+                ))
+            }
+        };
+        let revoked = match bitstring.get(credential_index) {
+            Some(bitref) => *bitref,
+            None => false,
+        };
+        if revoked {
+            return result.with_error("Credential is revoked.".to_string());
+        }
+        result
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum LoadResourceError {
+    #[error("Error building HTTP client: {0}")]
+    Build(reqwest::Error),
+    #[error("Error sending HTTP request: {0}")]
+    Request(reqwest::Error),
+    #[error("Parse error: {0}")]
+    Response(String),
+    #[error("Not found")]
+    NotFound,
+    #[error("HTTP error: {0}")]
+    HTTP(String),
+}
+
+#[derive(Error, Debug)]
+pub enum LoadCredentialError {
+    #[error("Unable to load resource: {0}")]
+    Load(#[from] LoadResourceError),
+    #[error("Error reading HTTP response: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+async fn load_resource(url: &str) -> Result<Vec<u8>, LoadCredentialError> {
+    #[cfg(test)]
+    match url {
+        crate::vc::tests::EXAMPLE_REVOCATION_2020_LIST_URL => {
+            return Ok(crate::vc::tests::EXAMPLE_REVOCATION_2020_LIST.to_vec());
+        }
+        _ => {}
+    }
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        "User-Agent",
+        reqwest::header::HeaderValue::from_static(crate::USER_AGENT),
+    );
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .map_err(|e| LoadResourceError::Build(e))?;
+    let accept = "application/json".to_string();
+    let resp = client
+        .get(url)
+        .header("Accept", accept)
+        .send()
+        .await
+        .map_err(|e| LoadResourceError::Request(e))?;
+    if let Err(err) = resp.error_for_status_ref() {
+        if err.status() == Some(reqwest::StatusCode::NOT_FOUND) {
+            Err(LoadResourceError::NotFound)?;
+        }
+        Err(LoadResourceError::HTTP(err.to_string()))?;
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| LoadResourceError::Response(e.to_string()))?
+        .to_vec();
+    Ok(bytes)
+}
+
+/// Fetch a credential from a HTTP(S) URL.
+/// The resulting verifiable credential is not yet validated or verified.
+pub async fn load_credential(url: &str) -> Result<Credential, LoadCredentialError> {
+    let data = load_resource(url).await?;
+    // TODO: support JWT-VC
+    let credential: Credential = serde_json::from_slice(&data)?;
+    Ok(credential)
+}
+
+#[derive(Error, Debug)]
+pub enum CredentialConversionError {
+    #[error("Conversion to JSON: {0}")]
+    ToValue(serde_json::Error),
+    #[error("Conversion from JSON: {0}")]
+    FromValue(serde_json::Error),
+    #[error("Missing expected URI in @context: {0}")]
+    MissingContext(&'static str),
+    #[error("Missing expected type: {0}. Found: {0:?}")]
+    MissingType(&'static str, OneOrMany<String>),
+    #[error("Missing issuer")]
+    MissingIssuer,
+}
+
+/// Convert Credential to a [RevocationList2020Credential], while validating it.
+// https://w3c-ccg.github.io/vc-status-rl-2020/#validate-algorithm
+impl TryFrom<Credential> for RevocationList2020Credential {
+    type Error = CredentialConversionError;
+    fn try_from(credential: Credential) -> Result<Self, Self::Error> {
+        if !credential
+            .context
+            .contains_uri(REVOCATION_LIST_2020_V1_CONTEXT)
+        {
+            return Err(CredentialConversionError::MissingContext(
+                REVOCATION_LIST_2020_V1_CONTEXT,
+            ));
+        }
+        if !credential
+            .type_
+            .contains(&"RevocationList2020Credential".to_string())
+        {
+            return Err(CredentialConversionError::MissingType(
+                "RevocationList2020Credential",
+                credential.type_,
+            ));
+        }
+        let credential =
+            serde_json::to_value(credential).map_err(|e| CredentialConversionError::ToValue(e))?;
+        let credential = serde_json::from_value(credential)
+            .map_err(|e| CredentialConversionError::FromValue(e))?;
+        Ok(credential)
+    }
+}
+
+impl TryFrom<RevocationList2020Credential> for Credential {
+    type Error = CredentialConversionError;
+    fn try_from(credential: RevocationList2020Credential) -> Result<Self, Self::Error> {
+        let mut credential =
+            serde_json::to_value(credential).map_err(|e| CredentialConversionError::ToValue(e))?;
+        use crate::vc::DEFAULT_CONTEXT;
+        use serde_json::json;
+        credential["@context"] = json!([DEFAULT_CONTEXT, REVOCATION_LIST_2020_V1_CONTEXT]);
+        credential["type"] = json!(["VerifiableCredential", "RevocationList2020Credential"]);
+        let credential = serde_json::from_value(credential)
+            .map_err(|e| CredentialConversionError::FromValue(e))?;
+        Ok(credential)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn default_list() {
+        let list = List(vec![0; MIN_BITSTRING_LENGTH / 8]);
+        let revoked_indexes = list.iter_revoked_indexes().unwrap().collect::<Vec<usize>>();
+        let empty: Vec<usize> = Vec::new();
+        assert_eq!(revoked_indexes, empty);
+        let el = EncodedList::try_from(&list).unwrap();
+        assert_eq!(EncodedList::default(), el);
+        let decoded_list = List::try_from(&el).unwrap();
+        assert_eq!(decoded_list, list);
+    }
+
+    #[test]
+    fn set_status() {
+        let mut rl = RevocationList2020::default();
+        rl.set_status(1, true).unwrap();
+        rl.set_status(5, true).unwrap();
+        let decoded_list = List::try_from(&rl.encoded_list).unwrap();
+        let revoked_indexes = decoded_list
+            .iter_revoked_indexes()
+            .unwrap()
+            .collect::<Vec<usize>>();
+        assert_eq!(revoked_indexes, vec![1, 5]);
+    }
+}

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -121,6 +121,19 @@ pub enum Issuer {
     Object(ObjectWithId),
 }
 
+impl Issuer {
+    /// Get the issuer's URI.
+    pub fn get_id(self: &Self) -> &str {
+        match self {
+            Self::URI(URI::String(uri)) => uri,
+            Self::Object(ObjectWithId {
+                id: URI::String(uri),
+                ..
+            }) => uri,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectWithId {
@@ -1001,11 +1014,7 @@ impl Credential {
             Some(vm) => vec![vm.to_string()],
             None => {
                 if let Some(ref issuer) = self.issuer {
-                    let issuer_uri = match issuer.clone() {
-                        Issuer::URI(uri) => uri,
-                        Issuer::Object(object_with_id) => object_with_id.id,
-                    };
-                    let URI::String(issuer_did) = issuer_uri;
+                    let issuer_did = issuer.get_id();
                     // https://w3c.github.io/did-core/#assertion
                     // assertionMethod is the verification relationship usually used for issuing
                     // VCs.

--- a/tests/revocationList.json
+++ b/tests/revocationList.json
@@ -1,0 +1,27 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/vc-revocation-list-2020/v1"
+  ],
+  "id": "https://example.test/revocationList.json",
+  "type": [
+    "VerifiableCredential",
+    "RevocationList2020Credential"
+  ],
+  "credentialSubject": {
+    "type": "RevocationList2020",
+    "encodedList": "H4sIAAAAAAAA_-3AMQ0AAAACIGf_0MbwgQYAAAAAAAAAAAAAAAAAAAB4G7mHB0sAQAAA"
+  },
+  "issuer": "did:example:foo",
+  "issuanceDate": "2021-08-31T20:51:49.266Z",
+  "proof": {
+    "@context": [
+      "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
+    ],
+    "type": "JsonWebSignature2020",
+    "proofPurpose": "assertionMethod",
+    "verificationMethod": "did:example:foo#key1",
+    "created": "2021-08-31T20:51:49.266Z",
+    "jws": "eyJhbGciOiJQUzI1NiIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..gY3U0xPMcT9dY7ZQCd-Eb6VuW16wN6YmvDmGIVZgyeqNfKVsrdl56eMjC1O0dnflYqe8UP67E3bBS03wzIpFtIxm1BffxXOeX_mEiXOL5eTiA0w28fOIp8zbyQUvtCu14dQC3xkw8y74Z-p9OQf8f5ohUq4ODqx1uzmSaq0apjNAOjzXsNpbZKpTlHm7qyo_AEhcCYDCLGUPEVOh6Jeo9rPrRWyG2u4IiZaMXtZ9oqleRonIMayH8X3gdBqFIMVtXG08PwIN1n1jhkbgO7xAY_Co-WBViIQUQPnzDrZcgwkTHh4xkRDgcKz2Gap2DzC9oJ5j9AJeEj-W36PPU6wGPw"
+  }
+}


### PR DESCRIPTION
Implement credentialStatus checking and [Revocation List 2020](https://w3c-ccg.github.io/vc-status-rl-2020/) verification.

Includes encoding and decoding of revocation list bitstrings.

Factored out of #272