### PR TITLE
Add vDL v1 context

### DIFF
--- a/contexts/LICENSES.md
+++ b/contexts/LICENSES.md
@@ -15,6 +15,7 @@ Citizenship Vocabulary: https://github.com/w3c-ccg/citizenship-vocab/
 Revocation List 2020: https://w3c-ccg.github.io/vc-status-rl-2020/
 BBS+ Signatures 2020: https://w3c-ccg.github.io/ldp-bbs2020/
 Ethereum EIP-712 Signature 2021: https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/
+Verifiable Driver's License Vocabulary: https://w3id.org/vdl
 
 Copyright © 2018-2021 World Wide Web Consortium, (Massachusetts Institute of Technology, European Research Consortium for Informatics and Mathematics, Keio University, Beihang). All Rights Reserved. This work is distributed under the [W3C® Software and Document License][1] in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 

--- a/contexts/src/lib.rs
+++ b/contexts/src/lib.rs
@@ -41,6 +41,8 @@ pub const EIP712SIG_V0_1: &str = include_str!("../eip712sig-v0.1.jsonld");
 pub const EIP712SIG_V1: &str = include_str!("../eip712sig-v1.jsonld");
 /// <https://identity.foundation/presentation-exchange/submission/v1>
 pub const PRESENTATION_SUBMISSION_V1: &str = include_str!("../presentation-submission.jsonld");
+/// <https://w3id.org/vdl/v1>
+pub const VDL_V1: &str = include_str!("../w3id-vdl-v1.jsonld");
 
 pub const TZ_V2: &str = include_str!("../tz-2021-v2.jsonld");
 pub const TZVM_V1: &str = include_str!("../tzvm-2021-v1.jsonld");

--- a/contexts/w3id-vdl-v1.jsonld
+++ b/contexts/w3id-vdl-v1.jsonld
@@ -1,0 +1,110 @@
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "license": {
+      "@id": "https://w3id.org/vdl#license",
+      "@type": "@id"
+    },
+    "Iso18013DriversLicenseCredential": "https://w3id.org/vdl#Iso18013DriversLicenseCredential",
+    "Iso18013DriversLicense": {
+      "@id": "https://w3id.org/vdl#Iso18013DriversLicense",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "family_name": {
+          "@id": "https://w3id.org/vdl#family_name"
+        },
+        "given_name": {
+          "@id": "https://w3id.org/vdl#given_name"
+        },
+        "birth_date": {
+          "@id": "https://w3id.org/vdl#birth_date"
+        },
+        "issue_date": {
+          "@id": "https://w3id.org/vdl#issue_date",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "expiry_date": {
+          "@id": "https://w3id.org/vdl#expiry_date",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "issuing_country": {
+          "@id": "https://w3id.org/vdl#issuing_country"
+        },
+        "issuing_authority": {
+          "@id": "https://w3id.org/vdl#issuing_authority"
+        },
+        "document_number": {
+          "@id": "https://w3id.org/vdl#document_number"
+        },
+        "administrative_number": {
+          "@id": "https://w3id.org/vdl#administrative_number"
+        },
+        "driving_privileges": {
+          "@id": "https://w3id.org/vdl#driving_privileges",
+          "@type": "@json"
+        },
+        "un_distinguishing_sign": {
+          "@id": "https://w3id.org/vdl#un_distinguishing_sign"
+        },
+        "gender": {
+          "@id": "https://w3id.org/vdl#gender"
+        },
+        "height": {
+          "@id": "https://w3id.org/vdl#height"
+        },
+        "weight": {
+          "@id": "https://w3id.org/vdl#weight"
+        },
+        "eye_color": {
+          "@id": "https://w3id.org/vdl#eye_color"
+        },
+        "hair_color": {
+          "@id": "https://w3id.org/vdl#hair_color"
+        },
+        "birth_place": {
+          "@id": "https://w3id.org/vdl#birth_place"
+        },
+        "resident_address": {
+          "@id": "https://w3id.org/vdl#resident_address"
+        },
+        "portrait": {
+          "@id": "https://w3id.org/vdl#portrait"
+        },
+        "portrait_capture_date": {
+          "@id": "https://w3id.org/vdl#portrait_capture_date"
+        },
+        "age_in_years": {
+          "@id": "https://w3id.org/vdl#age_in_years"
+        },
+        "age_birth_year": {
+          "@id": "https://w3id.org/vdl#age_birth_year"
+        },
+        "issuing_jurisdiction": {
+          "@id": "https://w3id.org/vdl#issuing_jurisdiction"
+        },
+        "nationality": {
+          "@id": "https://w3id.org/vdl#nationality"
+        },
+        "resident_city": {
+          "@id": "https://w3id.org/vdl#resident_city"
+        },
+        "resident_state": {
+          "@id": "https://w3id.org/vdl#resident_state"
+        },
+        "resident_postal_code": {
+          "@id": "https://w3id.org/vdl#resident_postal_code"
+        },
+        "name_national_character": {
+          "@id": "https://w3id.org/vdl#name_national_character"
+        },
+        "signature_usual_mark": {
+          "@id": "https://w3id.org/vdl#signature_usual_mark"
+        }
+      }
+    }
+  }
+}

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -138,6 +138,7 @@ pub const EIP712SIG_V0_1_CONTEXT: &str = "https://demo.spruceid.com/ld/eip712sig
 pub const EIP712SIG_V1_CONTEXT: &str = "https://w3id.org/security/suites/eip712sig-2021/v1";
 pub const PRESENTATION_SUBMISSION_V1_CONTEXT: &str =
     "https://identity.foundation/presentation-exchange/submission/v1";
+pub const VDL_V1_CONTEXT: &str = "https://w3id.org/vdl/v1";
 
 lazy_static! {
     pub static ref CREDENTIALS_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
@@ -272,6 +273,12 @@ lazy_static! {
         let iri = Iri::new(PRESENTATION_SUBMISSION_V1_CONTEXT).unwrap();
         RemoteDocument::new(doc, iri)
     };
+    pub static ref VDL_V1_CONTEXT_DOCUMENT: RemoteDocument<JsonValue> = {
+        let jsonld = ssi_contexts::VDL_V1;
+        let doc = json::parse(jsonld).unwrap();
+        let iri = Iri::new(VDL_V1_CONTEXT).unwrap();
+        RemoteDocument::new(doc, iri)
+    };
 }
 
 pub struct StaticLoader;
@@ -314,6 +321,7 @@ impl Loader for StaticLoader {
                 PRESENTATION_SUBMISSION_V1_CONTEXT => {
                     Ok(PRESENTATION_SUBMISSION_V1_CONTEXT_DOCUMENT.clone())
                 }
+                VDL_V1_CONTEXT => Ok(VDL_V1_CONTEXT_DOCUMENT.clone()),
                 _ => {
                     eprintln!("unknown context {}", url);
                     Err(json_ld::ErrorCode::LoadingDocumentFailed.into())


### PR DESCRIPTION
Add JSON-LD context for Verifiable Driver's License Vocabulary ("vDL vocab")

Context file: https://w3id.org/vdl/v1
Specification: https://w3id.org/vdl

Proposed CCG work item: https://github.com/w3c-ccg/community/issues/218