### PR TITLE
Add caching of successful VM resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,11 @@ p256 = { version = "0.8", optional = true, features = ["zeroize", "ecdsa"] }
 ssi-contexts = { version = "0.1.0", path = "contexts/" }
 ripemd160 = { version = "0.9", optional = true }
 sshkeys = "0.3"
-reqwest = { version = "0.11", features = ["json"] }
+# TODO enabled trust-dns feature for async resolver?
+reqwest = { version = "0.11", features = ["json", "socks"] }
 flate2 = "1.0"
 bitvec = "0.20"
+cached = "0.25"
 
 # dependencies for json-ld
 log = "^0.4"


### PR DESCRIPTION
- Not sure how to make that configurable nicely, but maybe that's something that could be put to later.
- The lack of caching is more sound but might result in many retry requests -- but I think that's more of a proxy concern.
- I haven't tested the cache.