### PR TITLE
Update EthereumEip712Signature2021 property names

### DIFF
--- a/contexts/eip712sig-v1.jsonld
+++ b/contexts/eip712sig-v1.jsonld
@@ -63,6 +63,24 @@
             }
           }
         },
+        "eip712": {
+          "@id": "https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#eip712-domain",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "types": {
+              "@id": "https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#message-schema",
+              "@type": "@json"
+            },
+            "primaryType": "https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#primary-type",
+            "domain": {
+              "@id": "https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#domain",
+              "@type": "@json"
+            }
+          }
+        },
         "proofValue": "https://w3id.org/security#proofValue",
         "verificationMethod": {
           "@id": "https://w3id.org/security#verificationMethod",

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -1105,7 +1105,7 @@ mod tests {
 
         // eth/Eip712
         let eip712_domain: ssi::eip712::ProofInfo = serde_json::from_value(json!({
-          "messageSchema": {
+          "types": {
             "EIP712Domain": [
               { "name": "name", "type": "string" }
             ],
@@ -1135,7 +1135,7 @@ mod tests {
         }))
         .unwrap();
         let vp_eip712_domain: ssi::eip712::ProofInfo = serde_json::from_value(json!({
-          "messageSchema": {
+          "types": {
             "EIP712Domain": [
               { "name": "name", "type": "string" }
             ],
@@ -1169,7 +1169,7 @@ mod tests {
             "EIP712Info": [
               { "name": "domain", "type": "EIP712Domain" },
               { "name": "primaryType", "type": "string" },
-              { "name": "messageSchema", "type": "Types" },
+              { "name": "types", "type": "Types" },
             ],
             "Types": [
               { "name": "EIP712Domain", "type": "Type[]" },


### PR DESCRIPTION
Corresponding to https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/32 and https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/33

- Rename messageSchema to types
- Rename eip712Domain to eip712
- Allow old way for backwards compatibility
- Update JSON-LD context file