### PR TITLE
Test bbs blinding values creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ members = [
 ]
 
 [dev-dependencies]
+blake2 = "0.8" # for bbs doctest
 uuid = { version = "0.8", features = ["v4", "serde"] }
 difference = "2.0"
 did-method-key = { path = "./did-key" }

--- a/src/bbs.rs
+++ b/src/bbs.rs
@@ -15,6 +15,7 @@ use zeroize::Zeroize;
 use std::fmt::Formatter;
 
 // This shows how the generators are created with nothing up my sleeve values
+// ```
 // const PREHASH: &'static [u8] = b"To be, or not to be- that is the question:
 // Whether 'tis nobler in the mind to suffer
 // The slings and arrows of outrageous fortune
@@ -53,6 +54,13 @@ use std::fmt::Formatter;
 // const DST_G1: &'static [u8] = b"BLS12381G1_XMD:BLAKE2B_SSWU_RO_BLS_SIGNATURES:1_0_0";
 // const DST_G2: &'static [u8] = b"BLS12381G2_XMD:BLAKE2B_SSWU_RO_BLS_SIGNATURES:1_0_0";
 //
+// use pairing_plus::{
+//     bls12_381::{G1, G2},
+//     hash_to_field::{BaseFromRO, ExpandMsgXmd},
+//     hash_to_curve::HashToCurve,
+//     serdes::SerDes,
+//     CurveProjective,
+// };
 // fn main() {
 //     let g1 = <G1 as HashToCurve<ExpandMsgXmd<blake2::Blake2b>>>::hash_to_curve(PREHASH, DST_G1);
 //     let g2 = <G2 as HashToCurve<ExpandMsgXmd<blake2::Blake2b>>>::hash_to_curve(PREHASH, DST_G2);
@@ -63,11 +71,10 @@ use std::fmt::Formatter;
 //     g1.serialize(&mut g1_bytes, true).unwrap();
 //     g2.serialize(&mut g2_bytes, true).unwrap();
 //
-//     println!("g1 = {}", hex::encode(g1_bytes.as_slice()));
-//     println!("g2 = {}", hex::encode(g2_bytes.as_slice()));
+//     assert_eq!(hex::encode(g1_bytes.as_slice()), "b9c9058e8a44b87014f98be4e1818db718f8b2d5101fc89e6983625f321f14b84d7cf6e155004987a215ee426df173c9");
+//     assert_eq!(hex::encode(g2_bytes.as_slice()), "a963de2adfb1163cf4bed24d708ce47432742d2080b2573ebe2e19a8698f60c541cec000fcb19783e9be73341356df5f1191cddec7c476d7742bcc421afc5d505e63373c627ea01fda04f0e40159d25bdd12f45a010d8580a78f6a7d262272f3");
 // }
-// g1 = b9c9058e8a44b87014f98be4e1818db718f8b2d5101fc89e6983625f321f14b84d7cf6e155004987a215ee426df173c9
-// g2 = a963de2adfb1163cf4bed24d708ce47432742d2080b2573ebe2e19a8698f60c541cec000fcb19783e9be73341356df5f1191cddec7c476d7742bcc421afc5d505e63373c627ea01fda04f0e40159d25bdd12f45a010d8580a78f6a7d262272f3
+// ```
 
 const BLINDING_G1: &'static [u8] = &[
     185, 201, 5, 142, 138, 68, 184, 112, 20, 249, 139, 228, 225, 129, 141, 183, 24, 248, 178, 213,

--- a/src/bbs.rs
+++ b/src/bbs.rs
@@ -71,17 +71,17 @@ use std::fmt::Formatter;
 ///     g1.serialize(&mut g1_bytes, true).unwrap();
 ///     g2.serialize(&mut g2_bytes, true).unwrap();
 ///
-///     assert_eq!(hex::encode(g1_bytes.as_slice()), "b9c9058e8a44b87014f98be4e1818db718f8b2d5101fc89e6983625f321f14b84d7cf6e155004987a215ee426df173c9");
-///     assert_eq!(hex::encode(g2_bytes.as_slice()), "a963de2adfb1163cf4bed24d708ce47432742d2080b2573ebe2e19a8698f60c541cec000fcb19783e9be73341356df5f1191cddec7c476d7742bcc421afc5d505e63373c627ea01fda04f0e40159d25bdd12f45a010d8580a78f6a7d262272f3");
+///     assert_eq!(g1_bytes.as_slice(), ssi::bbs::BLINDING_G1);
+///     assert_eq!(g2_bytes.as_slice(), ssi::bbs::BLINDING_G2);
 /// }
 /// ```
 
-const BLINDING_G1: &'static [u8] = &[
+pub const BLINDING_G1: &'static [u8] = &[
     185, 201, 5, 142, 138, 68, 184, 112, 20, 249, 139, 228, 225, 129, 141, 183, 24, 248, 178, 213,
     16, 31, 200, 158, 105, 131, 98, 95, 50, 31, 20, 184, 77, 124, 246, 225, 85, 0, 73, 135, 162,
     21, 238, 66, 109, 241, 115, 201,
 ];
-const BLINDING_G2: &'static [u8] = &[
+pub const BLINDING_G2: &'static [u8] = &[
     169, 99, 222, 42, 223, 177, 22, 60, 244, 190, 210, 77, 112, 140, 228, 116, 50, 116, 45, 32,
     128, 178, 87, 62, 190, 46, 25, 168, 105, 143, 96, 197, 65, 206, 192, 0, 252, 177, 151, 131,
     233, 190, 115, 52, 19, 86, 223, 95, 17, 145, 205, 222, 199, 196, 118, 215, 116, 43, 204, 66,

--- a/src/bbs.rs
+++ b/src/bbs.rs
@@ -14,67 +14,67 @@ use serde::{
 use zeroize::Zeroize;
 use std::fmt::Formatter;
 
-// This shows how the generators are created with nothing up my sleeve values
-// ```
-// const PREHASH: &'static [u8] = b"To be, or not to be- that is the question:
-// Whether 'tis nobler in the mind to suffer
-// The slings and arrows of outrageous fortune
-// Or to take arms against a sea of troubles,
-// And by opposing end them. To die- to sleep-
-// No more; and by a sleep to say we end
-// The heartache, and the thousand natural shocks
-// That flesh is heir to. 'Tis a consummation
-// Devoutly to be wish'd. To die- to sleep.
-// To sleep- perchance to dream: ay, there's the rub!
-// For in that sleep of death what dreams may come
-// When we have shuffled off this mortal coil,
-// Must give us pause. There's the respect
-// That makes calamity of so long life.
-// For who would bear the whips and scorns of time,
-// Th' oppressor's wrong, the proud man's contumely,
-// The pangs of despis'd love, the law's delay,
-// The insolence of office, and the spurns
-// That patient merit of th' unworthy takes,
-// When he himself might his quietus make
-// With a bare bodkin? Who would these fardels bear,
-// To grunt and sweat under a weary life,
-// But that the dread of something after death-
-// The undiscover'd country, from whose bourn
-// No traveller returns- puzzles the will,
-// And makes us rather bear those ills we have
-// Than fly to others that we know not of?
-// Thus conscience does make cowards of us all,
-// And thus the native hue of resolution
-// Is sicklied o'er with the pale cast of thought,
-// And enterprises of great pith and moment
-// With this regard their currents turn awry
-// And lose the name of action.- Soft you now!
-// The fair Ophelia!- Nymph, in thy orisons
-// Be all my sins rememb'red.";
-// const DST_G1: &'static [u8] = b"BLS12381G1_XMD:BLAKE2B_SSWU_RO_BLS_SIGNATURES:1_0_0";
-// const DST_G2: &'static [u8] = b"BLS12381G2_XMD:BLAKE2B_SSWU_RO_BLS_SIGNATURES:1_0_0";
-//
-// use pairing_plus::{
-//     bls12_381::{G1, G2},
-//     hash_to_field::{BaseFromRO, ExpandMsgXmd},
-//     hash_to_curve::HashToCurve,
-//     serdes::SerDes,
-//     CurveProjective,
-// };
-// fn main() {
-//     let g1 = <G1 as HashToCurve<ExpandMsgXmd<blake2::Blake2b>>>::hash_to_curve(PREHASH, DST_G1);
-//     let g2 = <G2 as HashToCurve<ExpandMsgXmd<blake2::Blake2b>>>::hash_to_curve(PREHASH, DST_G2);
-//
-//     let mut g1_bytes = Vec::new();
-//     let mut g2_bytes = Vec::new();
-//
-//     g1.serialize(&mut g1_bytes, true).unwrap();
-//     g2.serialize(&mut g2_bytes, true).unwrap();
-//
-//     assert_eq!(hex::encode(g1_bytes.as_slice()), "b9c9058e8a44b87014f98be4e1818db718f8b2d5101fc89e6983625f321f14b84d7cf6e155004987a215ee426df173c9");
-//     assert_eq!(hex::encode(g2_bytes.as_slice()), "a963de2adfb1163cf4bed24d708ce47432742d2080b2573ebe2e19a8698f60c541cec000fcb19783e9be73341356df5f1191cddec7c476d7742bcc421afc5d505e63373c627ea01fda04f0e40159d25bdd12f45a010d8580a78f6a7d262272f3");
-// }
-// ```
+/// This shows how the generators are created with nothing up my sleeve values
+/// ```
+/// const PREHASH: &'static [u8] = b"To be, or not to be- that is the question:
+/// Whether 'tis nobler in the mind to suffer
+/// The slings and arrows of outrageous fortune
+/// Or to take arms against a sea of troubles,
+/// And by opposing end them. To die- to sleep-
+/// No more; and by a sleep to say we end
+/// The heartache, and the thousand natural shocks
+/// That flesh is heir to. 'Tis a consummation
+/// Devoutly to be wish'd. To die- to sleep.
+/// To sleep- perchance to dream: ay, there's the rub!
+/// For in that sleep of death what dreams may come
+/// When we have shuffled off this mortal coil,
+/// Must give us pause. There's the respect
+/// That makes calamity of so long life.
+/// For who would bear the whips and scorns of time,
+/// Th' oppressor's wrong, the proud man's contumely,
+/// The pangs of despis'd love, the law's delay,
+/// The insolence of office, and the spurns
+/// That patient merit of th' unworthy takes,
+/// When he himself might his quietus make
+/// With a bare bodkin? Who would these fardels bear,
+/// To grunt and sweat under a weary life,
+/// But that the dread of something after death-
+/// The undiscover'd country, from whose bourn
+/// No traveller returns- puzzles the will,
+/// And makes us rather bear those ills we have
+/// Than fly to others that we know not of?
+/// Thus conscience does make cowards of us all,
+/// And thus the native hue of resolution
+/// Is sicklied o'er with the pale cast of thought,
+/// And enterprises of great pith and moment
+/// With this regard their currents turn awry
+/// And lose the name of action.- Soft you now!
+/// The fair Ophelia!- Nymph, in thy orisons
+/// Be all my sins rememb'red.";
+/// const DST_G1: &'static [u8] = b"BLS12381G1_XMD:BLAKE2B_SSWU_RO_BLS_SIGNATURES:1_0_0";
+/// const DST_G2: &'static [u8] = b"BLS12381G2_XMD:BLAKE2B_SSWU_RO_BLS_SIGNATURES:1_0_0";
+///
+/// use pairing_plus::{
+///     bls12_381::{G1, G2},
+///     hash_to_field::{BaseFromRO, ExpandMsgXmd},
+///     hash_to_curve::HashToCurve,
+///     serdes::SerDes,
+///     CurveProjective,
+/// };
+/// fn main() {
+///     let g1 = <G1 as HashToCurve<ExpandMsgXmd<blake2::Blake2b>>>::hash_to_curve(PREHASH, DST_G1);
+///     let g2 = <G2 as HashToCurve<ExpandMsgXmd<blake2::Blake2b>>>::hash_to_curve(PREHASH, DST_G2);
+///
+///     let mut g1_bytes = Vec::new();
+///     let mut g2_bytes = Vec::new();
+///
+///     g1.serialize(&mut g1_bytes, true).unwrap();
+///     g2.serialize(&mut g2_bytes, true).unwrap();
+///
+///     assert_eq!(hex::encode(g1_bytes.as_slice()), "b9c9058e8a44b87014f98be4e1818db718f8b2d5101fc89e6983625f321f14b84d7cf6e155004987a215ee426df173c9");
+///     assert_eq!(hex::encode(g2_bytes.as_slice()), "a963de2adfb1163cf4bed24d708ce47432742d2080b2573ebe2e19a8698f60c541cec000fcb19783e9be73341356df5f1191cddec7c476d7742bcc421afc5d505e63373c627ea01fda04f0e40159d25bdd12f45a010d8580a78f6a7d262272f3");
+/// }
+/// ```
 
 const BLINDING_G1: &'static [u8] = &[
     185, 201, 5, 142, 138, 68, 184, 112, 20, 249, 139, 228, 225, 129, 141, 183, 24, 248, 178, 213,


### PR DESCRIPTION
There is a code snippet in comments in `src/bbs.rs` that creates the blinding
generator values. This PR updates that file to make that code be tested during
[documentation tests](https://doc.rust-lang.org/rustdoc/documentation-tests.html).

For code review purposes, changing of the comment prefix from `//` to `///` is
done in a separate commit from the other changes.

cc @mikelodder7 