### PR TITLE
Allow RSA key length of greater than 2048

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -231,7 +231,7 @@ pub enum Error {
     /// Invalid ProofType type
     InvalidProofTypeType,
     /// Invalid key length
-    InvalidKeyLength,
+    InvalidKeyLength(usize),
     /// Inconsistent DID Key
     InconsistentDIDKey,
     /// Crypto error from `ring` crate
@@ -498,7 +498,7 @@ impl fmt::Display for Error {
             Error::ExpectedUnencodedHeader => write!(f, "Expected unencoded JWT header"),
             Error::ResourceNotFound(id) => write!(f, "Resource not found: {}", id),
             Error::InvalidProofTypeType => write!(f, "Invalid ProofType type"),
-            Error::InvalidKeyLength => write!(f, "Invalid key length"),
+            Error::InvalidKeyLength(len) => write!(f, "Invalid key length: {}", len),
             Error::InconsistentDIDKey => write!(f, "Inconsistent DID Key"),
             Error::DIDURL => write!(f, "Invalid DID URL"),
             Error::UnexpectedDIDFragment => write!(f, "Unexpected DID fragment"),

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -526,7 +526,7 @@ impl RSAParams {
     pub fn validate_key_size(&self) -> Result<(), Error> {
         let n = &self.modulus.as_ref().ok_or(Error::MissingModulus)?.0;
         if n.len() < 256 {
-            return Err(Error::InvalidKeyLength);
+            return Err(Error::InvalidKeyLength(n.len()));
         }
         Ok(())
     }

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -2310,8 +2310,8 @@ impl JsonWebSignature2020 {
                 // https://www.rfc-editor.org/rfc/rfc7518#section-6.3.1.1
                 match public_modulus.len() {
                     256 | 257 => (),
-                    _ => {
-                        return Err(Error::InvalidKeyLength);
+                    l => {
+                        return Err(Error::InvalidKeyLength(l));
                     }
                 }
                 match algorithm {

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -2304,21 +2304,10 @@ impl JsonWebSignature2020 {
             }
         }
         match &key.params {
-            JWKParams::RSA(rsa_params) => {
-                let public_modulus = &rsa_params.modulus.as_ref().ok_or(Error::MissingModulus)?.0;
-                // Ensure 2048-bit key. Note it may have an extra byte:
-                // https://www.rfc-editor.org/rfc/rfc7518#section-6.3.1.1
-                match public_modulus.len() {
-                    256 | 257 => (),
-                    l => {
-                        return Err(Error::InvalidKeyLength(l));
-                    }
-                }
-                match algorithm {
-                    Algorithm::PS256 => (),
-                    _ => return Err(Error::UnsupportedAlgorithm),
-                }
-            }
+            JWKParams::RSA(_) => match algorithm {
+                Algorithm::PS256 => (),
+                _ => return Err(Error::UnsupportedAlgorithm),
+            },
             JWKParams::EC(ec_params) => {
                 match &ec_params.curve.as_ref().ok_or(Error::MissingCurve)?[..] {
                     "secp256k1" => match algorithm {


### PR DESCRIPTION
Remove the check in JsonWebSignature2020.
Key length is already checked to be at least 2048 bits as required by [RFC7518](https://www.rfc-editor.org/rfc/rfc7518.html#section-3.3).

Related spec update for JsonWebSignature2020: https://github.com/w3c-ccg/lds-jws2020/pull/96