### PR TITLE
Set author on update_contexts action

### DIFF
--- a/.github/workflows/update_contexts.yml
+++ b/.github/workflows/update_contexts.yml
@@ -23,3 +23,4 @@ jobs:
         title: Update context files
         labels: github_actions
         body: 'Auto-generated: https://github.com/spruceid/ssi/actions/runs/${{ github.run_id }}'
+        author: ssi <noreply@didkit.dev>


### PR DESCRIPTION
Re: https://github.com/spruceid/ssi/pull/424#pullrequestreview-948797178

In the [create-pull-request documentation](https://github.com/peter-evans/create-pull-request#action-inputs) we can see that the git commit author field defaults "to the user who triggered the workflow run."

The `update_contexts` action runs periodically; maybe I was considered to have triggered it because I authored the latest commit?

This change changes the author name to be for ~~"DIDKit"~~ "ssi"; similar to how the committer field is "GitHub". A no-reply address is similarly used.