### PR TITLE
Update Solana chain id to follow CAIP-30

### DIFF
--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -21,6 +21,9 @@ const MAINNET_DOGECOIN: &str = "1a91e3dace36e2be3bf030a65679fe82";
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-26.md
 const MAINNET_TEZOS: &str = "NetXdQprcVkpaWU";
 
+// https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-30.md
+const MAINNET_SOLANA: &str = "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ";
+
 /// did:pkh DID Method
 pub struct DIDPKH;
 
@@ -327,7 +330,7 @@ async fn resolve_sol(did: &str, account_address: String) -> ResolutionResult {
         account_address,
         chain_id: ChainId {
             namespace: "solana".to_string(),
-            reference: "".to_string(), // TODO: use CAIP-30
+            reference: MAINNET_SOLANA.to_string(),
         },
     };
     let vm_url = DIDURL {

--- a/did-pkh/tests/did-sol.jsonld
+++ b/did-pkh/tests/did-sol.jsonld
@@ -17,7 +17,7 @@
       "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
       "type": "Ed25519VerificationKey2018",
       "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-      "blockchainAccountId": "solana:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "blockchainAccountId": "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
       "publicKeyJwk": {
         "kty": "OKP",
         "crv": "Ed25519",
@@ -28,7 +28,7 @@
       "id": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
       "type": "SolanaMethod2021",
       "controller": "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-      "blockchainAccountId": "solana:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+      "blockchainAccountId": "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
       "publicKeyJwk": {
         "kty": "OKP",
         "crv": "Ed25519",

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -15,6 +15,9 @@ use ssi::did_resolve::{
 };
 use ssi::jwk::{Base64urlUInt, OctetParams, Params, JWK};
 
+// https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-30.md
+const REFERENCE_SOLANA_MAINNET: &str = "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ";
+
 /// did:sol DID Method
 pub struct DIDSol;
 
@@ -79,7 +82,7 @@ impl DIDResolver for DIDSol {
             account_address: address,
             chain_id: ChainId {
                 namespace: "solana".to_string(),
-                reference: "".to_string(), // TODO: use CAIP-30
+                reference: REFERENCE_SOLANA_MAINNET.to_string(),
             },
         };
         let vm_didurl = DIDURL {

--- a/did-sol/tests/did.jsonld
+++ b/did-sol/tests/did.jsonld
@@ -16,7 +16,7 @@
     "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#controller",
     "type": "Ed25519VerificationKey2018",
     "controller": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-    "blockchainAccountId": "solana:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+    "blockchainAccountId": "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
     "publicKeyJwk": {
       "kty": "OKP",
       "crv": "Ed25519",
@@ -26,7 +26,7 @@
     "id": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev#SolanaMethod2021",
     "type": "SolanaMethod2021",
     "controller": "did:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
-    "blockchainAccountId": "solana:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+    "blockchainAccountId": "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
     "publicKeyJwk": {
       "kty": "OKP",
       "crv": "Ed25519",

--- a/src/caip2.rs
+++ b/src/caip2.rs
@@ -63,10 +63,7 @@ impl FromStr for ChainId {
             return Err(ChainIdParseError::NamespaceTooShort);
         }
         if !separated {
-            // Allow use of deprecated/invalid pre-CAIP-30 Solana
-            if namespace != "solana" {
-                return Err(ChainIdParseError::MissingSeparator);
-            }
+            return Err(ChainIdParseError::MissingSeparator);
         }
 
         for c in chars {
@@ -97,10 +94,6 @@ impl FromStr for ChainId {
 
 impl fmt::Display for ChainId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.namespace == "solana" && self.reference == "" {
-            // Special case for backwards-compatibility
-            return write!(f, "{}", self.namespace);
-        }
         write!(f, "{}:{}", self.namespace, self.reference)
     }
 }


### PR DESCRIPTION
Follow [CAIP-30](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-30.md) in `blockchainAccountId` ([CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)) for Solana. This also fixes following [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md), which expects the chain id to consist of a namespace component and reference component, separated by a colon (":"). CAIP-10 specifies that the chain id component in an account id is specified by CAIP-2, but does not convey this in the regex. I would consider this a bug in our implementation, but suggest that CAIP-10's regex could be updated to incorporate CAIP-2.

Using a non-CAIP-2-conformant chain id in `blockchainAccountId` I don't think would have have much impact as a bug:
- It is invalid according to CAIP-2, so other implementations may reject it.
- publicKeyJwk can be used instead of blockchainAccountId since the DID encodes the public key bytes directly. Indeed, the `did:pkh` resolver/generator here adds both `publicKeyJwk` and `blockchainAccountId`, and I believe the public key JWK is sufficient for verification purposes.
- `did:pkh:sol` is going to be deprecated in favor of `did:pkh:solana`

~~I am keeping the old way for now anyway, for potential backwards-compatibility in case it is in use. But this might be removed if/when stricter CAIP-2 parsing is added.~~ Support for the old way is removed, in commits ad2653f and 5147420, because it does not seem necessary to keep it, and this would simplify #283 and #286.