### PR TITLE
Document did:tz resolution options

### DIFF
--- a/did-tezos/README.md
+++ b/did-tezos/README.md
@@ -2,6 +2,20 @@
 
 Rust implementation of the [did:tz][] DID Method, based on the [ssi][] library.
 
+## Method-specific Resolution Options
+
+As per the [DID Tezos specific](https://did-tezos.spruceid.com/#tiered-did-resolution),
+DID resolution for did-tezos is always tiered, and in some use-cases this requires
+passing the did-tz resolver in ssi some
+[Resolution Metadata](https://w3c-ccg.github.io/did-resolution/#output-resolutionmetadata).
+These properties are as follows:
+- `tzkt_url`: Custom indexer endpoint URL
+- `updates`: [Off-Chain DID Document Updates](https://did-tezos.spruceid.com/#off-chain-did-document-updates),
+   aka "DID Document patches", as specified in the Tezos DID Method Specification.
+- `public_key`: a Public key in Base58 format ([publicKeyBase58](https://w3c-ccg.github.io/security-vocab/#publicKeyBase58))
+   to add to a [derived DID document (implicit resolution)](https://did-tezos.spruceid.com/#deriving-did-documents)
+   where no look-up mechanism is available in ssi.
+
 ## License
 
 [Apache License, Version 2.0](http://www.apache.org/licenses/)

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -40,6 +40,18 @@ impl Default for DIDTz {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl DIDResolver for DIDTz {
+    /// Resolve a did:tz DID.
+    ///
+    /// # Resolution options
+    ///
+    /// ## `tzkt_url`
+    /// Custom indexer endpoint URL.
+    ///
+    /// ## `updates`
+    /// [Off-Chain DID Document Updates](https://did-tezos.spruceid.com/#off-chain-did-document-updates), as specified in the Tezos DID Method Specification.
+    ///
+    /// ## `public_key`
+    /// Public key in Base58 format ([publicKeyBase58](https://w3c-ccg.github.io/security-vocab/#publicKeyBase58)) to add to a [derived DID document (implicit resolution)](https://did-tezos.spruceid.com/#deriving-did-documents).
     async fn resolve(
         &self,
         did: &str,


### PR DESCRIPTION
The did:tz implementation uses some custom DID Resolution options (input metadata). The `updates` option is defined in the [Tezos DID Method Specification](https://did-tezos.spruceid.com/#off-chain-did-document-updates). `public_key` and `tzkt_url` options are specific to this implementation. This PR adds some rustdocs for them.

Re: https://github.com/spruceid/ssi/pull/311#discussion_r755431182

Preview: https://demo.didkit.dev/2021/11/23/did-tz-rustdoc/did_tz/struct.DIDTz.html#resolution-options