### PR TITLE
Fix did:web with ports

### DIFF
--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1"
 reqwest = { version = "0.11", features = ["json"] }
 http = "0.2"
 serde_json = "1.0"
+urlencoding = "2.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
 version = "0.11"


### PR DESCRIPTION
The [spec](https://w3c-ccg.github.io/did-method-web/#method-specific-identifier) mention this:

> A port MAY be included and the colon MUST be percent encoded to prevent a conflict with paths. 

This pr add support for those cases.