### PR TITLE
Use new lds-jws2020 v1 context, conditionally

### DIFF
--- a/contexts/src/lib.rs
+++ b/contexts/src/lib.rs
@@ -19,6 +19,8 @@ pub const DID_RESOLUTION_V1: &str = include_str!("../w3c-did-resolution-v1.jsonl
 pub const DIF_ESRS2020: &str = include_str!("../dif-lds-ecdsa-secp256k1-recovery2020-0.0.jsonld");
 /// <https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json>
 pub const LDS_JWS2020_V1: &str = include_str!("../lds-jws2020-v1.jsonld");
+/// <https://w3id.org/security/suites/jws-2020/v1>
+pub const W3ID_JWS2020_V1: &str = include_str!("../w3id-jws2020-v1.jsonld");
 /// <https://w3id.org/citizenship/v1>
 pub const CITIZENSHIP_V1: &str = include_str!("../w3c-ccg-citizenship-v1.jsonld");
 /// <https://w3id.org/vaccination/v1>

--- a/contexts/w3id-jws2020-v1.jsonld
+++ b/contexts/w3id-jws2020-v1.jsonld
@@ -1,0 +1,82 @@
+{
+  "@context": {
+    "privateKeyJwk": {
+      "@id": "https://w3id.org/security#privateKeyJwk",
+      "@type": "@json"
+    },
+    "JsonWebKey2020": {
+      "@id": "https://w3id.org/security#JsonWebKey2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "publicKeyJwk": {
+          "@id": "https://w3id.org/security#publicKeyJwk",
+          "@type": "@json"
+        }
+      }
+    },
+    "JsonWebSignature2020": {
+      "@id": "https://w3id.org/security#JsonWebSignature2020",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "jws": "https://w3id.org/security#jws",
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -125,6 +125,7 @@ pub const ESRS2020_EXTRA_CONTEXT: &str =
     "https://demo.spruceid.com/EcdsaSecp256k1RecoverySignature2020/esrs2020-extra-0.0.jsonld";
 pub const LDS_JWS2020_V1_CONTEXT: &str =
     "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json";
+pub const W3ID_JWS2020_V1_CONTEXT: &str = "https://w3id.org/security/suites/jws-2020/v1";
 pub const CITIZENSHIP_V1_CONTEXT: &str = "https://w3id.org/citizenship/v1";
 pub const VACCINATION_V1_CONTEXT: &str = "https://w3id.org/vaccination/v1";
 pub const TRACEABILITY_CONTEXT: &str = "https://w3id.org/traceability/v1";
@@ -199,6 +200,12 @@ lazy_static! {
         let iri = Iri::new(LDS_JWS2020_V1_CONTEXT).unwrap();
         RemoteDocument::new(doc, iri)
     };
+    pub static ref W3ID_JWS2020_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
+        let jsonld = ssi_contexts::W3ID_JWS2020_V1;
+        let doc = json::parse(jsonld).unwrap();
+        let iri = Iri::new(W3ID_JWS2020_V1_CONTEXT).unwrap();
+        RemoteDocument::new(doc, iri)
+    };
     pub static ref CITIZENSHIP_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
         let jsonld = ssi_contexts::CITIZENSHIP_V1;
         let doc = json::parse(jsonld).unwrap();
@@ -260,6 +267,7 @@ impl Loader for StaticLoader {
                 DIF_ESRS2020_CONTEXT => Ok(DIF_ESRS2020_CONTEXT_DOCUMENT.clone()),
                 ESRS2020_EXTRA_CONTEXT => Ok(ESRS2020_EXTRA_CONTEXT_DOCUMENT.clone()),
                 LDS_JWS2020_V1_CONTEXT => Ok(LDS_JWS2020_V1_CONTEXT_DOCUMENT.clone()),
+                W3ID_JWS2020_V1_CONTEXT => Ok(W3ID_JWS2020_V1_CONTEXT_DOCUMENT.clone()),
                 CITIZENSHIP_V1_CONTEXT => Ok(CITIZENSHIP_V1_CONTEXT_DOCUMENT.clone()),
                 VACCINATION_V1_CONTEXT => Ok(VACCINATION_V1_CONTEXT_DOCUMENT.clone()),
                 TRACEABILITY_CONTEXT => Ok(TRACEABILITY_CONTEXT_DOCUMENT.clone()),

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -1893,7 +1893,7 @@ impl ProofSuite for JsonWebSignature2020 {
         let algorithm = key.get_algorithm().ok_or(Error::MissingAlgorithm)?;
         self.validate_key_and_algorithm(key, algorithm)?;
         let proof = Proof {
-            context: serde_json::json!([crate::jsonld::LDS_JWS2020_V1_CONTEXT]),
+            context: serde_json::json!([crate::jsonld::W3ID_JWS2020_V1_CONTEXT]),
             ..Proof::new("JsonWebSignature2020")
                 .with_options(options)
                 .with_properties(extra_proof_properties)
@@ -1911,7 +1911,7 @@ impl ProofSuite for JsonWebSignature2020 {
         let algorithm = public_key.get_algorithm().ok_or(Error::MissingAlgorithm)?;
         self.validate_key_and_algorithm(public_key, algorithm)?;
         let proof = Proof {
-            context: serde_json::json!([crate::jsonld::LDS_JWS2020_V1_CONTEXT]),
+            context: serde_json::json!([crate::jsonld::W3ID_JWS2020_V1_CONTEXT]),
             ..Proof::new("JsonWebSignature2020")
                 .with_options(options)
                 .with_properties(extra_proof_properties)


### PR DESCRIPTION
In addition to the currently bundled context file (`https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json`), there is a different one registered under w3id.org: `https://w3id.org/security/suites/jws-2020/v1` (redirects to `https://w3c-ccg.github.io/lds-jws2020/contexts/v1`).  This second, registered one is the one that is used in [JWS-Test-Suite](https://github.com/decentralized-identity/JWS-Test-Suite). This PR adds it to the repo and updates the `JsonWebSignature2020` implementation to use it instead of the other one.

Additionally, only add the context URI to the newly created proof objects if the parent linked data document doesn't already use this context URI. This is because in JWS-Test-Suite, the input credentials already have the context URI, so adding it again is redundant/unnecessary.