### PR TITLE
Implement Status List 2021

### DIFF
--- a/contexts/src/lib.rs
+++ b/contexts/src/lib.rs
@@ -38,6 +38,8 @@ pub const VACCINATION_V1: &str = include_str!("../w3c-ccg-vaccination-v1.jsonld"
 pub const TRACEABILITY_V1: &str = include_str!("../w3c-ccg-traceability-v1.jsonld");
 /// <https://w3id.org/vc-revocation-list-2020/v1>
 pub const REVOCATION_LIST_2020_V1: &str = include_str!("../w3id-vc-revocation-list-2020-v1.jsonld");
+/// <https://w3id.org/vc/status-list/v1>
+pub const STATUS_LIST_2021_V1: &str = include_str!("../w3id-vc-status-list-2021-v1.jsonld");
 /// <https://demo.spruceid.com/EcdsaSecp256k1RecoverySignature2020/esrs2020-extra-0.0.jsonld>
 #[deprecated(note = "Use W3ID_ESRS2020_V2 instead")]
 pub const ESRS2020_EXTRA: &str = include_str!("../esrs2020-extra-0.0.jsonld");

--- a/contexts/update.sh
+++ b/contexts/update.sh
@@ -25,4 +25,5 @@ exec curl \
 	https://w3id.org/vdl/v1 -o w3id-vdl-v1.jsonld \
 	https://w3id.org/wallet/v1 -o w3id-wallet-v1.jsonld \
 	https://w3id.org/zcap/v1 -o w3id-zcap-v1.jsonld \
+	https://w3id.org/vc-revocation-list-2020/v1 -o w3id-vc-revocation-list-2020-v1.json \
 	-L

--- a/contexts/update.sh
+++ b/contexts/update.sh
@@ -26,4 +26,5 @@ exec curl \
 	https://w3id.org/wallet/v1 -o w3id-wallet-v1.jsonld \
 	https://w3id.org/zcap/v1 -o w3id-zcap-v1.jsonld \
 	https://w3id.org/vc-revocation-list-2020/v1 -o w3id-vc-revocation-list-2020-v1.json \
+	https://w3id.org/vc/status-list/2021/v1 -o w3id-vc-status-list-2021-v1.jsonld \
 	-L

--- a/contexts/w3id-vc-status-list-2021-v1.jsonld
+++ b/contexts/w3id-vc-status-list-2021-v1.jsonld
@@ -1,0 +1,55 @@
+{
+  "@context": {
+    "@protected": true,
+
+    "StatusList2021Credential": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021Credential",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name"
+      }
+    },
+
+    "StatusList2021": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "statusPurpose":
+          "https://w3id.org/vc/status-list#statusPurpose",
+        "encodedList": "https://w3id.org/vc/status-list#encodedList"
+      }
+    },
+
+    "StatusList2021Entry": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021Entry",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "statusPurpose":
+          "https://w3id.org/vc/status-list#statusPurpose",
+        "statusListIndex":
+          "https://w3id.org/vc/status-list#statusListIndex",
+        "statusListCredential": {
+          "@id":
+            "https://w3id.org/vc/status-list#statusListCredential",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/examples/issue-status-list.rs
+++ b/examples/issue-status-list.rs
@@ -1,0 +1,36 @@
+// To generate test vector:
+// cargo run --example issue-status-list > tests/statusList.json
+
+#[async_std::main]
+async fn main() {
+    let key_str = include_str!("../tests/rsa2048-2020-08-25.json");
+    use ssi::vc::{Credential, Issuer, URI};
+    use std::convert::TryFrom;
+    let key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
+    let resolver = &ssi::did::example::DIDExample;
+    use ssi::revocation::{StatusList2021, StatusList2021Credential, StatusList2021Subject};
+    let mut rl = StatusList2021::new(131072).unwrap();
+    rl.set_status(1, true).unwrap();
+    let rl_vc = StatusList2021Credential {
+        issuer: Issuer::URI(URI::String("did:example:12345".to_string())),
+        id: URI::String("https://example.com/credentials/status/3".to_string()),
+        credential_subject: StatusList2021Subject::StatusList2021(rl),
+        more_properties: serde_json::Value::Null,
+    };
+    let mut vc = Credential::try_from(rl_vc).unwrap();
+    vc.issuance_date = Some(ssi::vc::VCDateTime::from(ssi::ldp::now_ms()));
+    let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
+    let verification_method = "did:example:12345#key1".to_string();
+    proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
+    let proof = vc
+        .generate_proof(&key, &proof_options, resolver)
+        .await
+        .unwrap();
+    vc.add_proof(proof);
+    let result = vc.verify(None, resolver).await;
+    if result.errors.len() > 0 {
+        panic!("verify failed: {:#?}", result);
+    }
+    let stdout_writer = std::io::BufWriter::new(std::io::stdout());
+    serde_json::to_writer_pretty(stdout_writer, &vc).unwrap();
+}

--- a/src/did.rs
+++ b/src/did.rs
@@ -1304,6 +1304,7 @@ pub mod example {
 
     const DOC_JSON_FOO: &str = include_str!("../tests/did-example-foo.json");
     const DOC_JSON_BAR: &str = include_str!("../tests/did-example-bar.json");
+    const DOC_JSON_12345: &str = include_str!("../tests/did-example-12345.json");
 
     // For vc-test-suite
     const DOC_JSON_TEST_ISSUER: &str = include_str!("../tests/did-example-test-issuer.json");
@@ -1342,6 +1343,7 @@ pub mod example {
                 "did:example:foo" => DOC_JSON_FOO,
                 "did:example:bar" => DOC_JSON_BAR,
                 "did:example:0xab" => DOC_JSON_TEST_ISSUER,
+                "did:example:12345" => DOC_JSON_12345,
                 "did:example:ebfeb1f712ebc6f1c276e12ec21" => DOC_JSON_TEST_HOLDER,
                 _ => return (ResolutionMetadata::from_error(ERROR_NOT_FOUND), None, None),
             };

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -139,6 +139,7 @@ pub const VACCINATION_V1_CONTEXT: &str = "https://w3id.org/vaccination/v1";
 pub const TRACEABILITY_CONTEXT: &str = "https://w3id.org/traceability/v1";
 pub const REVOCATION_LIST_2020_V1_CONTEXT: &str = "https://w3id.org/vc-revocation-list-2020/v1";
 pub const BBS_V1_CONTEXT: &str = "https://w3id.org/security/bbs/v1";
+pub const STATUS_LIST_2021_V1_CONTEXT: &str = "https://w3id.org/vc/status-list/2021/v1";
 pub const EIP712SIG_V0_1_CONTEXT: &str = "https://demo.spruceid.com/ld/eip712sig-2021/v0.1.jsonld";
 pub const EIP712SIG_V1_CONTEXT: &str = "https://w3id.org/security/suites/eip712sig-2021/v1";
 pub const PRESENTATION_SUBMISSION_V1_CONTEXT: &str =
@@ -268,6 +269,12 @@ lazy_static! {
         let iri = Iri::new(REVOCATION_LIST_2020_V1_CONTEXT).unwrap();
         RemoteDocument::new(doc, iri)
     };
+    pub static ref STATUS_LIST_2021_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
+        let jsonld = ssi_contexts::STATUS_LIST_2021_V1;
+        let doc = json::parse(jsonld).unwrap();
+        let iri = Iri::new(STATUS_LIST_2021_V1_CONTEXT).unwrap();
+        RemoteDocument::new(doc, iri)
+    };
     pub static ref EIP712SIG_V0_1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
         let jsonld = ssi_contexts::EIP712SIG_V0_1;
         let doc = json::parse(jsonld).unwrap();
@@ -349,6 +356,7 @@ impl Loader for StaticLoader {
                 REVOCATION_LIST_2020_V1_CONTEXT => {
                     Ok(REVOCATION_LIST_2020_V1_CONTEXT_DOCUMENT.clone())
                 }
+                STATUS_LIST_2021_V1_CONTEXT => Ok(STATUS_LIST_2021_V1_CONTEXT_DOCUMENT.clone()),
                 EIP712SIG_V0_1_CONTEXT => Ok(EIP712SIG_V0_1_CONTEXT_DOCUMENT.clone()),
                 BBS_V1_CONTEXT => Ok(BBS_V1_CONTEXT_DOCUMENT.clone()),
                 EIP712SIG_V1_CONTEXT => Ok(EIP712SIG_V1_CONTEXT_DOCUMENT.clone()),

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -76,6 +76,7 @@ pub struct RevocationList2020 {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct EncodedList(pub String);
 
+#[deprecated(note = "Use RevocationList2020Subject instead")]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "type")]
 pub enum RevocationSubject {

--- a/tests/did-example-12345.json
+++ b/tests/did-example-12345.json
@@ -1,0 +1,25 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:example:12345",
+  "verificationMethod": [
+    {
+      "id": "did:example:12345#key1",
+      "type": "JsonWebKey2020",
+      "controller": "did:example:12345",
+      "publicKeyJwk": {
+        "kty": "RSA",
+        "n": "sbX82NTV6IylxCh7MfV4hlyvaniCajuP97GyOqSvTmoEdBOflFvZ06kR_9D6ctt45Fk6hskfnag2GG69NALVH2o4RCR6tQiLRpKcMRtDYE_thEmfBvDzm_VVkOIYfxu-Ipuo9J_S5XDNDjczx2v-3oDh5-CIHkU46hvFeCvpUS-L8TJSbgX0kjVk_m4eIb9wh63rtmD6Uz_KBtCo5mmR4TEtcLZKYdqMp3wCjN-TlgHiz_4oVXWbHUefCEe8rFnX1iQnpDHU49_SaXQoud1jCaexFn25n-Aa8f8bc5Vm-5SeRwidHa6ErvEhTvf1dz6GoNPp2iRvm-wJ1gxwWJEYPQ",
+        "e": "AQAB"
+      }
+    }
+  ],
+  "assertionMethod": [
+    "did:example:12345#key1"
+  ],
+  "authentication": [
+    "did:example:12345#key1"
+  ]
+}

--- a/tests/statusList.json
+++ b/tests/statusList.json
@@ -1,0 +1,27 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/vc/status-list/2021/v1"
+  ],
+  "id": "https://example.com/credentials/status/3",
+  "type": [
+    "VerifiableCredential",
+    "StatusList2021Credential"
+  ],
+  "credentialSubject": {
+    "type": "StatusList2021",
+    "encodedList": "H4sIAAAAAAAA_-3AMQ0AAAACIGf_0MbwgQYAAAAAAAAAAAAAAAAAAAB4G7mHB0sAQAAA"
+  },
+  "issuer": "did:example:12345",
+  "issuanceDate": "2022-04-12T21:48:38.044Z",
+  "proof": {
+    "@context": [
+      "https://w3id.org/security/suites/jws-2020/v1"
+    ],
+    "type": "JsonWebSignature2020",
+    "proofPurpose": "assertionMethod",
+    "verificationMethod": "did:example:12345#key1",
+    "created": "2022-04-12T21:48:38.044Z",
+    "jws": "eyJhbGciOiJQUzI1NiIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..feXmGMLFgZ5j0dvUUy2IM43y3TOr_2KfoWAyAPScQByGIb0LNJNJgFRK69XMdAvBkR7ZjVcXq509y7aLJh3Up_mDL6xIW39pVSKi2K7eUAsLzrl-pVNghKUztZ8-2VrnfJD2S64WcjSb2MR3tFuAEZrKzGUE5-loRPjT4GkPv4xQxQjujk9gZDdrOFpZemI5cGaPR5tvelZeXdqpoapzPWU19v4j_d8QQCSO1P5eZfcNXlE953Z17Wfu1G0-jVNc-cf_JhOWImxuWb4d30gHeh3y7tqU2fdgHMkO9VaRD-dNYD1RByLTgkfLFhKtd5Ikag-S0jz7ZBCFTps0VjHIDQ"
+  }
+}


### PR DESCRIPTION
Implement [Status List 2021](https://w3c-ccg.github.io/vc-status-list-2021/) credential status check, similar to [Revocation List 2020](https://w3c-ccg.github.io/vc-status-rl-2020/) (#273).

- [x] Test - wait for text vector? https://github.com/w3c-ccg/vc-status-list-2021/issues/16 Added example script generating test vector.
- [x] Update context file for 2021 when updated in specification (https://github.com/w3c-ccg/vc-status-list-2021/issues/10)
- [x] Update to use statusPurpose and other changes: https://github.com/w3c-ccg/vc-status-list-2021/compare/abd4f1d9317dfdb343b0ebba6a61e25d25c81f53..15ee3c63555c049ce23485956be7a9544ac7edab