### PR TITLE
Justify use of unsafe/transmute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,10 @@ example-http-issuer = []
 
 [dependencies]
 json-ld = "0.4"
-bbs = "0.4.1"
-pairing-plus = "0.19"
+# SAFETY: bbs and pairing-plus are set to specific versions due to a
+# dependency on internal struct representations using transmute in src/bbs.rs.
+bbs = "=0.4.1"
+pairing-plus = "=0.19.0"
 ff = { version = "0.6", package = "ff-zeroize" }
 hkdf = "0.8"
 zeroize = { version = "1.4", features = ["zeroize_derive"] }

--- a/src/bbs.rs
+++ b/src/bbs.rs
@@ -96,6 +96,9 @@ pub struct BlsSecretKey(pub Fr);
 
 impl From<SecretKey> for BlsSecretKey {
     fn from(x: SecretKey) -> Self {
+        // SAFETY: These two types, bbs::keys::SecretKey and ssi::bbs::BlsSecretKey, both wrap
+        // pairing_plus::bls12_381::Fr, so transmute should be okay. The bls and pairing-plus
+        // crate versions should be checked to ensure this equivalence continues to hold.
         unsafe { std::mem::transmute(x) }
     }
 }


### PR DESCRIPTION
There is a use of `unsafe` `std::mem::transmute` in `src/bbs.rs`, representing a dependency on the internal representation of structs from external crates `bbs` and `pairing-plus` ([`SecretKey`](https://docs.rs/bbs/0.4.1/bbs/keys/struct.SecretKey.html) via `bbs::prelude::*`, and [`pairing_plus::bls12_381::Fr`](https://docs.rs/pairing-plus/0.19.0/pairing_plus/bls12_381/struct.Fr.html)). This PR adds a note describing this situation.
These crates are depended on by specific versions, so that they can be manually checked when they need to be updated, to ensure that the dependency on the structs' internal representation is still correct. The `bbs` dependency already is at a specific version; the dependency on `pairing-plus` is updated to use a specific version, and a note is added in Cargo.toml about this relationship, to correspond with the note added in `src/bbs.rs`.