### PR TITLE
ssi v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] 2022-03-02
 ### Added
 - Use CAIP-10 in did:pkh ([#279](https://github.com/spruceid/ssi/pull/279), [#286](https://github.com/spruceid/ssi/pull/286), [#303](https://github.com/spruceid/ssi/pull/303)).
 - Use updated JsonWebSignature2020 context file ([#322](https://github.com/spruceid/ssi/pull/322)).
@@ -322,7 +324,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [vc-test-suite]: https://github.com/w3c/vc-test-suite
 [verification relationship]: https://www.w3.org/TR/did-core/#dfn-verification-relationship
 
-[Unreleased]: https://github.com/spruceid/ssi/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/spruceid/ssi/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/spruceid/ssi/releases/tag/v0.4.0
 [0.3.0]: https://github.com/spruceid/ssi/releases/tag/v0.3.0
 [0.2.2]: https://github.com/spruceid/ssi/releases/tag/v0.2.2
 [0.2.1]: https://github.com/spruceid/ssi/releases/tag/v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ openssl-devel
 ### Crates.io
 
 ```
-ssi = "0.3"
+ssi = "0.4"
 ```
 
 ### From Source

--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-ethr/"
 documentation = "https://docs.rs/did-ethr/"
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false, features = ["secp256k1", "keccak"] }
+ssi = { version = "0.4", path = "../", default-features = false, features = ["secp256k1", "keccak"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/did-ion/Cargo.toml
+++ b/did-ion/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/did-ion/"
 [features]
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false, features = ["http-did", "secp256k1"] }
+ssi = { version = "0.4", path = "../", default-features = false, features = ["http-did", "secp256k1"] }
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -16,7 +16,7 @@ secp256k1 = ["k256", "ssi/secp256k1"]
 secp256r1 = ["p256", "ssi/secp256r1"]
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false }
+ssi = { version = "0.4", path = "../", default-features = false }
 async-trait = "0.1"
 thiserror = "1.0"
 multibase = "0.8"

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/did-onion/"
 tor-tests = []
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false }
+ssi = { version = "0.4", path = "../", default-features = false }
 async-trait = "0.1"
 reqwest = { version = "0.11", features = ["json", "socks"] }
 http = "0.2"

--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-pkh/"
 documentation = "https://docs.rs/did-pkh/"
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false, features = ["secp256k1", "keccak-hash", "secp256r1", "ripemd160"] }
+ssi = { version = "0.4", path = "../", default-features = false, features = ["secp256k1", "keccak-hash", "secp256r1", "ripemd160"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/did-sol/Cargo.toml
+++ b/did-sol/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-sol/"
 documentation = "https://docs.rs/did-sol/"
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false, features = [] }
+ssi = { version = "0.4", path = "../", default-features = false, features = [] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/did-test/Cargo.toml
+++ b/did-test/Cargo.toml
@@ -8,7 +8,7 @@ description = "did-test-suite test vector generator"
 publish = false
 
 [dependencies]
-ssi = { version = "0.3", path = "../" }
+ssi = { version = "0.4", path = "../" }
 did-method-key = { version = "0.1", path = "../../ssi/did-key", features = ["secp256k1", "secp256r1"] }
 did-tz = { version = "0.1", path = "../../ssi/did-tezos", default-features = false, features = ["secp256k1", "secp256r1"] }
 did-pkh = { version = "0.1", path = "../../ssi/did-pkh" }

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -19,7 +19,7 @@ secp256r1 = ["ssi/secp256r1"]
 p256 = ["secp256r1"]
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false }
+ssi = { version = "0.4", path = "../", default-features = false }
 chrono = { version = "0.4" }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-web/"
 documentation = "https://docs.rs/did-web/"
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false }
+ssi = { version = "0.4", path = "../", default-features = false }
 async-trait = "0.1"
 reqwest = { version = "0.11", features = ["json"] }
 http = "0.2"

--- a/did-webkey/Cargo.toml
+++ b/did-webkey/Cargo.toml
@@ -16,7 +16,7 @@ default = ["ssi/ring"]
 p256 = ["ssi/p256"]
 
 [dependencies]
-ssi = { version = "0.3", path = "../", default-features = false, features = [
+ssi = { version = "0.4", path = "../", default-features = false, features = [
     "secp256r1",
 ] }
 anyhow = "1.0.52"

--- a/vc-test/Cargo.toml
+++ b/vc-test/Cargo.toml
@@ -8,7 +8,7 @@ description = "vc-test-suite test driver for ssi"
 publish = false
 
 [dependencies]
-ssi = { version = "0.3", path = "../", features = ["example-http-issuer"] }
+ssi = { version = "0.4", path = "../", features = ["example-http-issuer"] }
 async-std = { version = "1.9", features = ["attributes"] }
 serde_json = "1.0"
 base64 = "0.12"


### PR DESCRIPTION
Tag ssi v0.4.0 for publishing to crates.io.

DID method crates to be updated after `ssi` is published.


### Breaking changes 
- ES256K-R/EcdsaSecp256k1RecoverySignature2020 hashing changed. #351, #367
- VC-JWT timestamps constrained to between year 1685 and 2255, for microsecond precision. #315
- Various API changes