### PR TITLE
Disallow revocation list index out of bounds

### DIFF
--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -321,7 +321,10 @@ impl CredentialStatus for RevocationList2020Status {
         };
         let revoked = match bitstring.get(credential_index) {
             Some(bitref) => *bitref,
-            None => false,
+            None => {
+                return result
+                    .with_error("Credential index in revocation list is invalid.".to_string());
+            }
         };
         if revoked {
             return result.with_error("Credential is revoked.".to_string());


### PR DESCRIPTION
During verification, [get](https://docs.rs/bitvec/0.22.3/bitvec/slice/struct.BitSlice.html#method.get) returns `None` when the index is out of bounds. Throw an error in this case.

Related: https://github.com/w3c-ccg/vc-status-list-2021/issues/9