### PR TITLE
Panic if unexpected length in PassthroughDigest

### DIFF
--- a/src/passthrough_digest.rs
+++ b/src/passthrough_digest.rs
@@ -9,13 +9,7 @@ pub struct PassthroughDigest {
 impl Update for PassthroughDigest {
     fn update(&mut self, data: impl AsRef<[u8]>) {
         let d = data.as_ref();
-        if d.len() == 32 {
-            self.value = d.try_into().unwrap();
-        } else if !d.is_empty() {
-            self.value = [d[0]; 32];
-        } else {
-            self.value = [0; 32];
-        }
+        self.value = d.try_into().unwrap();
     }
 }
 


### PR DESCRIPTION
`PassthroughDigest` represents a workaround for the requirement for a Digest implementation for use with the `k256` and `p256` crates.
Even though it it is only meant to be used internally for these specific uses, this PR updates it to add an additional requirement for security/robustness. This change is to require that the input data length is exactly 32 bytes, rather than allowing other lengths. ~~This change enables panic to happen if an incorrect length is passed. An incorrect length would not be passed in the current code but could occur if code is changed resulting in incorrect use of `PassthroughDigest`. In case of such a change, we could consider it better to panic and reveal the bug during development, rather than potentially allow execution to proceed in a bad state.~~

Edit: test failure suggests this is not a correct change.