### PR TITLE
Enable crate feature info in rustdocs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,3 +111,7 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 difference = "2.0"
 did-method-key = { path = "./did-key" }
 tokio = { version = "1.0", features = ["macros"] }
+
+[package.metadata.docs.rs]
+features = ["secp256r1", "secp256k1", "ripemd-160", "http-did"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,20 +1,22 @@
 use crate::error::Error;
 
-#[cfg(feature = "sha2")]
+#[cfg(any(feature = "sha2", feature = "ring"))]
 pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(data);
-    let hash = hasher.finalize().into();
-    Ok(hash)
-}
-
-#[cfg(feature = "ring")]
-pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
-    use ring::digest;
-    use std::convert::TryInto;
-    let hash = digest::digest(&digest::SHA256, data).as_ref().try_into()?;
-    Ok(hash)
+    #[cfg(feature = "sha2")]
+    {
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(data);
+        let hash = hasher.finalize().into();
+        Ok(hash)
+    }
+    #[cfg(feature = "ring")]
+    {
+        use ring::digest;
+        use std::convert::TryInto;
+        let hash = digest::digest(&digest::SHA256, data).as_ref().try_into()?;
+        Ok(hash)
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 pub mod bbs;
 pub mod blakesig;
 pub mod caip10;


### PR DESCRIPTION
As mentioned in https://github.com/spruceid/ssi/pull/360#discussion_r780338507

The [`doc_cfg`](https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html) and `doc_auto_cfg` features are described in https://github.com/rust-lang/rust/pull/90502 and enable rustdocs to render uses of `#[cfg(feature = ...])`. These features are enabled using a cfg attribute `docsrs` which is enabled in Cargo.toml for docs.rs. It can also be enabled on the command-line as in the following command to build the docs:
`RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --no-deps --features secp256r1,secp256k1,ripemd-160,http-did`

After building docs with that command, open `target/doc/ssi/hash/fn.sha256.html`:
![Screenshot of ssi::hash::sha256 rustdocs with feature info](https://demo.didkit.dev/2022/01/07/sha256-rustdoc.png)

Features secp256r1,secp256k1,ripemd-160,http-did are set as enabled by default for the docs.rs build (from 883f3c48ba17cd7a5a9248065de998a784a94ffb in #311).

I combined the two sha256 function implementations into one function, as I wasn't otherwise able to get the docs to list its supported crate features as "sha2 or ring".