### PR TITLE
Usability improvement regarding ssi::vc::VCDateTime

### DIFF
--- a/src/vc.rs
+++ b/src/vc.rs
@@ -729,6 +729,15 @@ where
     }
 }
 
+impl<Tz: chrono::TimeZone> Into<DateTime<Tz>> for VCDateTime
+where
+    chrono::DateTime<chrono::FixedOffset>: Into<chrono::DateTime<Tz>>,
+{
+    fn into(self) -> DateTime<Tz> {
+        self.date_time.into()
+    }
+}
+
 pub fn base64_encode_json<T: Serialize>(object: &T) -> Result<String, Error> {
     let json = serde_json::to_string(&object)?;
     Ok(base64::encode_config(json, base64::URL_SAFE_NO_PAD))
@@ -2465,6 +2474,14 @@ pub(crate) mod tests {
         }"###;
         let doc: Credential = serde_json::from_str(doc_str).unwrap();
         println!("{}", serde_json::to_string_pretty(&doc).unwrap());
+    }
+
+    #[test]
+    fn test_vc_date_time_roundtrip() {
+        let expected_utc_now = chrono::Utc::now();
+        let vc_date_time_now = VCDateTime::from(expected_utc_now);
+        let roundtripped_utc_now: chrono::DateTime::<chrono::Utc> = vc_date_time_now.into();
+        assert_eq!(roundtripped_utc_now, expected_utc_now);
     }
 
     #[async_std::test]


### PR DESCRIPTION
Added a crucial, missing conversion -- ssi::vc::VCDateTime into chrono::DateTime<Tz>.  Without this, it's not possible to get a DateTime<Tz> back out of a VCDateTime.