### PR TITLE
Update webkey:gpg for didkit-wasm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,6 @@ jobs:
       with:
         submodules: true
 
-    - name: Install additional build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install nettle-dev capnproto
-
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v2
       with:

--- a/README.md
+++ b/README.md
@@ -40,18 +40,6 @@ clang
 openssl-devel
 ```
 
-If using feature `did-webkey/sequoia-openpgp` for PGP support, the following
-dependencies are also needed:
-
-```
-nettle-dev
-capnproto
-```
-
-If using feature
-[`did-webkey/crypto-cng`](https://gitlab.com/sequoia-pgp/sequoia#cryptography),
-only `capnproto` is needed.
-
 ## Install
 
 ### Crates.io

--- a/did-webkey/Cargo.toml
+++ b/did-webkey/Cargo.toml
@@ -12,9 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-webkey/"
 documentation = "https://docs.rs/did-webkey/"
 
 [features]
-default = ["ssi/ring", "crypto-nettle"]
-crypto-cng = ["sequoia-openpgp/crypto-cng"]
-crypto-nettle = ["sequoia-openpgp/crypto-nettle"]
+default = ["ssi/ring"]
 p256 = ["ssi/p256"]
 
 [dependencies]
@@ -30,13 +28,8 @@ serde_json = "1.0.75"
 serde = { version = "1.0.134", features = ["derive"] }
 sshkeys = "0.3.1"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-sequoia-openpgp = { version = "1.7.0", features = [
-    "compression-deflate",
-], default-features = false, optional = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 sequoia-openpgp = { version = "1.7.0", default-features = false, features = [
+    "compression-deflate",
     "crypto-rust",
     "allow-experimental-crypto",
     "allow-variable-time-crypto",

--- a/did-webkey/src/lib.rs
+++ b/did-webkey/src/lib.rs
@@ -4,14 +4,11 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use anyhow::{anyhow, Context, Result};
-#[cfg(feature = "sequoia-openpgp")]
-use openpgp::{
+use sequoia_openpgp::{
     cert::prelude::*,
     parse::{PacketParser, Parse},
     serialize::SerializeInto,
 };
-#[cfg(feature = "sequoia-openpgp")]
-use sequoia_openpgp as openpgp;
 use sshkeys::PublicKeyKind;
 use ssi::did::{DIDMethod, Document, VerificationMethod, VerificationMethodMap, DIDURL};
 use ssi::did_resolve::{
@@ -47,7 +44,6 @@ impl FromStr for DIDWebKeyType {
     }
 }
 
-#[cfg(feature = "sequoia-openpgp")]
 fn parse_pubkeys_gpg(
     did: &str,
     bytes: Vec<u8>,
@@ -66,7 +62,6 @@ fn parse_pubkeys_gpg(
     Ok((vm_maps, did_urls))
 }
 
-#[cfg(feature = "sequoia-openpgp")]
 fn gpg_pk_to_vm(did: &str, cert: Cert) -> Result<(VerificationMethodMap, DIDURL)> {
     let vm_url = DIDURL {
         did: did.to_string(),
@@ -473,7 +468,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "sequoia-openpgp")]
     async fn from_did_webkey_gpg() {
         let did_url: &str = "https://localhost/user.gpg";
         let pubkeys: &str = include_str!("../tests/user.gpg");


### PR DESCRIPTION
Extends #373. Enable use with didkit-wasm in https://github.com/spruceid/didkit/pull/261.

I found it necessary to remove use of `sequoia-openpgp` as a feature and optional dependency (c73e6af56e720a3855b4ebf177fcf8c30995257b); this follows the changes in aaae84f0005290b035db6d052d83e3962beff4f3 which removed the option of using `rpgp` as an alternative (since it was not as effective at parsing). This PR also changes `did:webkey` to use `sequoia-openpgp/crypto-rust` unconditionally (db3fd3ef89069bd3e1f1b42501e48b029ede4f12), since architecture-conditional dependency features are not working (https://github.com/spruceid/ssi/pull/373#issuecomment-1049042945). Note that this PR (as well as #373) adds some redundant use of crypto dependencies, since e.g. `ed25519-dalek` and `rsa` are brought in by `sequoia-openpgp/crypto-rust`, while `ring` is still used in `ssi`.