### PR TITLE
Update json-ld to v0.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "json-ld-normalization"]
 	path = json-ld-normalization
 	url = https://github.com/json-ld/rdf-dataset-canonicalization/
-[submodule "json-ld"]
-	path = json-ld
-	url = https://github.com/spruceid/json-ld

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ keccak = ["keccak-hash", "secp256k1", "k256/keccak256"]
 sha = ["sha2", "k256/sha256"]
 
 [dependencies]
+json-ld = "0.4"
 bbs = "0.4.1"
 pairing-plus = "0.19"
 ff = { version = "0.6", package = "ff-zeroize" }
@@ -49,7 +50,7 @@ async-std = { version = "1.9", features = ["attributes"] }
 async-trait = "0.1"
 json = "^0.12"
 futures = "0.3"
-iref = "1.4"
+iref = "^2.0.3"
 lazy_static = "1.4"
 combination = "0.1"
 sha2 = { version = "0.9", optional = true }
@@ -77,15 +78,6 @@ reqwest = { version = "0.11", features = ["json"] }
 flate2 = "1.0"
 bitvec = "0.20"
 
-# dependencies for json-ld
-log = "^0.4"
-mown = "^0.2"
-# json = "^0.12"
-#iref = "^1.4.3"
-#futures = "^0.3"
-once_cell = "^1.4"
-langtag = "^0.2"
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 
@@ -112,9 +104,4 @@ members = [
 uuid = { version = "0.8", features = ["v4", "serde"] }
 difference = "2.0"
 did-method-key = { path = "./did-key" }
-
-# dev-dependencies for json-ld
-static-iref = "^1.0"
-iref-enum = "^1.2"
-stderrlog = "^0.5"
 tokio = { version = "1.0", features = ["macros"] }

--- a/NOTICE
+++ b/NOTICE
@@ -14,8 +14,3 @@ Copyright © 2018-2021 World Wide Web Consortium, (Massachusetts Institute of Te
 Portions of this software are based in part on the work of schema.org. Because Spruce Systems, Inc. has included the work of schema.org in this product, Spruce Systems, Inc. is providing attribution in the following notice:
 
 Copyright in the schema by the sponsors of schema.org (Google, Inc., Yahoo, Inc., Microsoft Corporation and Yandex) are licensed to website publishers and other third parties under the Creative Commons Attribution-ShareAlike License (version 3.0) according to their Terms of Service, please visit https://schema.org/docs/terms.html. To view a copy of this license, please visit http://creativecommons.org/licenses/by-sa/3.0/.
-
-This software includes a modified copy of the json-ld crate by Timothée Haudebourg.
-The json-ld crate is available under either the Apache License, Version 2.0; or the MIT License.
-Original source: https://github.com/timothee-haudebourg/json-ld
-Modified source: https://github.com/spruceid/json-ld/tree/vendor

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@ use crate::eip712::TypedDataConstructionError;
 use crate::eip712::TypedDataConstructionJSONError;
 #[cfg(feature = "keccak-hash")]
 use crate::eip712::TypedDataHashError;
-use crate::json_ld;
 use crate::tzkey::{DecodeTezosSignatureError, EncodeTezosSignedMessageError};
 use base64::DecodeError as Base64Error;
 #[cfg(feature = "ed25519-dalek")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,6 @@ pub static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_P
 #[cfg(any(feature = "k256", feature = "p256"))]
 pub mod passthrough_digest;
 
-#[path = "../json-ld/src/lib.rs"]
-mod json_ld;
-
 extern crate pest;
 #[macro_use]
 extern crate pest_derive;
@@ -45,10 +42,6 @@ extern crate derive_builder;
 extern crate lazy_static;
 #[macro_use]
 extern crate json;
-
-// for json-ld:
-#[macro_use]
-extern crate log;
 
 #[derive(Parser)]
 #[grammar = "did.pest"]


### PR DESCRIPTION
- [x] Unbundle `json-ld` crate. Use new version from registry.
- [x] Update `iref` dependency.
- [x] Enable RDF deserialization test cases now passing. (https://github.com/timothee-haudebourg/json-ld/issues/8#issuecomment-916490211)
- [x] Address [`cannot_add_properties_after_signing`](https://github.com/spruceid/ssi/blob/61db82d00d41649d7bc7689c4cbb09dd34457e2b/src/vc.rs#L2560-L2570) test failure: https://github.com/spruceid/ssi/pull/295 https://github.com/timothee-haudebourg/json-ld/pull/14

DIDKit considerations:
- VC HTTP API Test Suite VP Case 2 no longer verifies - the invalid `id` property seems to be dropped. Proposing to regenerate it: https://github.com/w3c-ccg/vc-http-api-test-suite/pull/3
- Old VC HTTP API Test Suite may need to be removed, for the same reason: https://github.com/spruceid/didkit/pull/214