### PR TITLE
Generate types for EthereumEIP712Signature2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement Sidetree client ([#379](https://github.com/spruceid/ssi/pull/379))
 - Add `did:ion` DID method implementation ([#379](https://github.com/spruceid/ssi/pull/379))
 - Added more rustdocs ([#311](https://github.com/spruceid/ssi/pull/311)).
+- Generate EIP-712 types for EthereumEIP712Signature2021 ([#301](https://github.com/spruceid/ssi/pull/301)).
 
 ### Changed
 - Use Error types in bbs code ([#338](https://github.com/spruceid/ssi/pull/338)).


### PR DESCRIPTION
Implement EIP-712 type generation for linked data proof suite as being specified in https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/25. Test test vectors added in https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/26 and with minor updates in https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/43.

- [x] Make temporary changes needed to evaluate test vectors. Work-arounds were made for issues listed here: https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/26#issuecomment-920906406
- [x] Implement types generation. Implemented as specified in PR draft as of 2021-09-17 (https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/25/commits/37365dd1a964b68f4f6d65f1a47ec72101acc6aa).
- [x] Integrate types generation into proof creation (mostly) and verification.
- [x] Validate test vector for types generation. ~~Discrepancy found: https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/25/files#r711353493~~. Test vectors verified, with workarounds.
- [x] Implement fetching TypedData from URI remotely? Or from a local source? Fetching hard-coded example for testing purposes only.
- [x] Validate test vectors for verifiable credential/proofs. Verified only, no generation.
  - [ ] 3.6.1. Basic Document - Types Generation - No Embedding. (Not working for some reason. Opened issue: https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/issues/42)
  - [x] 3.6.2. Nested Document - TypedData Provided - Embedded EIP712 Properties
  - [x] 3.6.3. Nested Document - Types Generation - TypedData Schema as URI (with fix in https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/26/files#r798853853)
  - [x] 3.6.4. Nested Document - Types Generation - Types Embedded
- [x] Undo or confirm above mentioned temporary changes/work-arounds.
  - [x] Handle difference in handling `proof` object, if needed. Proposed test vectors do not currently include `proof` in the data to be signed: https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/26/files#r710072926. The check for untyped properties is disabled to allow validating the test vectors, but this causes CI failure.