### PR TITLE
Implement ES384 JWS with openssl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Test with alternative crypto libraries
       run: cargo test --no-default-features --features rsa,ed25519-dalek,sha2,rand
 
+    - name: Test with openssl
+      run: cargo test --no-default-features --features=openssl,sha2
+
     - name: Test with secp256k1
       run: |
         cargo test --verbose --workspace --features secp256k1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rsa = { version = "0.3", optional = true }
 ed25519-dalek = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }
 rand_old = { package = "rand", version = "0.7" }
+openssl = { version = "0.10", optional = true }
 multibase = "0.8"
 simple_asn1 = "^0.5.2"
 num-bigint = "0.4"

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -12,9 +12,10 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-key/"
 documentation = "https://docs.rs/did-key/"
 
 [features]
-default = ["ssi/ring"]
+default = ["ssi/ring", "ssi_p384"]
 secp256k1 = ["k256", "ssi/secp256k1"]
 secp256r1 = ["p256", "ssi/secp256r1"]
+ssi_p384 = ["ssi/openssl"]
 
 [dependencies]
 ssi = { version = "0.4", path = "../", default-features = false }

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -113,6 +113,7 @@ fn pick_proof_suite<'a, 'b>(
     Ok(match algorithm {
         Algorithm::RS256 => &RsaSignature2018,
         Algorithm::PS256 => &JsonWebSignature2020,
+        Algorithm::ES384 => &JsonWebSignature2020,
         Algorithm::AleoTestnet1Signature => {
             #[cfg(not(feature = "aleosig"))]
             return Err(Error::MissingFeatures("aleosig"));
@@ -2290,7 +2291,7 @@ impl JsonWebSignature2020 {
             Algorithm::EdDSA => (),
             Algorithm::ES256K => (),
             Algorithm::ES256 => (),
-            // Algorithm::ES384 => (), TODO
+            Algorithm::ES384 => (),
             Algorithm::PS256 => (),
             _ => return Err(Error::UnsupportedAlgorithm),
         }
@@ -2316,7 +2317,10 @@ impl JsonWebSignature2020 {
                     },
                     "P-256" => match algorithm {
                         Algorithm::ES256 => (),
-                        // Algorithm::ES384 => (), TODO
+                        _ => return Err(Error::UnsupportedAlgorithm),
+                    },
+                    "P-384" => match algorithm {
+                        Algorithm::ES384 => (),
                         _ => return Err(Error::UnsupportedAlgorithm),
                     },
                     _ => {


### PR DESCRIPTION
- [x] Implement ES384 JWS sign
- [x] Implement ES384 JWS verify
- [x] Implement P-384 key to did:key conversion
- [x] Implement P-384 did:key resolution
- [x] Implement JsonWebSignature2020 for ES384 (sign/verify/prepare/complete)
- [ ] Implement https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/#ecdsasecp384r1signature2019 - Missing context file upstream
- [ ] Add `generate_p384` function
- [ ] Add end-to-end test(s)
- [ ] Add test vector(s)