### PR TITLE
Verification method to JWK conversion

### DIFF
--- a/src/did.rs
+++ b/src/did.rs
@@ -1077,4 +1077,38 @@ mod tests {
         println!("{}", serde_json::to_string_pretty(&doc).unwrap());
         assert_eq!(doc.id, id);
     }
+
+    #[test]
+    fn vmm_to_jwk() {
+        // Identity: publicKeyJWK -> JWK
+        const JWK: &'static str = include_str!("../tests/ed25519-2020-10-18.json");
+        let jwk: JWK = serde_json::from_str(JWK).unwrap();
+        let pk_jwk = jwk.to_public();
+        let vmm_ed = VerificationMethodMap {
+            id: String::from("did:example:foo#key2"),
+            type_: String::from("Ed25519VerificationKey2018"),
+            controller: String::from("did:example:foo"),
+            public_key_jwk: Some(pk_jwk.clone()),
+            ..Default::default()
+        };
+        let jwk = vmm_ed.get_jwk().unwrap();
+        assert_eq!(jwk, pk_jwk);
+    }
+
+    #[test]
+    fn vmm_bs58_to_jwk() {
+        // publicKeyBase58 (deprecated) -> JWK
+        const JWK: &'static str = include_str!("../tests/ed25519-2020-10-18.json");
+        let jwk: JWK = serde_json::from_str(JWK).unwrap();
+        let pk_jwk = jwk.to_public();
+        let vmm_ed = VerificationMethodMap {
+            id: String::from("did:example:foo#key3"),
+            type_: String::from("Ed25519VerificationKey2018"),
+            controller: String::from("did:example:foo"),
+            public_key_base58: Some("2sXRz2VfrpySNEL6xmXJWQg6iY94qwNp1qrJJFBuPWmH".to_string()),
+            ..Default::default()
+        };
+        let jwk = vmm_ed.get_jwk().unwrap();
+        assert_eq!(jwk, pk_jwk);
+    }
 }


### PR DESCRIPTION
Internally we are using JWK to represent most kinds of keys, and are preferring to use [publicKeyJwk](https://www.w3.org/TR/did-core/#dfn-publickeyjwk) in DID Documents where possible. But some verification method maps do not use `publicKeyJwk` but rather use others:
- `publicKeyMultibase` is the main alternative, listed in [DID Core](https://www.w3.org/TR/did-core/#dfn-publickeymultibase). VMs using it typically use it with multicodec - as noted in its [Security Vocabulary](https://w3c-ccg.github.io/security-vocab/#publicKeyMultibase) entry. Newer signature suites such as [Ed25519 Signature 2020](https://github.com/w3c-ccg/lds-ed25519-2020/) use this one specifically. We are using it in `TezosJcsSignature2021` (non-multicodec).
- `publicKeyHex` is [deprecated](https://w3c-ccg.github.io/security-vocab/#publicKeyHex) in W3C CCG Security Vocabularity, but is still often used with [EcdsaSecp256k1VerificationKey2019](https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/). (Issue: https://github.com/w3c-ccg/lds-ecdsa-secp256k1-2019/issues/4)
- `publicKeyBase58` is similarly [deprecated](https://w3c-ccg.github.io/security-vocab/#publicKeyBase58), but is often used with `Ed25519Signature2018`. (Discussion: https://github.com/w3c-ccg/lds-ed25519-2018/issues/3)

We have a conversion function to allow using non-JWK verification material as JWK. This was added in #121, for compatibility with the `Ed25519Signature2018` `did:web` issuer in the [VC HTTP API Test Suite](https://github.com/w3c-ccg/vc-http-api-test-suite/). This PR is similar, adding support for `publicKeyHex` and JWK conversion for `EcdsaSecp256k1VerificationKey2019`. Additionally, tests are added.

These changes should help enable compatibility with implementations and specifications that still rely on `publicKeyHex`, particularly in conjunction with `EcdsaSecp256k1VerificationKey2019`.