### PR TITLE
Restrict Revocation List allowed URL schemes

### DIFF
--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -238,6 +238,16 @@ impl CredentialStatus for RevocationList2020Status {
                 self.id
             ));
         }
+        // Check the revocation list URL before attempting to load it.
+        // Revocation List 2020 does not specify an expected URL scheme (URI scheme), but
+        // examples and test vectors use https.
+        match self.revocation_list_credential.split_once(':') {
+            Some(("https", _)) => (),
+            // TODO: an option to allow HTTP?
+            // TODO: load from DID URLs?
+            Some((scheme, _)) => return result.with_error(format!("Invalid schema: {}", self.id)),
+            _ => return result.with_error(format!("Invalid rsrc: {}", self.id)),
+        }
         let revocation_list_credential =
             match load_credential(&self.revocation_list_credential).await {
                 Ok(credential) => credential,


### PR DESCRIPTION
[Revocation List 2020](https://w3c-ccg.github.io/vc-status-rl-2020/) doesn't say what is a URL. But examples and test vectors use `https`. This implementation has been allowing `http` also. For a more secure default, this PR changes it to allow only `https`.
We could later add some option or mode for allowing HTTP where it is safe and necessary to do so, and/or other protocols/schemes.

If merged, a change similar to this one should be made in the implementation of Status List 2021 in #278.