### PR TITLE
Publish DID method crates with ssi v0.3

### DIFF
--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-ethr"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-method-key"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-onion"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-pkh"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-test/Cargo.toml
+++ b/did-test/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 ssi = { version = "0.3", path = "../" }
 did-method-key = { version = "0.1", path = "../../ssi/did-key", features = ["secp256k1", "secp256r1"] }
 did-tz = { version = "0.1", path = "../../ssi/did-tezos", default-features = false, features = ["secp256k1", "secp256r1"] }
-did-pkh = { version = "0.0.1", path = "../../ssi/did-pkh" }
+did-pkh = { version = "0.1", path = "../../ssi/did-pkh" }
 did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
 did-web = { version = "0.1", path = "../../ssi/did-web" }
 did-webkey = { version = "0.1", path = "../../ssi/did-webkey", features = ["p256"] }

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-tz"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-web"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Increment the version of the DID method workspace crates, to prepare for publishing to `crates.io`.

# Summary of changes

For more details, see the [Changelog](https://github.com/spruceid/ssi/blob/v0.3.0/CHANGELOG.md#030), commit history, and issue/pull-request threads.

## Common changes

- Update versions. Update from `0.0.x` to `0.1.0` for some, so that dependents can use ranges.
- Remove unnecessary `contentType` and `created` DID resolution metadata.
- Improve `CAIP-2` conformance in `blockchainAccountId`

## Crate changes

### `did-pkh`
- `v0.0.1` → `v0.1.0`
- Remove incorrect crate keyword
- Use CAIP-26 in Tezos blockchainAccountId
- Add `did:pkh:celo` and `did:pkh:poly` (Note: these will be deprecated in favor of `did:pkh:eip122` in #279/#286)

### `did-tz`
- `v0.1.0` → `v0.1.1`
- Remove `libsecp256k1` dependency
- Use `api.tzkt.io` instead of `better-call.dev`
- Use `CAIP-26` for chain id in `blockchainAccountId`.

### `did-ethr`
- `v0.0.1` → `v0.1.0`
- Support public key DID variant.

### `did-web`
- `v0.1.0` → `v0.1.1`
- Add User-Agent header in requests.
- Fix returning `notFound` error code.
- Fix typo in readme.

### `did-onion`
- `v0.1.0` → `v0.1.1`
- Add User-agent header in requests

### `did-key`
- `v0.1.1` → `v0.1.2`
- Support BLS 12381 G2 (`did:key:zUC7K`)
- Use EC compression for P-256 (`did:key:zrur` → `did:key:zDna`)
- Fix JSON-LD document results

### `did-webkey`
- `v0.1.0` (initial release)

<details>
<summary>Publish commands</summary>

Remove `--dry-run` to publish for real (with permission).
```
cargo publish --dry-run --manifest-path did-tezos/Cargo.toml --features ssi/ring,ssi/rand
cargo publish --dry-run --manifest-path did-ethr/Cargo.toml --features ssi/ring,ssi/rand
cargo publish --dry-run --manifest-path did-pkh/Cargo.toml --features ssi/ring,ssi/rand
cargo publish --dry-run --manifest-path did-key/Cargo.toml --features ssi/ring,ssi/rand
cargo publish --dry-run --manifest-path did-web/Cargo.toml --features ssi/ring,ssi/rand
cargo publish --dry-run --manifest-path did-onion/Cargo.toml --features ssi/ring,ssi/rand
cargo publish --dry-run --manifest-path did-webkey/Cargo.toml --features ssi/ring,ssi/rand
```
</details>