### PR TITLE
Add script to fetch context files

### DIFF
--- a/contexts/README.md
+++ b/contexts/README.md
@@ -7,6 +7,10 @@
 [Decentralized Identifiers]: https://www.w3.org/TR/did-core/
 [Linked Data Proofs]: https://w3c-ccg.github.io/ld-proofs/
 
+## Updating
+
+Sometimes context files change over time. This crate aims to keep up to date with upstream changes in the context files it contains. To manually re-fetch the context files, run the script [update.sh](./update.sh) in the source directory.
+
 ## Licenses
 
 The licenses of the context files are summarized in the following table. For more details, see the [LICENSES.md](./LICENSES.md) file.

--- a/contexts/src/lib.rs
+++ b/contexts/src/lib.rs
@@ -1,3 +1,5 @@
+// Note: update ../update.sh when updating URLs/filenames in this file.
+
 /// <https://www.w3.org/2018/credentials/v1>
 pub const CREDENTIALS_V1: &str = include_str!("../w3c-2018-credentials-v1.jsonld");
 /// <https://www.w3.org/2018/credentials/examples/v1>

--- a/contexts/update.sh
+++ b/contexts/update.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Note: update src/lib.rs when updating URLs/filenames in this file.
+cd "$(dirname "$0")" || exit 1
+exec curl \
+	https://www.w3.org/2018/credentials/v1 -o w3c-2018-credentials-v1.jsonld \
+	https://www.w3.org/2018/credentials/examples/v1 -o w3c-2018-credentials-examples-v1.jsonld \
+	https://www.w3.org/ns/odrl.jsonld -o w3c-odrl.jsonld \
+	https://schema.org/docs/jsonldcontext.jsonld -o schema.org.jsonld \
+	https://w3id.org/security/v1 -o w3id-security-v1.jsonld \
+	https://w3id.org/security/v2 -o w3id-security-v2.jsonld \
+	https://www.w3.org/ns/did/v1 -o w3c-did-v1.jsonld \
+	https://w3id.org/did-resolution/v1 -o w3c-did-resolution-v1.jsonld \
+	https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/lds-ecdsa-secp256k1-recovery2020-0.0.jsonld -o dif-lds-ecdsa-secp256k1-recovery2020-0.0.jsonld \
+	https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json -o lds-jws2020-v1.jsonld \
+	https://w3id.org/security/suites/jws-2020/v1 -o w3id-jws2020-v1.jsonld \
+	https://w3id.org/security/suites/ed25519-2020/v1 -o w3id-ed25519-signature-2020-v1.jsonld \
+	https://w3id.org/security/suites/blockchain-2021/v1 -o w3id-blockchain-2021-v1.jsonld \
+	https://w3id.org/citizenship/v1 -o w3c-ccg-citizenship-v1.jsonld \
+	https://w3id.org/vaccination/v1 -o w3c-ccg-vaccination-v1.jsonld \
+	https://w3id.org/traceability/v1 -o w3c-ccg-traceability-v1.jsonld \
+	https://demo.spruceid.com/EcdsaSecp256k1RecoverySignature2020/esrs2020-extra-0.0.jsonld -o esrs2020-extra-0.0.jsonld \
+	https://w3id.org/security/bbs/v1 -o bbs-v1.jsonld \
+	https://identity.foundation/presentation-exchange/submission/v1 -o presentation-submission.jsonld \
+	https://w3id.org/vdl/v1 -o w3id-vdl-v1.jsonld \
+	-L


### PR DESCRIPTION
This adds a shell script to re-fetch the bundled context files. This is to make it easier to manually check the context files for new versions (i.e. for updating as in #250 and #375).