### PR TITLE
Default to JsonWebSignature2020 for P-256

### DIFF
--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -130,7 +130,7 @@ fn pick_proof_suite<'a, 'b>(
                     &P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021
                 }
             }
-            _ => &EcdsaSecp256r1Signature2019,
+            _ => &JsonWebSignature2020,
         },
         Algorithm::ES256K | Algorithm::ESBlake2bK => match verification_method {
             Some(URI::String(ref vm))


### PR DESCRIPTION
Although `EcdsaSecp256r1Signature2019` is in the VC Data Model v1.0 base context, it doesn't have a specification in CCG, DIF, etc.
(unlike `EcdsaSecp256k1Signature2019` which has a specification draft here: https://github.com/w3c-ccg/lds-ecdsa-secp256k1-2019). `EcdsaSecp256r1Signature2019` also has divergent implementations: some are using it in a non-JSON-LD way: https://github.com/spruceid/ssi/issues/330.

`JsonWebSignature2020` covers the functionality of `ssi`'s `EcdsaSecp256r1Signature2019` implementation, i.e. `Secp256r1` / `P-256` / `ES256` in a RDF-based linked data proof, and has a specification (https://github.com/w3c-ccg/lds-jws2020/) and a test suite in development (https://github.com/decentralized-identity/JWS-Test-Suite) - with multiple implementations, e.g. [Transmute](https://identity.foundation/JWS-Test-Suite/#transmute)'s showing `Secp256r1` support in the implementation report.

This PR changes `ssi` to default to generate linked data proofs using `JsonWebSignature2020` for `P-256` keys, instead of using `EcdsaSecp256r1Signature2019`. `EcdsaSecp256r1Signature2019` proofs can still be created, using that proof type specifically - e.g. in DIDKit CLI with the `-t` option added in https://github.com/spruceid/didkit/pull/230.

As for the other four key types supported by `JsonWebSignature2020` besides P-256:
- RSA (PS256): `ssi` uses `JsonWebSignature2020`, as `RsaSignature2018` is deprecated (https://github.com/spruceid/ssi/pull/240), and `RS256` is considered insecure.
- Secp256k1 (ES256K): `ssi` uses `EcdsaSecp256k1Signature2019` by default, as that is in the VC Data Model base context, and has a spec which is not marked as deprecated (https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/). However, it doesn't have interop demonstrated like `JsonWebSignature2020` does.
- Ed25519 (EdDSA): ssi uses `Ed25519Signature2018` by default, as that is in the VC Data Model 1.0 base context, has a spec which is not marked as deprecated (https://w3c-ccg.github.io/lds-ed25519-2018/) and has interop testing in VC API Test Suite (https://github.com/w3c-ccg/vc-api-test-suite).
- Secp384r1 (ES384): `JsonWebSignature2020` would be used, but `ssi` doesn't support this yet (https://github.com/spruceid/ssi/issues/312).