### PR TITLE
Update DID method crates for ssi v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,6 @@ members = [
 blake2_old = { package = "blake2", version = "0.8" } # for bbs doctest
 uuid = { version = "0.8", features = ["v4", "serde"] }
 difference = "2.0"
-did-method-key = { path = "./did-key" }
 tokio = { version = "1.0", features = ["macros"] }
 hyper = { version = "0.14", features = ["server", "http1", "stream"] }
 

--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-ethr"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-ethr/Cargo.toml
+++ b/did-ethr/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-ethr/"
 documentation = "https://docs.rs/did-ethr/"
 
+[features]
+default = ["ssi/ring"]
+
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false, features = ["secp256k1", "keccak"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/did-ion/Cargo.toml
+++ b/did-ion/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-ion/"
 documentation = "https://docs.rs/did-ion/"
 
 [features]
+default = ["ssi/ring"]
 
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false, features = ["http-did", "secp256k1"] }

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-method-key"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-key/"
 documentation = "https://docs.rs/did-key/"
 
 [features]
+default = ["ssi/ring"]
 secp256k1 = ["k256", "ssi/secp256k1"]
 secp256r1 = ["p256", "ssi/secp256r1"]
 

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-onion/"
 documentation = "https://docs.rs/did-onion/"
 
 [features]
+default = ["ssi/ring"]
 tor-tests = []
 
 [dependencies]

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-onion"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-pkh/"
 documentation = "https://docs.rs/did-pkh/"
 
+[features]
+default = ["ssi/ring"]
+
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false, features = ["secp256k1", "keccak-hash", "secp256r1", "ripemd160"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/did-pkh/Cargo.toml
+++ b/did-pkh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-pkh"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-tz"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-web/"
 documentation = "https://docs.rs/did-web/"
 
+[features]
+default = ["ssi/ring"]
+
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false }
 async-trait = "0.1"

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-web"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"

--- a/did-webkey/Cargo.toml
+++ b/did-webkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-webkey"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Increment versions of workspace crates for publishing to `crates.io`.

Includes #402 which should fix the `docs.rs` builds of these crates (#169).

<details>
<summary>Command to test publish crates</summary>

```
for method in ethr key onion pkh tezos web webkey ion; do cargo publish --dry-run --manifest-path did-$method/Cargo.toml; done
```
Remove `--dry-run` to publish for real.
</summary>