### PR TITLE
Use default ssi/ring in DID method crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,6 @@ members = [
 blake2_old = { package = "blake2", version = "0.8" } # for bbs doctest
 uuid = { version = "0.8", features = ["v4", "serde"] }
 difference = "2.0"
-did-method-key = { path = "./did-key" }
 tokio = { version = "1.0", features = ["macros"] }
 hyper = { version = "0.14", features = ["server", "http1", "stream"] }
 

--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-ethr/"
 documentation = "https://docs.rs/did-ethr/"
 
+[features]
+default = ["ssi/ring"]
+
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false, features = ["secp256k1", "keccak"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/did-ion/Cargo.toml
+++ b/did-ion/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-ion/"
 documentation = "https://docs.rs/did-ion/"
 
 [features]
+default = ["ssi/ring"]
 
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false, features = ["http-did", "secp256k1"] }

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-key/"
 documentation = "https://docs.rs/did-key/"
 
 [features]
+default = ["ssi/ring"]
 secp256k1 = ["k256", "ssi/secp256k1"]
 secp256r1 = ["p256", "ssi/secp256r1"]
 

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-onion/"
 documentation = "https://docs.rs/did-onion/"
 
 [features]
+default = ["ssi/ring"]
 tor-tests = []
 
 [dependencies]

--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-pkh/"
 documentation = "https://docs.rs/did-pkh/"
 
+[features]
+default = ["ssi/ring"]
+
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false, features = ["secp256k1", "keccak-hash", "secp256r1", "ripemd160"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-web/"
 documentation = "https://docs.rs/did-web/"
 
+[features]
+default = ["ssi/ring"]
+
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false }
 async-trait = "0.1"


### PR DESCRIPTION
This updates DID method crates to follow the pattern of `did:tz` and `did:webkey` which use `ssi/ring` as a default feature, so that a build works by default.

e.g. these should all succeed:
```
cargo test -p did-ion
cargo test -p did-method-key
cargo test -p did-onion
cargo test -p did-pkh
cargo test -p did-pkh
cargo test -p did-tz
cargo test -p did-web
cargo test -p did-webkey
```

This should fix #169, #310, and #396.

DIDKit will need to be updated to set `default-features=false` for these crates - except for did-tz and did-webkey which already have this set.

A dev-dependency on did-method-key triggered default features on did-method-key; that dev-dependency but does not seem to be used anywhere, so is removed.