### PR TITLE
Require credentialSubject to be non-empty

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -142,6 +142,12 @@ pub enum Error {
     MissingProof,
     /// Missing issuance date
     MissingIssuanceDate,
+    /// Credential subject must be non-empty
+    ///
+    /// [Verifiable credential subject](crate::vc::CredentialSubject) arity must be positive
+    /// and value must be non-empty, per [VC
+    /// Data Model](https://www.w3.org/TR/vc-data-model/#credential-subject).
+    EmptyCredentialSubject,
     /// Missing type VerifiableCredential
     MissingTypeVerifiableCredential,
     /// Missing type VerifiablePresentation
@@ -408,6 +414,7 @@ impl fmt::Display for Error {
             Error::MissingPrime => write!(f, "Missing prime factor in RSA key"),
             Error::MissingKeyParameters => write!(f, "JWT key parameters not found"),
             Error::MissingProof => write!(f, "Missing proof property"),
+            Error::EmptyCredentialSubject => write!(f, "Credential subject must be non-empty"),
             Error::MissingIssuanceDate => write!(f, "Missing issuance date"),
             Error::MissingTypeVerifiableCredential => {
                 write!(f, "Missing type VerifiableCredential")

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -114,6 +114,22 @@ pub struct CredentialSubject {
     pub property_set: Option<Map<String, Value>>,
 }
 
+impl CredentialSubject {
+    /// Check if the credential subject is empty
+    ///
+    /// An empty credential subject (containing no properties, not even an id property) is
+    /// considered invalid, as the VC Data Model defines the value of the
+    /// [credentialSubject](https://www.w3.org/TR/vc-data-model/#credential-subject) property as
+    /// "a set of objects that contain one or more properties [...]"
+    pub fn is_empty(&self) -> bool {
+        self.id.is_none()
+            && match self.property_set {
+                Some(ref ps) => ps.is_empty(),
+                None => true,
+            }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum Issuer {
@@ -1168,6 +1184,18 @@ impl Credential {
         }
         if self.issuer.is_none() {
             return Err(Error::MissingIssuer);
+        }
+        if self.credential_subject.is_empty() {
+            // https://www.w3.org/TR/vc-data-model/#credential-subject
+            // VC-Data-Model "defines a credentialSubject property for the expression of claims
+            // about one or more subjects."
+            // Therefore, zero credentialSubject values is considered invalid.
+            return Err(Error::EmptyCredentialSubject);
+        }
+        for subject in &self.credential_subject {
+            if subject.is_empty() {
+                return Err(Error::EmptyCredentialSubject);
+            }
         }
         if self.issuance_date.is_none() {
             return Err(Error::MissingIssuanceDate);
@@ -3004,7 +3032,9 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             "type": ["VerifiableCredential"],
             "issuer": "did:example:foo",
             "issuanceDate": "2021-08-25T18:38:54Z",
-            "credentialSubject": {},
+            "credentialSubject": {
+              "id": "did:example:foo"
+            },
             "credentialStatus": {
                 "id": "_:1",
                 "type": "RevocationList2020Status",
@@ -3021,7 +3051,9 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             "type": ["VerifiableCredential"],
             "issuer": "did:example:foo",
             "issuanceDate": "2021-08-25T20:15:45Z",
-            "credentialSubject": {},
+            "credentialSubject": {
+              "id": "did:example:foo"
+            },
             "credentialStatus": {
                 "id": "_:1",
                 "type": "RevocationList2020Status",


### PR DESCRIPTION
As seen in https://github.com/decentralized-identity/JWS-Test-Suite/issues/46, VC Data Model appears to require that [credentialSubject](https://www.w3.org/TR/vc-data-model/#credential-subject) contains at least one property. Similarly, there must be at least one credential subject. This PR adds checks for these two cases (no empty-object or empty-array credentialSubject values), and updates two examples to use non-empty credentialSubject values. Signed test vectors using empty credentialSubject with data integrity proofs are updated to use a blank node id as the credential subject id, since this does not require reissuing those credential.