### PR TITLE
Adds url with serde dep to prevent downstream build errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ reqwest = { version = "0.11", features = ["json"] }
 flate2 = "1.0"
 bitvec = "0.20"
 clear_on_drop = "0.2.4"
+url = { version = "2.2", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Resolves an install error downstream in `didkit-cli` which results in failing to build because `url` doesn't have the `serde` traits.