### PR TITLE
Add did:pkh for Aleo

### DIFF
--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
 bs58 = { version = "0.4", features = ["check"] }
+bech32 = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"] }

--- a/did-pkh/tests/did-aleo.jsonld
+++ b/did-pkh/tests/did-aleo.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/blockchain-2021/v1"
+  ],
+  "id": "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348",
+  "verificationMethod": [
+    {
+      "id": "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348#blockchainAccountId",
+      "type": "BlockchainVerificationMethod2021",
+      "controller": "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348",
+      "blockchainAccountId": "aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348"
+    }
+  ],
+  "authentication": [
+    "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348#blockchainAccountId"
+  ],
+  "assertionMethod": [
+    "did:pkh:aleo:1:aleo1y90yg3yzs4g7q25f9nn8khuu00m8ysynxmcw8aca2d0phdx8dgpq4vw348#blockchainAccountId"
+  ]
+}


### PR DESCRIPTION
- [ ] Register CAIP-2 namespace for Aleo: https://github.com/ChainAgnostic/CAIPs/pull/84
- [ ] Add test vector and verification method type to `did:pkh` specification draft: https://github.com/w3c-ccg/did-pkh/pull/15
- [x] Add entry for Aleo in `did:pkh` specification
- [x] Parse Bech32 account address
- [x] Use `BlockchainVerificationMethod2021` for verification method

This doesn't yet implement signing/verifying `BlockchainSignature2021`, only the construction of the DID document and verification method object that it will verify against. The verification method type may be changed to a different type if we find or develop a more specific one than `BlockchainVerificationMethod2021`/`BlockchainSignature2021`. 
Edit: Signing/verifying is implemented in #360.

~~Parsing the constructed DID documents with `ssi` will depend on JSON-LD context for Blockchain Vocabulary (#347).~~