### PR TITLE
Add support for fractional (up to microseconds) timestamps on JWTClaims.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -212,6 +212,7 @@ pub enum Error {
     #[cfg(feature = "p256")]
     P256EC(p256::elliptic_curve::Error),
     MissingFeatures(&'static str),
+    NumericDateOutOfMicrosecondPrecisionRange,
 }
 
 impl fmt::Display for Error {
@@ -394,6 +395,7 @@ impl fmt::Display for Error {
             Error::ECEncodingError => write!(f, "Unable to encode EC key"),
             Error::ECDecompress => write!(f, "Unable to decompress elliptic curve"),
             Error::MissingFeatures(features) => write!(f, "Missing features: {}", features),
+            Error::NumericDateOutOfMicrosecondPrecisionRange => write!(f, "Out of valid microsecond-precision range of NumericDate"),
         }
     }
 }


### PR DESCRIPTION
Microsecond precision with f64 will be possible until about the year 2255. The calculation is 53 bits of mantissa in f64 gives 2^53 = 9007199254740992.0, then dividing by the number of microseconds in a year (approx 60.0*60.0*24*365.25*1000000) gives approx 285. Add that to 1970 (the beginning of the Unix epoch) and the result is 2255.
