### PR TITLE
Address cargo clippy warnings

### DIFF
--- a/src/did.rs
+++ b/src/did.rs
@@ -339,6 +339,7 @@ pub struct Proof {
 #[derive(Debug, Serialize, Clone, PartialEq)]
 #[non_exhaustive]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum Resource {
     /// Verification method map.
     ///
@@ -439,6 +440,7 @@ pub struct DIDDeactivate {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "didDocumentOperation", content = "didDocument")]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::large_enum_variant)]
 pub enum DIDDocumentOperation {
     /// Set the contents of the DID document
     ///
@@ -829,7 +831,7 @@ impl VerificationMethodMap {
                 if pk_bytes.len() != 34 {
                     return Err(Error::MultibaseKeyLength(34, pk_bytes.len()));
                 }
-                if &pk_bytes[0..2] != MULTICODEC_ED25519_PREFIX {
+                if pk_bytes[0..2] != MULTICODEC_ED25519_PREFIX {
                     return Err(Error::MultibaseKeyPrefix);
                 }
                 crate::jwk::Params::OKP(crate::jwk::OctetParams {
@@ -943,7 +945,7 @@ impl FromStr for RelativeDIDURLPath {
         } else {
             // path-noscheme = segment-nz-nc *( "/" segment )
             // segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
-            let first_segment = path.splitn(2, '/').next().unwrap().to_string();
+            let first_segment = path.split_once('/').map_or(path, |x| x.0).to_string();
             if first_segment.contains(':') {
                 // First path segment containing ":" would make an absolute URI.
                 return Err(Error::DIDURL);

--- a/src/did_resolve.rs
+++ b/src/did_resolve.rs
@@ -193,6 +193,7 @@ pub struct DereferencingMetadata {
 #[derive(Debug, Serialize, Clone, PartialEq)]
 /// A resource returned by [DID URL dereferencing][dereference]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum Content {
     /// A DID Document
     DIDDocument(Document),
@@ -859,6 +860,7 @@ impl HTTPDIDResolver {
     }
 }
 
+#[cfg(feature = "http")]
 fn transform_resolution_result(
     result: Result<ResolutionResult, serde_json::Error>,
 ) -> (

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -911,7 +911,7 @@ impl TypedData {
             // changed in https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/pull/32
             .or_else(|| proof_obj.remove("eip712Domain"));
         doc_obj.insert("proof".to_string(), proof_value);
-        let mut message = EIP712Value::try_from(doc_value)
+        let message = EIP712Value::try_from(doc_value)
             .map_err(TypedDataConstructionJSONError::ConvertMessage)?;
         let proof_info: ProofInfo = match info {
             Some(info) => {

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -1643,7 +1643,7 @@ where
     T: Loader<Document = JsonValue> + std::marker::Send + Sync,
 {
     let options = options.unwrap_or(&DEFAULT_JSON_LD_OPTIONS);
-    let expanded_doc = expand_json(json, more_contexts_json, lax, Some(&options), loader).await?;
+    let expanded_doc = expand_json(json, more_contexts_json, lax, Some(options), loader).await?;
     let mut node_map = Map::new();
     node_map.insert(AT_DEFAULT.to_string(), Map::new());
     let mut blank_node_id_generator = BlankNodeIdentifierGenerator::default();

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -864,7 +864,7 @@ pub enum RsaX509PubParseError {
 
 /// Parse a "RSA public key (X.509 encoded)" (multicodec) into a JWK.
 pub fn rsa_x509_pub_parse(pk_bytes: &[u8]) -> Result<JWK, RsaX509PubParseError> {
-    let rsa_pk: RSAPublicKey = simple_asn1::der_decode(&pk_bytes)?;
+    let rsa_pk: RSAPublicKey = simple_asn1::der_decode(pk_bytes)?;
     let rsa_params = RSAParams::try_from(&rsa_pk)?;
     Ok(JWK::from(Params::RSA(rsa_params)))
 }

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -250,7 +250,8 @@ pub fn verify_bytes_warnable(
     key: &JWK,
     signature: &[u8],
 ) -> Result<VerificationWarnings, Error> {
-    let warnings = VerificationWarnings::default();
+    #[allow(unused_mut)]
+    let mut warnings = VerificationWarnings::default();
     if let Some(key_algorithm) = key.algorithm {
         if key_algorithm != algorithm
             && !(key_algorithm == Algorithm::EdDSA && algorithm == Algorithm::EdBlake2b)

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -250,7 +250,7 @@ pub fn verify_bytes_warnable(
     key: &JWK,
     signature: &[u8],
 ) -> Result<VerificationWarnings, Error> {
-    let mut warnings = VerificationWarnings::default();
+    let warnings = VerificationWarnings::default();
     if let Some(key_algorithm) = key.algorithm {
         if key_algorithm != algorithm
             && !(key_algorithm == Algorithm::EdDSA && algorithm == Algorithm::EdBlake2b)

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -1380,7 +1380,6 @@ impl ProofSuite for EthereumEip712Signature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
     ) -> Result<VerificationWarnings, Error> {
-        use std::str::FromStr;
         let sig_hex = proof
             .proof_value
             .as_ref()

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -513,7 +513,6 @@ async fn sign_proof(
 async fn sign_nojws(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
-    _resolver: &dyn DIDResolver,
     key: &JWK,
     type_: &str,
     algorithm: Algorithm,
@@ -532,7 +531,7 @@ async fn sign_nojws(
         proof.context = serde_json::json!([context_uri]);
     }
     let message = to_jws_payload(document, &proof).await?;
-    let sig = crate::jws::sign_bytes(algorithm, &message, &key)?;
+    let sig = crate::jws::sign_bytes(algorithm, &message, key)?;
     let sig_multibase = multibase::encode(multibase::Base::Base58Btc, sig);
     proof.proof_value = Some(sig_multibase);
     Ok(proof)
@@ -576,7 +575,6 @@ async fn prepare_proof(
 async fn prepare_nojws(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
-    _resolver: &dyn DIDResolver,
     public_key: &JWK,
     type_: &str,
     algorithm: Algorithm,
@@ -644,7 +642,7 @@ async fn verify_nojws(
         .verification_method
         .as_ref()
         .ok_or(Error::MissingVerificationMethod)?;
-    let key = resolve_key(&verification_method, resolver).await?;
+    let key = resolve_key(verification_method, resolver).await?;
     let message = to_jws_payload(document, proof).await?;
     let (_base, sig) = multibase::decode(proof_value)?;
     crate::jws::verify_bytes_warnable(algorithm, &message, &key, &sig)
@@ -776,14 +774,13 @@ impl ProofSuite for Ed25519Signature2020 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
+        _resolver: &dyn DIDResolver,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
         sign_nojws(
             document,
             options,
-            resolver,
             key,
             "Ed25519Signature2020",
             Algorithm::EdDSA,
@@ -804,14 +801,13 @@ impl ProofSuite for Ed25519Signature2020 {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
+        _resolver: &dyn DIDResolver,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         prepare_nojws(
             document,
             options,
-            resolver,
             public_key,
             "Ed25519Signature2020",
             Algorithm::EdDSA,

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -256,10 +256,8 @@ impl CredentialStatus for RevocationList2020Status {
             match load_credential(&self.revocation_list_credential).await {
                 Ok(credential) => credential,
                 Err(e) => {
-                    return result.with_error(format!(
-                        "Unable to fetch revocation list credential: {}",
-                        e.to_string()
-                    ));
+                    return result
+                        .with_error(format!("Unable to fetch revocation list credential: {}", e));
                 }
             };
         let list_issuer_id = match &revocation_list_credential.issuer {
@@ -278,7 +276,7 @@ impl CredentialStatus for RevocationList2020Status {
 
         match revocation_list_credential.validate() {
             Err(e) => {
-                return result.with_error(format!("Invalid list credential: {}", e.to_string()));
+                return result.with_error(format!("Invalid list credential: {}", e));
             }
             Ok(()) => {}
         }
@@ -300,10 +298,8 @@ impl CredentialStatus for RevocationList2020Status {
             match RevocationList2020Credential::try_from(revocation_list_credential) {
                 Ok(credential) => credential,
                 Err(e) => {
-                    return result.with_error(format!(
-                        "Unable to parse revocation list credential: {}",
-                        e.to_string()
-                    ));
+                    return result
+                        .with_error(format!("Unable to parse revocation list credential: {}", e));
                 }
             };
         if revocation_list_credential.id != URI::String(self.revocation_list_credential.to_string())
@@ -318,12 +314,7 @@ impl CredentialStatus for RevocationList2020Status {
 
         let list = match List::try_from(&revocation_list.encoded_list) {
             Ok(list) => list,
-            Err(e) => {
-                return result.with_error(format!(
-                    "Unable to decode revocation list: {}",
-                    e.to_string()
-                ))
-            }
+            Err(e) => return result.with_error(format!("Unable to decode revocation list: {}", e)),
         };
         let credential_index = self.revocation_list_index.0;
         use bitvec::prelude::*;

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -414,18 +414,18 @@ impl std::convert::TryFrom<DateTime<FixedOffset>> for NumericDate {
     }
 }
 
-impl std::convert::Into<DateTime<Utc>> for NumericDate {
-    fn into(self) -> DateTime<Utc> {
+impl From<NumericDate> for DateTime<Utc> {
+    fn from(nd: NumericDate) -> Self {
         let (whole_seconds, fractional_nanoseconds) =
-            self.into_whole_seconds_and_fractional_nanoseconds();
+            nd.into_whole_seconds_and_fractional_nanoseconds();
         Utc.timestamp(whole_seconds, fractional_nanoseconds)
     }
 }
 
-impl std::convert::Into<LocalResult<DateTime<Utc>>> for NumericDate {
-    fn into(self) -> LocalResult<DateTime<Utc>> {
+impl From<NumericDate> for LocalResult<DateTime<Utc>> {
+    fn from(nd: NumericDate) -> Self {
         let (whole_seconds, fractional_nanoseconds) =
-            self.into_whole_seconds_and_fractional_nanoseconds();
+            nd.into_whole_seconds_and_fractional_nanoseconds();
         Utc.timestamp_opt(whole_seconds, fractional_nanoseconds)
     }
 }

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -310,6 +310,7 @@ pub struct Presentation {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum CredentialOrJWT {
     Credential(Credential),
     JWT(String),
@@ -382,7 +383,7 @@ impl std::ops::Sub<NumericDate> for NumericDate {
     fn sub(self, rhs: NumericDate) -> Self::Output {
         let self_dtu: DateTime<Utc> = self.into();
         let rhs_dtu: DateTime<Utc> = rhs.into();
-        Self::Output::try_from(self_dtu - rhs_dtu).unwrap()
+        self_dtu - rhs_dtu
     }
 }
 
@@ -395,22 +396,22 @@ impl std::ops::Sub<Duration> for NumericDate {
     }
 }
 
-impl std::convert::TryFrom<DateTime<Utc>> for NumericDate {
+impl TryFrom<DateTime<Utc>> for NumericDate {
     type Error = Error;
     fn try_from(dtu: DateTime<Utc>) -> Result<Self, Self::Error> {
         // Have to take seconds and nanoseconds separately in order to get the full allowable
         // range of microsecond-precision values as described above.
         let whole_seconds = dtu.timestamp() as f64;
         let fractional_seconds = dtu.timestamp_nanos().rem_euclid(1_000_000_000) as f64 * 1.0e-9;
-        Ok(Self::try_from_seconds(whole_seconds + fractional_seconds)?)
+        Self::try_from_seconds(whole_seconds + fractional_seconds)
     }
 }
 
-impl std::convert::TryFrom<DateTime<FixedOffset>> for NumericDate {
+impl TryFrom<DateTime<FixedOffset>> for NumericDate {
     type Error = Error;
     fn try_from(dtfo: DateTime<FixedOffset>) -> Result<Self, Self::Error> {
         let dtu = DateTime::<Utc>::from(dtfo);
-        Ok(NumericDate::try_from(dtu)?)
+        NumericDate::try_from(dtu)
     }
 }
 
@@ -747,7 +748,7 @@ where
 
 impl<Tz: chrono::TimeZone> From<VCDateTime> for DateTime<Tz>
 where
-    chrono::DateTime<Tz>: From<chrono::DateTime<chrono::FixedOffset>>
+    chrono::DateTime<Tz>: From<chrono::DateTime<chrono::FixedOffset>>,
 {
     fn from(vc_date_time: VCDateTime) -> Self {
         Self::from(vc_date_time.date_time)
@@ -912,12 +913,13 @@ impl Credential {
     }
 
     pub fn to_jwt_claims(&self) -> Result<JWTClaims, Error> {
-        let subject_opt = self.credential_subject.to_single().clone();
+        let subject_opt = self.credential_subject.to_single();
+
         let subject = match subject_opt {
-            Some(subject) => match subject.id.as_ref() {
-                Some(id) => Some(StringOrURI::String(id.to_string())),
-                None => None,
-            },
+            Some(subject) => subject
+                .id
+                .as_ref()
+                .map(|id| StringOrURI::String(id.to_string())),
             None => None,
         };
 
@@ -1465,10 +1467,8 @@ impl Presentation {
             Some(vp) => vp,
             None => return Err(Error::MissingPresentation),
         };
-        if let Some(iss) = claims.issuer {
-            if let StringOrURI::URI(issuer_uri) = iss {
-                vp.holder = Some(issuer_uri);
-            }
+        if let Some(StringOrURI::URI(issuer_uri)) = claims.issuer {
+            vp.holder = Some(issuer_uri);
         }
         if let Some(id) = claims.jwt_id {
             let uri = URI::try_from(id)?;


### PR DESCRIPTION
Partially addresses #399.
More warnings/errors to address can be found using `cargo clippy --workspace --features secp256k1`