### PR TITLE
Add struct for CAIP-2 chain id

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 
 use ssi::caip10::BlockchainAccountId;
+use ssi::caip2::ChainId;
 use ssi::did::{
     Context, Contexts, DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap,
     DEFAULT_CONTEXT, DIDURL,
@@ -86,7 +87,10 @@ impl DIDResolver for DIDEthr {
 
         let blockchain_account_id = BlockchainAccountId {
             account_address: address,
-            chain_id: format!("eip155:{}", chain_id),
+            chain_id: ChainId {
+                namespace: "eip155".to_string(),
+                reference: chain_id.to_string(),
+            },
         };
         let vm_didurl = DIDURL {
             did: did.to_string(),

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 
 use ssi::caip10::BlockchainAccountId;
+use ssi::caip2::ChainId;
 use ssi::did::{
     Context, Contexts, DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap,
     DEFAULT_CONTEXT, DIDURL,
@@ -14,11 +15,11 @@ use ssi::did_resolve::{
 use ssi::jwk::{Base64urlUInt, OctetParams, Params, JWK};
 
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-4.md
-const CHAIN_ID_BITCOIN_MAINNET: &str = "bip122:000000000019d6689c085ae165831e93";
-const CHAIN_ID_DOGECOIN_MAINNET: &str = "bip122:1a91e3dace36e2be3bf030a65679fe82";
+const MAINNET_BITCOIN: &str = "000000000019d6689c085ae165831e93";
+const MAINNET_DOGECOIN: &str = "1a91e3dace36e2be3bf030a65679fe82";
 
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-26.md
-const CHAIN_ID_TEZOS_MAINNET: &str = "tezos:NetXdQprcVkpaWU";
+const MAINNET_TEZOS: &str = "NetXdQprcVkpaWU";
 
 /// did:pkh DID Method
 pub struct DIDPKH;
@@ -55,7 +56,10 @@ async fn resolve_tz(did: &str, account_address: String) -> ResolutionResult {
     };
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: CHAIN_ID_TEZOS_MAINNET.to_string(),
+        chain_id: ChainId {
+            namespace: "tezos".to_string(),
+            reference: MAINNET_TEZOS.to_string(),
+        },
     };
     let mut context = BTreeMap::new();
     context.insert(
@@ -129,7 +133,10 @@ async fn resolve_eth(did: &str, account_address: String) -> ResolutionResult {
     );
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: "eip155:1".to_string(),
+        chain_id: ChainId {
+            namespace: "eip155".to_string(),
+            reference: "1".to_string(),
+        },
     };
     let vm_url = DIDURL {
         did: did.to_string(),
@@ -196,7 +203,10 @@ async fn resolve_celo(did: &str, account_address: String) -> ResolutionResult {
     );
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: "eip155:42220".to_string(),
+        chain_id: ChainId {
+            namespace: "eip155".to_string(),
+            reference: "42220".to_string(),
+        },
     };
     let vm_url = DIDURL {
         did: did.to_string(),
@@ -239,7 +249,10 @@ async fn resolve_poly(did: &str, account_address: String) -> ResolutionResult {
     );
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: "eip155:137".to_string(),
+        chain_id: ChainId {
+            namespace: "eip155".to_string(),
+            reference: "137".to_string(),
+        },
     };
     let vm_url = DIDURL {
         did: did.to_string(),
@@ -312,7 +325,10 @@ async fn resolve_sol(did: &str, account_address: String) -> ResolutionResult {
     };
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: "solana".to_string(),
+        chain_id: ChainId {
+            namespace: "solana".to_string(),
+            reference: "".to_string(), // TODO: use CAIP-30
+        },
     };
     let vm_url = DIDURL {
         did: did.to_string(),
@@ -366,7 +382,10 @@ async fn resolve_btc(did: &str, account_address: String) -> ResolutionResult {
     };
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: CHAIN_ID_BITCOIN_MAINNET.to_string(),
+        chain_id: ChainId {
+            namespace: "bip122".to_string(),
+            reference: MAINNET_BITCOIN.to_string(),
+        },
     };
     let vm_url = DIDURL {
         did: did.to_string(),
@@ -418,7 +437,10 @@ async fn resolve_doge(did: &str, account_address: String) -> ResolutionResult {
     );
     let blockchain_account_id = BlockchainAccountId {
         account_address,
-        chain_id: CHAIN_ID_DOGECOIN_MAINNET.to_string(),
+        chain_id: ChainId {
+            namespace: "bip122".to_string(),
+            reference: MAINNET_DOGECOIN.to_string(),
+        },
     };
     let vm_url = DIDURL {
         did: did.to_string(),

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 
 use ssi::caip10::BlockchainAccountId;
+use ssi::caip2::ChainId;
 use ssi::did::{
     Context, Contexts, DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap,
     DEFAULT_CONTEXT, DIDURL,
@@ -76,7 +77,10 @@ impl DIDResolver for DIDSol {
         );
         let blockchain_account_id = BlockchainAccountId {
             account_address: address,
-            chain_id: "solana".to_string(), // TODO: standardize
+            chain_id: ChainId {
+                namespace: "solana".to_string(),
+                reference: "".to_string(), // TODO: use CAIP-30
+            },
         };
         let vm_didurl = DIDURL {
             did: did.to_string(),

--- a/src/caip2.rs
+++ b/src/caip2.rs
@@ -1,0 +1,128 @@
+use std::fmt;
+use std::str::FromStr;
+
+use thiserror::Error;
+
+/// <https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md>
+#[derive(Clone, PartialEq, Hash, Debug)]
+pub struct ChainId {
+    pub namespace: String,
+    pub reference: String,
+}
+
+const NAMESPACE_MIN_LENGTH: usize = 3;
+const NAMESPACE_MAX_LENGTH: usize = 8;
+const REFERENCE_MIN_LENGTH: usize = 1;
+const REFERENCE_MAX_LENGTH: usize = 32;
+
+#[derive(Error, Debug)]
+pub enum ChainIdParseError {
+    #[error("Unexpected character in namesapce: {0}")]
+    NamespaceChar(char),
+    #[error("Namespace too long")]
+    NamespaceTooLong,
+    #[error("Namespace too long")]
+    NamespaceTooShort,
+    #[error("Unexpected character in reference: {0}")]
+    ReferenceChar(char),
+    #[error("Reference too long")]
+    ReferenceTooLong,
+    #[error("Reference too short")]
+    ReferenceTooShort,
+    #[error("Missing separator between namespace and reference")]
+    MissingSeparator,
+}
+
+impl FromStr for ChainId {
+    type Err = ChainIdParseError;
+    fn from_str(chain_id: &str) -> Result<Self, Self::Err> {
+        // namespace:   [-a-z0-9]{3,8}
+        let mut namespace = String::with_capacity(NAMESPACE_MAX_LENGTH);
+        // reference:   [-a-zA-Z0-9]{1,32}
+        let mut reference = String::with_capacity(REFERENCE_MAX_LENGTH);
+        let mut chars = chain_id.chars();
+        let mut separated = false;
+        while let Some(c) = chars.next() {
+            match c {
+                '-' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l'
+                | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y'
+                | 'z' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => {
+                    if namespace.len() >= NAMESPACE_MAX_LENGTH {
+                        return Err(ChainIdParseError::NamespaceTooLong);
+                    }
+                    namespace.push(c);
+                }
+                ':' => {
+                    separated = true;
+                    break;
+                }
+                c => return Err(ChainIdParseError::NamespaceChar(c)),
+            }
+        }
+        if namespace.len() < NAMESPACE_MIN_LENGTH {
+            return Err(ChainIdParseError::NamespaceTooShort);
+        }
+        if !separated {
+            // Allow use of deprecated/invalid pre-CAIP-30 Solana
+            if namespace != "solana" {
+                return Err(ChainIdParseError::MissingSeparator);
+            }
+        }
+
+        for c in chars {
+            match c {
+                '-' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l'
+                | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y'
+                | 'z' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L'
+                | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y'
+                | 'Z' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => {
+                    if reference.len() >= REFERENCE_MAX_LENGTH {
+                        return Err(ChainIdParseError::ReferenceTooLong);
+                    }
+                    reference.push(c);
+                }
+                c => return Err(ChainIdParseError::NamespaceChar(c)),
+            }
+        }
+        if reference.len() < REFERENCE_MIN_LENGTH {
+            return Err(ChainIdParseError::ReferenceTooShort);
+        }
+
+        Ok(Self {
+            namespace,
+            reference,
+        })
+    }
+}
+
+impl fmt::Display for ChainId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.namespace == "solana" && self.reference == "" {
+            // Special case for backwards-compatibility
+            return write!(f, "{}", self.namespace);
+        }
+        write!(f, "{}:{}", self.namespace, self.reference)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[async_std::test]
+    async fn chain_id() {
+        // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md#test-cases
+        let dummy_max_length = "chainstd:8c3444cf8970a9e41a706fab93e7a6c4";
+        let chain_id = ChainId::from_str(&dummy_max_length).unwrap();
+        assert_eq!(chain_id.to_string(), dummy_max_length);
+
+        let reference_too_long = format!("{}0", dummy_max_length);
+        ChainId::from_str(&reference_too_long).unwrap_err();
+        let reference_too_short = format!("{}:", chain_id.reference);
+        ChainId::from_str(&reference_too_short).unwrap_err();
+        let namespace_too_long = format!("0{}", dummy_max_length);
+        ChainId::from_str(&namespace_too_long).unwrap_err();
+        let namespace_too_short = format!("ch:{}", chain_id.reference);
+        ChainId::from_str(&namespace_too_short).unwrap_err();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bbs;
 pub mod blakesig;
 pub mod caip10;
+pub mod caip2;
 pub mod der;
 pub mod did;
 pub mod did_resolve;


### PR DESCRIPTION
Add a module for [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md) (chain id) with a `ChainId` struct, similar to the module for [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md) (account id) with a `BlockchainAccountId` struct.
Update the `BlockchainAccountId` struct to use the `ChainId` struct internally.

This should make it easier to operate on blockchain account and chain ids.