### PR TITLE
Default disallow example non-DID VC issuer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ripemd-160 = ["ripemd160", "secp256k1"]
 # TODO handle better keccak and sha
 keccak = ["keccak-hash", "secp256k1", "k256/keccak256"]
 sha = ["sha2", "k256/sha256"]
+example-http-issuer = []
 
 [dependencies]
 json-ld = "0.4"

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -318,6 +318,7 @@ pub(crate) async fn ensure_or_pick_verification_relationship(
         // Unable to verify verification relationship for non-DID issuers.
         // Allow some for testing purposes only.
         match &issuer[..] {
+            #[cfg(feature = "example-http-issuer")]
             "https://example.edu/issuers/14" => {
                 // https://github.com/w3c/vc-test-suite/blob/cdc7835/test/vc-data-model-1.0/input/example-016-jwt.jsonld#L8
                 // We don't have a way to actually resolve this to anything. Just allow it for

--- a/vc-test/Cargo.toml
+++ b/vc-test/Cargo.toml
@@ -8,7 +8,7 @@ description = "vc-test-suite test driver for ssi"
 publish = false
 
 [dependencies]
-ssi = { version = "0.3", path = "../" }
+ssi = { version = "0.3", path = "../", features = ["example-http-issuer"] }
 async-std = { version = "1.9", features = ["attributes"] }
 serde_json = "1.0"
 base64 = "0.12"


### PR DESCRIPTION
VC Test Suite requires being able to issue a verifiable credential out of a test vector credential whose issuer property is <https://example.edu/issuers/14>.

`ssi` checks verification relationship when issuing verifiable credentials. But this checking expects a DID URI as issuer, which resolves to a DID document, that contains verification material. In the case of a HTTP issuer URI (URL), something analogous should probably be done, but we don't have support for that yet. So for this `example.edu` HTTP issuer, the check is simply skipped, and for all HTTP issuers, an error is raised. This behavior addresses the current requirements. However, it might not be advisable to allow the check to be skipped in this case, outside the `vc-test-suite` test driver that requires it. Typically, handling of an example URL like this might be gated by a `#[cfg(test)]` attribute. However, the `vc-test-suite` test driver is run as an executable, so I don't think that the test configuration option can be used here. Instead, this PR adds a new feature for it, `example-http-issuer`. This feature is then disabled by default but enabled for use in the `ssi-vc-test` package.