### PR TITLE
ES256K-R/EcdsaSecp256k1RecoverySignature2020 using Keccak256

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -230,6 +230,9 @@ pub enum Algorithm {
     /// https://github.com/decentralized-identity/EcdsaSecp256k1RecoverySignature2020#es256k-r
     #[serde(rename = "ES256K-R")]
     ES256KR,
+    /// like ES256K-R but using Keccak-256 instead of SHA-256
+    #[serde(rename = "ES256K-R")]
+    ESKeccakKR,
     ESBlake2b,
     ESBlake2bK,
     None,

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -237,7 +237,7 @@ pub trait ProofSuite {
     ) -> Result<VerificationWarnings, Error>;
 }
 
-pub type VerificationWarnings = Vec<String>;
+pub use crate::jws::VerificationWarnings;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -631,8 +631,7 @@ async fn verify_nojws(
     let key = resolve_key(&verification_method, resolver).await?;
     let message = to_jws_payload(document, proof).await?;
     let (_base, sig) = multibase::decode(proof_value)?;
-    crate::jws::verify_bytes(algorithm, &message, &key, &sig)?;
-    Ok(Default::default())
+    crate::jws::verify_bytes_warnable(algorithm, &message, &key, &sig)
 }
 
 pub struct RsaSignature2018;
@@ -1687,9 +1686,9 @@ impl ProofSuite for TezosSignature2021 {
         };
 
         // VM must have either publicKeyJwk or blockchainAccountId.
-        if let Some(vm_jwk) = vm.public_key_jwk {
-            // If VM has publicKey, use that to veify the signature.
-            crate::jws::verify_bytes(algorithm, &micheline, &vm_jwk, &sig)?;
+        let warnings = if let Some(vm_jwk) = vm.public_key_jwk {
+            // If VM has publicKey, use that to verify the signature.
+            crate::jws::verify_bytes_warnable(algorithm, &micheline, &vm_jwk, &sig)?
             // Note: VM blockchainAccountId is ignored in this case.
         } else if let Some(account_id) = account_id_opt {
             // VM does not have publicKeyJwk: proof must have public key
@@ -1697,14 +1696,14 @@ impl ProofSuite for TezosSignature2021 {
                 // Proof has public key: verify it with blockchainAccountId,
                 account_id.verify(&proof_jwk)?;
                 // and verify the signature.
-                crate::jws::verify_bytes(algorithm, &micheline, &proof_jwk, &sig)?;
+                crate::jws::verify_bytes_warnable(algorithm, &micheline, &proof_jwk, &sig)?
             } else {
                 return Err(Error::MissingKey);
             }
         } else {
             return Err(Error::MissingKey);
         };
-        Ok(Default::default())
+        Ok(warnings)
     }
 }
 
@@ -1834,9 +1833,9 @@ impl ProofSuite for TezosJcsSignature2021 {
         };
 
         // VM must have either publicKeyJwk or blockchainAccountId.
-        if let Some(vm_jwk) = vm.public_key_jwk {
-            // If VM has publicKey, use that to veify the signature.
-            crate::jws::verify_bytes(algorithm, &micheline, &vm_jwk, &sig)?;
+        let mut warnings = if let Some(vm_jwk) = vm.public_key_jwk {
+            // If VM has publicKey, use that to verify the signature.
+            crate::jws::verify_bytes_warnable(algorithm, &micheline, &vm_jwk, &sig)?
             // Note: VM blockchainAccountId is ignored in this case.
         } else if let Some(account_id) = account_id_opt {
             // VM does not have publicKeyJwk: proof must have public key
@@ -1850,14 +1849,15 @@ impl ProofSuite for TezosJcsSignature2021 {
                 // Proof has public key: verify it with blockchainAccountId,
                 account_id.verify(&proof_jwk)?;
                 // and verify the signature.
-                crate::jws::verify_bytes(algorithm, &micheline, &proof_jwk, &sig)?;
+                crate::jws::verify_bytes_warnable(algorithm, &micheline, &proof_jwk, &sig)?
             } else {
                 return Err(Error::MissingKey);
             }
         } else {
             return Err(Error::MissingKey);
         };
-        Ok(vec!["TezosJcsSignature2021 is experimental.".to_string()])
+        warnings.push("TezosJcsSignature2021 is experimental.".to_string());
+        Ok(warnings)
     }
 }
 
@@ -1945,8 +1945,7 @@ impl ProofSuite for SolanaSignature2021 {
         let tx = crate::soltx::LocalSolanaTransaction::with_message(&message);
         let bytes = tx.to_bytes();
         let sig = bs58::decode(&sig_b58).into_vec()?;
-        crate::jws::verify_bytes(Algorithm::EdDSA, &bytes, &key, &sig)?;
-        Ok(Default::default())
+        crate::jws::verify_bytes_warnable(Algorithm::EdDSA, &bytes, &key, &sig)
     }
 }
 
@@ -2093,8 +2092,7 @@ impl ProofSuite for JsonWebSignature2020 {
         self.validate_algorithm(header.algorithm)?;
         let key = resolve_key(verification_method, resolver).await?;
         self.validate_key_and_algorithm(&key, header.algorithm)?;
-        crate::jws::verify_bytes(header.algorithm, &signing_input, &key, &signature)?;
-        Ok(Default::default())
+        crate::jws::verify_bytes_warnable(header.algorithm, &signing_input, &key, &signature)
     }
     async fn complete(
         &self,

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -1120,8 +1120,16 @@ impl Credential {
         };
         let mut results = VerificationResult::new();
         if matched_jwt {
-            match crate::jws::verify_bytes(header.algorithm, &signing_input, &key, &signature) {
-                Ok(()) => results.checks.push(Check::JWS),
+            match crate::jws::verify_bytes_warnable(
+                header.algorithm,
+                &signing_input,
+                &key,
+                &signature,
+            ) {
+                Ok(mut warnings) => {
+                    results.checks.push(Check::JWS);
+                    results.warnings.append(&mut warnings);
+                }
                 Err(err) => results
                     .errors
                     .push(format!("Unable to filter proofs: {}", err)),
@@ -1633,8 +1641,16 @@ impl Presentation {
         };
         let mut results = VerificationResult::new();
         if matched_jwt {
-            match crate::jws::verify_bytes(header.algorithm, &signing_input, &key, &signature) {
-                Ok(()) => results.checks.push(Check::JWS),
+            match crate::jws::verify_bytes_warnable(
+                header.algorithm,
+                &signing_input,
+                &key,
+                &signature,
+            ) {
+                Ok(mut warnings) => {
+                    results.checks.push(Check::JWS);
+                    results.warnings.append(&mut warnings);
+                }
                 Err(err) => results
                     .errors
                     .push(format!("Unable to filter proofs: {}", err)),

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -14,7 +14,7 @@ use crate::one_or_many::OneOrMany;
 use crate::rdf::DataSet;
 
 use async_trait::async_trait;
-use chrono::{Duration, LocalResult, prelude::*};
+use chrono::{prelude::*, Duration, LocalResult};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -400,14 +400,16 @@ impl std::convert::TryFrom<DateTime<FixedOffset>> for NumericDate {
 
 impl std::convert::Into<DateTime<Utc>> for NumericDate {
     fn into(self) -> DateTime<Utc> {
-        let (whole_seconds, fractional_nanoseconds) = self.into_whole_seconds_and_fractional_nanoseconds();
+        let (whole_seconds, fractional_nanoseconds) =
+            self.into_whole_seconds_and_fractional_nanoseconds();
         Utc.timestamp(whole_seconds, fractional_nanoseconds)
     }
 }
 
 impl std::convert::Into<LocalResult<DateTime<Utc>>> for NumericDate {
     fn into(self) -> LocalResult<DateTime<Utc>> {
-        let (whole_seconds, fractional_nanoseconds) = self.into_whole_seconds_and_fractional_nanoseconds();
+        let (whole_seconds, fractional_nanoseconds) =
+            self.into_whole_seconds_and_fractional_nanoseconds();
         Utc.timestamp_opt(whole_seconds, fractional_nanoseconds)
     }
 }
@@ -2273,22 +2275,58 @@ pub(crate) mod tests {
 
     #[test]
     fn numeric_date() {
-        assert_eq!(NumericDate::try_from_seconds(NumericDate::MIN.as_seconds()).unwrap(), NumericDate::MIN, "NumericDate::MIN value did not survive round trip");
-        assert_eq!(NumericDate::try_from_seconds(NumericDate::MAX.as_seconds()).unwrap(), NumericDate::MAX, "NumericDate::MAX value did not survive round trip");
+        assert_eq!(
+            NumericDate::try_from_seconds(NumericDate::MIN.as_seconds()).unwrap(),
+            NumericDate::MIN,
+            "NumericDate::MIN value did not survive round trip"
+        );
+        assert_eq!(
+            NumericDate::try_from_seconds(NumericDate::MAX.as_seconds()).unwrap(),
+            NumericDate::MAX,
+            "NumericDate::MAX value did not survive round trip"
+        );
 
-        assert!(NumericDate::try_from_seconds(NumericDate::MIN.as_seconds() - 1.0e-6).is_err(), "NumericDate::MIN-1.0e-6 value did not hit out-of-range error");
-        assert!(NumericDate::try_from_seconds(NumericDate::MAX.as_seconds() + 1.0e-6).is_err(), "NumericDate::MAX+1.0e-6 value did not hit out-of-range error");
+        assert!(
+            NumericDate::try_from_seconds(NumericDate::MIN.as_seconds() - 1.0e-6).is_err(),
+            "NumericDate::MIN-1.0e-6 value did not hit out-of-range error"
+        );
+        assert!(
+            NumericDate::try_from_seconds(NumericDate::MAX.as_seconds() + 1.0e-6).is_err(),
+            "NumericDate::MAX+1.0e-6 value did not hit out-of-range error"
+        );
 
-        assert!(NumericDate::try_from_seconds(NumericDate::MIN.as_seconds() + 1.0e-6).is_ok(), "NumericDate::MIN-1.0e-6 value did not hit out-of-range error");
-        assert!(NumericDate::try_from_seconds(NumericDate::MAX.as_seconds() - 1.0e-6).is_ok(), "NumericDate::MAX+1.0e-6 value did not hit out-of-range error");
+        assert!(
+            NumericDate::try_from_seconds(NumericDate::MIN.as_seconds() + 1.0e-6).is_ok(),
+            "NumericDate::MIN-1.0e-6 value did not hit out-of-range error"
+        );
+        assert!(
+            NumericDate::try_from_seconds(NumericDate::MAX.as_seconds() - 1.0e-6).is_ok(),
+            "NumericDate::MAX+1.0e-6 value did not hit out-of-range error"
+        );
 
         let one_microsecond = Duration::microseconds(1);
-        assert_eq!((NumericDate::MIN + one_microsecond) - one_microsecond, NumericDate::MIN, "NumericDate::MIN+1.0e-6 wasn't correctly represented");
-        assert_eq!((NumericDate::MAX - one_microsecond) + one_microsecond, NumericDate::MAX, "NumericDate::MAX-1.0e-6 wasn't correctly represented");
+        assert_eq!(
+            (NumericDate::MIN + one_microsecond) - one_microsecond,
+            NumericDate::MIN,
+            "NumericDate::MIN+1.0e-6 wasn't correctly represented"
+        );
+        assert_eq!(
+            (NumericDate::MAX - one_microsecond) + one_microsecond,
+            NumericDate::MAX,
+            "NumericDate::MAX-1.0e-6 wasn't correctly represented"
+        );
 
         // At the MIN and MAX, increasing by half a microsecond shouldn't alter MIN or MAX.
-        assert_eq!(NumericDate::MIN - Duration::nanoseconds(500), NumericDate::MIN, "NumericDate::MIN isn't the true min");
-        assert_eq!(NumericDate::MAX + Duration::nanoseconds(500), NumericDate::MAX, "NumericDate::MAX isn't the true max");
+        assert_eq!(
+            NumericDate::MIN - Duration::nanoseconds(500),
+            NumericDate::MIN,
+            "NumericDate::MIN isn't the true min"
+        );
+        assert_eq!(
+            NumericDate::MAX + Duration::nanoseconds(500),
+            NumericDate::MAX,
+            "NumericDate::MAX isn't the true max"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Address #364 by re-allowing signatures that used Keccak-256 instead of SHA-256 in ES256K-R/EcdsaSecp256k1RecoverySignature2020, as this library produced before #351.

Without a way to distinguish the legacy signatures, this implementation uses a trial recovery approach. Verification is done by attempting to use SHA-256 hashing, and then if that fails, attempting to use Keccak-256. If using Keccak-256 succeeds, a warning is produced. The warning allows a verifier or holder know that the VC used the legacy signing implementation (and should probably therefore be re-issued).

This legacy compatibility for `ES256K-R` is added for verification in `EcdsaSecp256k1RecoverySignature2020`, and for `ES256K-R` in VC JWT format. Non-breaking API changes are made in order to return the warning in the VC JWT case.

In a future major version this legacy behavior could be moved into a non-default feature flag. For now I think it may be better to keep it without a feature flag, because didkit depends on ssi with `default-features = false`.