### PR TITLE
Check proof type when matching proof objects

### DIFF
--- a/src/vc.rs
+++ b/src/vc.rs
@@ -1850,6 +1850,9 @@ impl Proof {
         if let Some(ref proof_purpose) = options.proof_purpose {
             assert_local!(self.proof_purpose.as_ref() == Some(proof_purpose));
         }
+        if let Some(ref type_) = options.type_ {
+            assert_local!(&self.type_ == type_);
+        }
         true
     }
 


### PR DESCRIPTION
This allows the type property of `LinkedDataProofOptions` to be used for selecting proofs by type.