### PR TITLE
Test JWT VC with single-element-array subject

### DIFF
--- a/src/one_or_many.rs
+++ b/src/one_or_many.rs
@@ -67,6 +67,19 @@ impl<T> OneOrMany<T> {
             }
         }
     }
+
+    pub fn to_single_mut(&mut self) -> Option<&mut T> {
+        match self {
+            Self::One(value) => Some(value),
+            Self::Many(values) => {
+                if values.len() == 1 {
+                    Some(&mut values[0])
+                } else {
+                    None
+                }
+            }
+        }
+    }
 }
 
 // consuming iterator


### PR DESCRIPTION
When converting between the JWT subject ("sub" claim) and the VC `credentialSubject`, [VC Data Model 1.0](https://www.w3.org/TR/vc-data-model/#jwt-encoding) only allows a single subject. (The "sub" value must be a StringOrURI: [RFC 7519](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.2)). When issuing a JWT VC, we allow the case where a `credentialSubject` is an array containing a single value (object with `id` property) as well as single object value. But when verifying such a JWT VC, this case was not handled, and an error "Unable to convert JWT claims to VC: Invalid subject for JWT" would result. This PR changes the conversion of JWT claims to Credential to support the case where the `credentialSubject` is an array containing a single element.