### PR TITLE
Feature context loader

### DIFF
--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -508,22 +508,23 @@ mod tests {
         let did = DIDKey.generate(&Source::Key(&key)).unwrap();
         let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
+        let mut context_loader = ssi::jsonld::ContextLoader::default();
         vc.issuer = Some(Issuer::URI(URI::String(did.clone())));
         issue_options.verification_method = Some(URI::String(verification_method));
         let proof = vc
-            .generate_proof(&key, &issue_options, &DIDKey)
+            .generate_proof(&key, &issue_options, &DIDKey, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDKey).await;
+        let verification_result = vc.verify(None, &DIDKey, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(vc.verify(None, &DIDKey).await.errors.len() > 0);
+        assert!(vc.verify(None, &DIDKey, &mut context_loader).await.errors.len() > 0);
     }
 
     #[async_std::test]
@@ -547,21 +548,22 @@ mod tests {
 
         let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
+        let mut context_loader = ssi::jsonld::ContextLoader::default();
         issue_options.verification_method = Some(URI::String(verification_method));
         let proof = vc
-            .generate_proof(&key, &issue_options, &DIDKey)
+            .generate_proof(&key, &issue_options, &DIDKey, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDKey).await;
+        let verification_result = vc.verify(None, &DIDKey, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(vc.verify(None, &DIDKey).await.errors.len() > 0);
+        assert!(vc.verify(None, &DIDKey, &mut context_loader).await.errors.len() > 0);
     }
 
     #[async_std::test]
@@ -585,20 +587,21 @@ mod tests {
 
         let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
         let mut issue_options = LinkedDataProofOptions::default();
+        let mut context_loader = ssi::jsonld::ContextLoader::default();
         issue_options.verification_method = Some(URI::String(verification_method));
         let proof = vc
-            .generate_proof(&key, &issue_options, &DIDKey)
+            .generate_proof(&key, &issue_options, &DIDKey, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDKey).await;
+        let verification_result = vc.verify(None, &DIDKey, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(vc.verify(None, &DIDKey).await.errors.len() > 0);
+        assert!(vc.verify(None, &DIDKey, &mut context_loader).await.errors.len() > 0);
     }
 }

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -917,6 +917,7 @@ mod tests {
             ..Default::default()
         };
         eprintln!("vm {:?}", issue_options.verification_method);
+        let mut context_loader = ssi::jsonld::ContextLoader::default();
         let vc_no_proof = vc.clone();
         /*
         let proof = vc.generate_proof(&key, &issue_options).await.unwrap();
@@ -924,36 +925,36 @@ mod tests {
         // Sign with proof suite directly because there is not currently a way to do it
         // for Eip712Signature2021 in did-pkh otherwise.
         let proof = proof_suite
-            .sign(&vc, &issue_options, &DIDPKH, &key, None)
+            .sign(&vc, &issue_options, &DIDPKH, &mut context_loader, &key, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         println!("VC: {}", serde_json::to_string_pretty(&vc).unwrap());
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDPKH).await;
+        let verification_result = vc.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:pkh:example:bad".to_string())));
-        assert!(vc_bad_issuer.verify(None, &DIDPKH).await.errors.len() > 0);
+        assert!(vc_bad_issuer.verify(None, &DIDPKH, &mut context_loader).await.errors.len() > 0);
 
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let proof_bad = proof_suite
-            .sign(&vc_no_proof, &issue_options, &DIDPKH, &wrong_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDPKH, &mut context_loader, &wrong_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
-        assert!(vc_wrong_key.verify(None, &DIDPKH).await.errors.len() > 0);
+        assert!(vc_wrong_key.verify(None, &DIDPKH, &mut context_loader).await.errors.len() > 0);
 
         // Mess with proof signature to make verify fail
         let mut vc_fuzzed = vc.clone();
         fuzz_proof_value(&mut vc_fuzzed.proof);
-        let vp_verification_result = vc_fuzzed.verify(None, &DIDPKH).await;
+        let vp_verification_result = vc_fuzzed.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.len() >= 1);
 
@@ -978,27 +979,27 @@ mod tests {
         vp_issue_options.eip712_domain = vp_eip712_domain_opt;
         // let vp_proof = vp.generate_proof(&key, &vp_issue_options).await.unwrap();
         let vp_proof = proof_suite
-            .sign(&vp, &vp_issue_options, &DIDPKH, &key, None)
+            .sign(&vp, &vp_issue_options, &DIDPKH, &mut context_loader, &key, None)
             .await
             .unwrap();
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();
-        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDPKH).await;
+        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDPKH, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.is_empty());
 
         // Mess with proof signature to make verify fail
         let mut vp_fuzzed = vp.clone();
         fuzz_proof_value(&mut vp_fuzzed.proof);
-        let vp_verification_result = vp_fuzzed.verify(Some(vp_issue_options), &DIDPKH).await;
+        let vp_verification_result = vp_fuzzed.verify(Some(vp_issue_options), &DIDPKH, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.len() >= 1);
 
         // Test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:pkh:example:bad".to_string()));
-        assert!(vp2.verify(None, &DIDPKH).await.errors.len() > 0);
+        assert!(vp2.verify(None, &DIDPKH, &mut context_loader).await.errors.len() > 0);
     }
 
     async fn credential_prepare_complete_verify_did_pkh_tz(
@@ -1030,9 +1031,10 @@ mod tests {
             ..Default::default()
         };
         eprintln!("vm {:?}", issue_options.verification_method);
+        let mut context_loader = ssi::jsonld::ContextLoader::default();
         let vc_no_proof = vc.clone();
         let prep = proof_suite
-            .prepare(&vc, &issue_options, &DIDPKH, &key, None)
+            .prepare(&vc, &issue_options, &DIDPKH, &mut context_loader, &key, None)
             .await
             .unwrap();
 
@@ -1044,29 +1046,29 @@ mod tests {
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDPKH).await;
+        let verification_result = vc.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:pkh:example:bad".to_string())));
-        assert!(vc_bad_issuer.verify(None, &DIDPKH).await.errors.len() > 0);
+        assert!(vc_bad_issuer.verify(None, &DIDPKH, &mut context_loader).await.errors.len() > 0);
 
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let proof_bad = proof_suite
-            .sign(&vc_no_proof, &issue_options, &DIDPKH, &wrong_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDPKH, &mut context_loader, &wrong_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
-        assert!(vc_wrong_key.verify(None, &DIDPKH).await.errors.len() > 0);
+        assert!(vc_wrong_key.verify(None, &DIDPKH, &mut context_loader).await.errors.len() > 0);
 
         // Mess with proof signature to make verify fail
         let mut vc_fuzzed = vc.clone();
         fuzz_proof_value(&mut vc_fuzzed.proof);
-        let vp_verification_result = vc_fuzzed.verify(None, &DIDPKH).await;
+        let vp_verification_result = vc_fuzzed.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.len() >= 1);
 
@@ -1090,7 +1092,7 @@ mod tests {
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
 
         let prep = proof_suite
-            .prepare(&vp, &vp_issue_options, &DIDPKH, &key, None)
+            .prepare(&vp, &vp_issue_options, &DIDPKH, &mut context_loader, &key, None)
             .await
             .unwrap();
         let sig = sign_tezos(&prep, algorithm, &key);
@@ -1098,21 +1100,21 @@ mod tests {
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();
-        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDPKH).await;
+        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDPKH, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.is_empty());
 
         // Mess with proof signature to make verify fail
         let mut vp_fuzzed = vp.clone();
         fuzz_proof_value(&mut vp_fuzzed.proof);
-        let vp_verification_result = vp_fuzzed.verify(Some(vp_issue_options), &DIDPKH).await;
+        let vp_verification_result = vp_fuzzed.verify(Some(vp_issue_options), &DIDPKH, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.len() >= 1);
 
         // Test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:pkh:example:bad".to_string()));
-        assert!(vp2.verify(None, &DIDPKH).await.errors.len() > 0);
+        assert!(vp2.verify(None, &DIDPKH, &mut context_loader).await.errors.len() > 0);
     }
 
     fn sign_tezos(prep: &ssi::ldp::ProofPreparation, algorithm: Algorithm, key: &JWK) -> String {
@@ -1433,7 +1435,8 @@ mod tests {
     async fn test_verify_vc(vc_str: &str, num_warnings: usize) {
         let mut vc = ssi::vc::Credential::from_json_unsigned(vc_str).unwrap();
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDPKH).await;
+        let mut context_loader = ssi::jsonld::ContextLoader::default();
+        let verification_result = vc.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
         assert_eq!(verification_result.warnings.len(), num_warnings);
@@ -1441,7 +1444,7 @@ mod tests {
         let mut map = std::collections::HashMap::new();
         map.insert("foo".to_string(), serde_json::json!("bar"));
         vc.property_set = Some(map);
-        let verification_result = vc.verify(None, &DIDPKH).await;
+        let verification_result = vc.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.len() > 0);
     }

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -274,34 +274,35 @@ mod tests {
             issue_options.verification_method = Some(URI::String(did.to_string() + "#controller"));
         }
         eprintln!("vm {:?}", issue_options.verification_method);
+        let mut context_loader = ssi::jsonld::ContextLoader::default();
         let vc_no_proof = vc.clone();
         let proof = vc
-            .generate_proof(&key, &issue_options, &DIDSol)
+            .generate_proof(&key, &issue_options, &DIDSol, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDSol).await;
+        let verification_result = vc.verify(None, &DIDSol, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(vc_bad_issuer.verify(None, &DIDSol).await.errors.len() > 0);
+        assert!(vc_bad_issuer.verify(None, &DIDSol, &mut context_loader).await.errors.len() > 0);
 
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let other_key = JWK::generate_ed25519().unwrap();
         use ssi::ldp::ProofSuite;
         let proof_bad = ssi::ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
-            .sign(&vc_no_proof, &issue_options, &DIDSol, &other_key, None)
+            .sign(&vc_no_proof, &issue_options, &DIDSol, &mut context_loader, &other_key, None)
             .await
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
-        assert!(vc_wrong_key.verify(None, &DIDSol).await.errors.len() > 0);
+        assert!(vc_wrong_key.verify(None, &DIDSol, &mut context_loader).await.errors.len() > 0);
 
         // Make it into a VP
         use ssi::one_or_many::OneOrMany;
@@ -324,14 +325,15 @@ mod tests {
         vp.holder = Some(URI::String(did.to_string()));
         vp_issue_options.verification_method = Some(URI::String(did.to_string() + "#controller"));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
+        let mut context_loader = ssi::jsonld::ContextLoader::default();
         let vp_proof = vp
-            .generate_proof(&key, &vp_issue_options, &DIDSol)
+            .generate_proof(&key, &vp_issue_options, &DIDSol, &mut context_loader)
             .await
             .unwrap();
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();
-        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDSol).await;
+        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDSol, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.is_empty());
 
@@ -346,14 +348,14 @@ mod tests {
             },
             _ => unreachable!(),
         }
-        let vp_verification_result = vp1.verify(Some(vp_issue_options), &DIDSol).await;
+        let vp_verification_result = vp1.verify(Some(vp_issue_options), &DIDSol, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.len() >= 1);
 
         // test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:example:bad".to_string()));
-        assert!(vp2.verify(None, &DIDSol).await.errors.len() > 0);
+        assert!(vp2.verify(None, &DIDSol, &mut context_loader).await.errors.len() > 0);
     }
 
     /*

--- a/examples/issue-revocation-list.rs
+++ b/examples/issue-revocation-list.rs
@@ -8,6 +8,7 @@ async fn main() {
     use std::convert::TryFrom;
     let key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     let resolver = &ssi::did::example::DIDExample;
+    let mut context_loader = ssi::jsonld::CONTEXT_LOADER.clone();
     use ssi::revocation::{
         RevocationList2020, RevocationList2020Credential, RevocationList2020Subject,
     };
@@ -25,11 +26,11 @@ async fn main() {
     let verification_method = "did:example:foo#key1".to_string();
     proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
     let proof = vc
-        .generate_proof(&key, &proof_options, resolver)
+        .generate_proof(&key, &proof_options, resolver, &mut context_loader)
         .await
         .unwrap();
     vc.add_proof(proof);
-    let result = vc.verify(None, resolver).await;
+    let result = vc.verify(None, resolver, &mut context_loader).await;
     if result.errors.len() > 0 {
         panic!("verify failed: {:#?}", result);
     }

--- a/examples/issue-revocation-list.rs
+++ b/examples/issue-revocation-list.rs
@@ -8,7 +8,7 @@ async fn main() {
     use std::convert::TryFrom;
     let key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     let resolver = &ssi::did::example::DIDExample;
-    let mut context_loader = ssi::jsonld::CONTEXT_LOADER.clone();
+    let mut context_loader = ssi::jsonld::ContextLoader::default();
     use ssi::revocation::{
         RevocationList2020, RevocationList2020Credential, RevocationList2020Subject,
     };

--- a/examples/issue-status-list.rs
+++ b/examples/issue-status-list.rs
@@ -22,7 +22,7 @@ async fn main() {
     let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
     let verification_method = "did:example:12345#key1".to_string();
     proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
-    let mut context_loader = ssi::jsonld::CONTEXT_LOADER.clone();
+    let mut context_loader = ssi::jsonld::ContextLoader::default();
     let proof = vc
         .generate_proof(&key, &proof_options, resolver, &mut context_loader)
         .await

--- a/examples/issue-status-list.rs
+++ b/examples/issue-status-list.rs
@@ -22,12 +22,13 @@ async fn main() {
     let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
     let verification_method = "did:example:12345#key1".to_string();
     proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
+    let mut context_loader = ssi::jsonld::CONTEXT_LOADER.clone();
     let proof = vc
-        .generate_proof(&key, &proof_options, resolver)
+        .generate_proof(&key, &proof_options, resolver, &mut context_loader)
         .await
         .unwrap();
     vc.add_proof(proof);
-    let result = vc.verify(None, resolver).await;
+    let result = vc.verify(None, resolver, &mut context_loader).await;
     if result.errors.len() > 0 {
         panic!("verify failed: {:#?}", result);
     }

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -21,14 +21,15 @@ async fn main() {
     let verification_method = "did:example:foo#key1".to_string();
     proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
     let proof_format = std::env::args().skip(1).next();
+    let mut context_loader = ssi::jsonld::CONTEXT_LOADER.clone();
     match &proof_format.unwrap()[..] {
         "ldp" => {
             let proof = vc
-                .generate_proof(&key, &proof_options, resolver)
+                .generate_proof(&key, &proof_options, resolver, &mut context_loader)
                 .await
                 .unwrap();
             vc.add_proof(proof);
-            let result = vc.verify(None, resolver).await;
+            let result = vc.verify(None, resolver, &mut context_loader).await;
             if result.errors.len() > 0 {
                 panic!("verify failed: {:#?}", result);
             }
@@ -42,7 +43,7 @@ async fn main() {
                 .generate_jwt(Some(&key), &proof_options, resolver)
                 .await
                 .unwrap();
-            let result = ssi::vc::Credential::verify_jwt(&jwt, None, resolver).await;
+            let result = ssi::vc::Credential::verify_jwt(&jwt, None, resolver, &mut context_loader).await;
             if result.errors.len() > 0 {
                 panic!("verify failed: {:#?}", result);
             }

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -21,7 +21,7 @@ async fn main() {
     let verification_method = "did:example:foo#key1".to_string();
     proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
     let proof_format = std::env::args().skip(1).next();
-    let mut context_loader = ssi::jsonld::CONTEXT_LOADER.clone();
+    let mut context_loader = ssi::jsonld::ContextLoader::default();
     match &proof_format.unwrap()[..] {
         "ldp" => {
             let proof = vc

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -44,7 +44,7 @@ async fn main() {
     proof_options.proof_purpose = Some(ssi::vc::ProofPurpose::Authentication);
     proof_options.challenge = Some("example".to_string());
 
-    let mut context_loader = ssi::jsonld::CONTEXT_LOADER.clone();
+    let mut context_loader = ssi::jsonld::ContextLoader::default();
     match &proof_format_out[..] {
         "ldp" => {
             let proof = vp

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -44,14 +44,15 @@ async fn main() {
     proof_options.proof_purpose = Some(ssi::vc::ProofPurpose::Authentication);
     proof_options.challenge = Some("example".to_string());
 
+    let mut context_loader = ssi::jsonld::CONTEXT_LOADER.clone();
     match &proof_format_out[..] {
         "ldp" => {
             let proof = vp
-                .generate_proof(&key, &proof_options, resolver)
+                .generate_proof(&key, &proof_options, resolver, &mut context_loader)
                 .await
                 .unwrap();
             vp.add_proof(proof);
-            let result = vp.verify(Some(proof_options), resolver).await;
+            let result = vp.verify(Some(proof_options), resolver, &mut context_loader).await;
             if result.errors.len() > 0 {
                 panic!("verify failed: {:#?}", result);
             }
@@ -66,7 +67,7 @@ async fn main() {
                 .await
                 .unwrap();
             print!("{}", jwt);
-            let result = ssi::vc::Presentation::verify_jwt(&jwt, None, resolver).await;
+            let result = ssi::vc::Presentation::verify_jwt(&jwt, None, resolver, &mut context_loader).await;
             if result.errors.len() > 0 {
                 panic!("verify failed: {:#?}", result);
             }

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -1902,7 +1902,7 @@ mod tests {
 
         // Verify the VC/proof
         let mut vc = vc.clone();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         vc.add_proof(proof.clone());
         vc.validate().unwrap();
         let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
@@ -2038,7 +2038,7 @@ mod tests {
 
         let basic_doc = ExampleDocument(TEST_BASIC_DOCUMENT.clone());
         let resolver = MOCK_ETHR_DID_RESOLVER.clone();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let verification_result = proof.verify(&basic_doc, &resolver, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
@@ -2221,7 +2221,7 @@ mod tests {
 
         let nested_doc = ExampleDocument(TEST_NESTED_DOCUMENT.clone());
         let resolver = MOCK_ETHR_DID_RESOLVER.clone();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let verification_result = proof.verify(&nested_doc, &resolver, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
@@ -2261,7 +2261,7 @@ mod tests {
 
         let nested_doc = ExampleDocument(TEST_NESTED_DOCUMENT.clone());
         let resolver = MOCK_ETHR_DID_RESOLVER.clone();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let verification_result = proof.verify(&nested_doc, &resolver, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
@@ -2380,7 +2380,7 @@ mod tests {
 
         let nested_doc = ExampleDocument(TEST_NESTED_DOCUMENT.clone());
         let resolver = MOCK_ETHR_DID_RESOLVER.clone();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let verification_result = proof.verify(&nested_doc, &resolver, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 use thiserror::Error;
 
+use crate::jsonld::ContextLoader;
 use crate::keccak_hash::bytes_to_lowerhex;
 use crate::ldp::LinkedDataDocument;
 use crate::vc::Proof;
@@ -790,9 +791,10 @@ impl TypedData {
     pub async fn from_document_and_options(
         document: &(dyn LinkedDataDocument + Sync),
         proof: &Proof,
+        context_loader: &mut ContextLoader,
     ) -> Result<Self, TypedDataConstructionError> {
         let doc_dataset = document
-            .to_dataset_for_signing(None)
+            .to_dataset_for_signing(None, context_loader)
             .await
             .map_err(|e| TypedDataConstructionError::DocumentToDataset(e.to_string()))?;
         let doc_dataset_normalized = crate::urdna2015::normalize(&doc_dataset)
@@ -801,7 +803,7 @@ impl TypedData {
         #[allow(clippy::redundant_closure)]
         doc_statements_normalized.sort_by_cached_key(|x| String::from(x));
         let sigopts_dataset = proof
-            .to_dataset_for_signing(Some(document))
+            .to_dataset_for_signing(Some(document), context_loader)
             .await
             .map_err(|e| TypedDataConstructionError::ProofToDataset(e.to_string()))?;
         let sigopts_dataset_normalized = crate::urdna2015::normalize(&sigopts_dataset)
@@ -1514,7 +1516,7 @@ mod tests {
         ];
         let values: Vec<String> = props
             .iter()
-            .map(|(name_, value)| Value::from((*value).clone()).as_str().unwrap().to_string())
+            .map(|(_name_, value)| Value::from((*value).clone()).as_str().unwrap().to_string())
             .collect();
         assert_eq!(values, expected_values);
     }
@@ -1900,16 +1902,16 @@ mod tests {
 
         // Verify the VC/proof
         let mut vc = vc.clone();
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         vc.add_proof(proof.clone());
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDExample).await;
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
         assert_eq!(sig_hex, "0x5fb8f18f21f54c2df8a2720d0afcee7dbbb18e4b7a22ce6e8183633d63b076d329122584db769cd78b6cd5a7094ede5ceaa43317907539187f1f0d8875f99e051b");
     }
 
-    use crate::ldp::resolve_vm;
     use crate::vc::{LinkedDataProofOptions, ProofPurpose, URI};
 
     #[async_std::test]
@@ -1966,6 +1968,7 @@ mod tests {
         async fn to_dataset_for_signing(
             &self,
             _parent: Option<&(dyn LinkedDataDocument + Sync)>,
+            _context_loader: &mut ContextLoader,
         ) -> Result<crate::rdf::DataSet, crate::error::Error> {
             todo!();
         }
@@ -2035,7 +2038,8 @@ mod tests {
 
         let basic_doc = ExampleDocument(TEST_BASIC_DOCUMENT.clone());
         let resolver = MOCK_ETHR_DID_RESOLVER.clone();
-        let verification_result = proof.verify(&basic_doc, &resolver).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let verification_result = proof.verify(&basic_doc, &resolver, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
     }
@@ -2217,7 +2221,8 @@ mod tests {
 
         let nested_doc = ExampleDocument(TEST_NESTED_DOCUMENT.clone());
         let resolver = MOCK_ETHR_DID_RESOLVER.clone();
-        let verification_result = proof.verify(&nested_doc, &resolver).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let verification_result = proof.verify(&nested_doc, &resolver, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
     }
@@ -2256,7 +2261,8 @@ mod tests {
 
         let nested_doc = ExampleDocument(TEST_NESTED_DOCUMENT.clone());
         let resolver = MOCK_ETHR_DID_RESOLVER.clone();
-        let verification_result = proof.verify(&nested_doc, &resolver).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let verification_result = proof.verify(&nested_doc, &resolver, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
@@ -2374,7 +2380,8 @@ mod tests {
 
         let nested_doc = ExampleDocument(TEST_NESTED_DOCUMENT.clone());
         let resolver = MOCK_ETHR_DID_RESOLVER.clone();
-        let verification_result = proof.verify(&nested_doc, &resolver).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let verification_result = proof.verify(&nested_doc, &resolver, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
     }

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -371,7 +371,6 @@ impl Loader for StaticLoader {
                 WALLET_V1_CONTEXT => Ok(WALLET_V1_CONTEXT_DOCUMENT.clone()),
                 ZCAP_V1_CONTEXT => Ok(ZCAP_V1_CONTEXT_DOCUMENT.clone()),
                 _ => {
-                    eprintln!("unknown context {}", url);
                     Err(json_ld::ErrorCode::LoadingDocumentFailed.into())
                 }
             }
@@ -451,11 +450,9 @@ impl Loader for ContextLoader {
                     .get(url_buf.as_str())
                     .map(|rd| rd.clone())
                     .ok_or_else(|| {
-                        eprintln!("unknown context {}", url_buf);
                         json_ld::ErrorCode::LoadingDocumentFailed.into()
                     })
             } else {
-                eprintln!("unknown context {}", url_buf);
                 Err(json_ld::ErrorCode::LoadingDocumentFailed.into())
             }
         }

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -391,6 +391,13 @@ pub struct ContextLoader {
     context_map: Option<Arc<RwLock<ContextMap>>>,
 }
 
+impl std::fmt::Debug for ContextLoader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_struct("ContextLoader")
+         .finish_non_exhaustive()
+    }
+}
+
 impl ContextLoader {
     /// Constructs an "empty" ContextLoader.
     pub fn empty() -> Self {

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -2467,7 +2467,7 @@ mod tests {
             ..Default::default()
         };
         let resolver = DIDExample;
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let doc = ExampleDocument;
         let _proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &mut context_loader, &key, None)
             .await
@@ -2486,7 +2486,7 @@ mod tests {
         };
         let doc = ExampleDocument;
         let resolver = DIDExample;
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &mut context_loader, &key, None)
             .await
             .unwrap();
@@ -2507,7 +2507,7 @@ mod tests {
         };
         let doc = ExampleDocument;
         let resolver = DIDExample;
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &mut context_loader, &key, None)
             .await
             .unwrap();
@@ -2527,7 +2527,7 @@ mod tests {
         };
         let doc = ExampleDocument;
         let resolver = DIDExample;
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &mut context_loader, &key, None)
             .await
             .unwrap();
@@ -2634,7 +2634,7 @@ mod tests {
         for proof in vc.proof.iter().flatten() {
             n_proofs += 1;
             let resolver = ExampleResolver;
-            let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+            let mut context_loader = crate::jsonld::ContextLoader::default();
             let warnings = EcdsaSecp256k1RecoverySignature2020
                 .verify(&proof, &vc, &resolver, &mut context_loader)
                 .await
@@ -2760,7 +2760,7 @@ mod tests {
         };
 
         let resolver = ED2020ExampleResolver { issuer_document };
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
 
         println!("{}", serde_json::to_string(&vc).unwrap());
         // reissue VC
@@ -2882,7 +2882,7 @@ mod tests {
         let vc_str = include_str!("../tests/lds-aleo2021-vc0.jsonld");
         let mut vc = Credential::from_json_unsigned(vc_str).unwrap();
         let resolver = ExampleResolver;
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
 
         if vc.proof.iter().flatten().next().is_none() {
             // Issue VC / Generate Test Vector

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -17,6 +17,7 @@ use crate::did_resolve::{dereference, Content, DIDResolver, DereferencingInputMe
 use crate::eip712::TypedData;
 use crate::error::Error;
 use crate::hash::sha256;
+use crate::jsonld::ContextLoader;
 use crate::jwk::Base64urlUInt;
 use crate::jwk::{Algorithm, Params as JWKParams, JWK};
 use crate::jws::Header;
@@ -215,6 +216,7 @@ pub trait LinkedDataDocument {
     async fn to_dataset_for_signing(
         &self,
         parent: Option<&(dyn LinkedDataDocument + Sync)>,
+        context_loader: &mut ContextLoader,
     ) -> Result<DataSet, Error>;
 }
 
@@ -226,6 +228,7 @@ pub trait ProofSuite {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error>;
@@ -235,6 +238,7 @@ pub trait ProofSuite {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error>;
@@ -250,6 +254,7 @@ pub trait ProofSuite {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error>;
 }
 
@@ -366,6 +371,7 @@ impl LinkedDataProofs {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -380,7 +386,7 @@ impl LinkedDataProofs {
         let mut options = options.clone();
         ensure_or_pick_verification_relationship(&mut options, document, key, resolver).await?;
         suite
-            .sign(document, &options, resolver, key, extra_proof_properties)
+            .sign(document, &options, resolver, context_loader, key, extra_proof_properties)
             .await
     }
 
@@ -390,6 +396,7 @@ impl LinkedDataProofs {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -409,6 +416,7 @@ impl LinkedDataProofs {
                 document,
                 &options,
                 resolver,
+                context_loader,
                 public_key,
                 extra_proof_properties,
             )
@@ -420,9 +428,10 @@ impl LinkedDataProofs {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let suite = get_proof_suite(proof.type_.as_str())?;
-        suite.verify(proof, document, resolver).await
+        suite.verify(proof, document, resolver, context_loader).await
     }
 }
 
@@ -461,9 +470,10 @@ pub async fn resolve_vm(
 async fn to_jws_payload(
     document: &(dyn LinkedDataDocument + Sync),
     proof: &Proof,
+    context_loader: &mut ContextLoader,
 ) -> Result<Vec<u8>, Error> {
-    let sigopts_dataset = proof.to_dataset_for_signing(Some(document)).await?;
-    let doc_dataset = document.to_dataset_for_signing(None).await?;
+    let sigopts_dataset = proof.to_dataset_for_signing(Some(document), context_loader).await?;
+    let doc_dataset = document.to_dataset_for_signing(None, context_loader).await?;
     let doc_dataset_normalized = urdna2015::normalize(&doc_dataset)?;
     let doc_normalized = doc_dataset_normalized.to_nquads()?;
     let sigopts_dataset_normalized = urdna2015::normalize(&sigopts_dataset)?;
@@ -482,6 +492,7 @@ async fn sign(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
     _resolver: &dyn DIDResolver,
+    context_loader: &mut ContextLoader,
     key: &JWK,
     type_: &str,
     algorithm: Algorithm,
@@ -495,7 +506,7 @@ async fn sign(
     let proof = Proof::new(type_)
         .with_options(options)
         .with_properties(extra_proof_properties);
-    sign_proof(document, proof, key, algorithm).await
+    sign_proof(document, proof, key, algorithm, context_loader).await
 }
 
 async fn sign_proof(
@@ -503,8 +514,9 @@ async fn sign_proof(
     mut proof: Proof,
     key: &JWK,
     algorithm: Algorithm,
+    context_loader: &mut ContextLoader,
 ) -> Result<Proof, Error> {
-    let message = to_jws_payload(document, &proof).await?;
+    let message = to_jws_payload(document, &proof, context_loader).await?;
     let jws = crate::jws::detached_sign_unencoded_payload(algorithm, &message, key)?;
     proof.jws = Some(jws);
     Ok(proof)
@@ -513,6 +525,7 @@ async fn sign_proof(
 async fn sign_nojws(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
+    context_loader: &mut ContextLoader,
     key: &JWK,
     type_: &str,
     algorithm: Algorithm,
@@ -530,7 +543,7 @@ async fn sign_nojws(
     if !document_has_context(document, context_uri)? {
         proof.context = serde_json::json!([context_uri]);
     }
-    let message = to_jws_payload(document, &proof).await?;
+    let message = to_jws_payload(document, &proof, context_loader).await?;
     let sig = crate::jws::sign_bytes(algorithm, &message, key)?;
     let sig_multibase = multibase::encode(multibase::Base::Base58Btc, sig);
     proof.proof_value = Some(sig_multibase);
@@ -541,6 +554,7 @@ async fn prepare(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
     _resolver: &dyn DIDResolver,
+    context_loader: &mut ContextLoader,
     public_key: &JWK,
     type_: &str,
     algorithm: Algorithm,
@@ -554,15 +568,16 @@ async fn prepare(
     let proof = Proof::new(type_)
         .with_options(options)
         .with_properties(extra_proof_properties);
-    prepare_proof(document, proof, algorithm).await
+    prepare_proof(document, proof, algorithm, context_loader).await
 }
 
 async fn prepare_proof(
     document: &(dyn LinkedDataDocument + Sync),
     proof: Proof,
     algorithm: Algorithm,
+    context_loader: &mut ContextLoader,
 ) -> Result<ProofPreparation, Error> {
-    let message = to_jws_payload(document, &proof).await?;
+    let message = to_jws_payload(document, &proof, context_loader).await?;
     let (jws_header, signing_input) =
         crate::jws::prepare_detached_unencoded_payload(algorithm, &message)?;
     Ok(ProofPreparation {
@@ -575,6 +590,7 @@ async fn prepare_proof(
 async fn prepare_nojws(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
+    context_loader: &mut ContextLoader,
     public_key: &JWK,
     type_: &str,
     algorithm: Algorithm,
@@ -592,7 +608,7 @@ async fn prepare_nojws(
     if !document_has_context(document, context_uri)? {
         proof.context = serde_json::json!([context_uri]);
     }
-    let message = to_jws_payload(document, &proof).await?;
+    let message = to_jws_payload(document, &proof, context_loader).await?;
     Ok(ProofPreparation {
         proof,
         jws_header: None,
@@ -616,6 +632,7 @@ async fn verify(
     proof: &Proof,
     document: &(dyn LinkedDataDocument + Sync),
     resolver: &dyn DIDResolver,
+    context_loader: &mut ContextLoader,
 ) -> Result<VerificationWarnings, Error> {
     let jws = proof.jws.as_ref().ok_or(Error::MissingProofSignature)?;
     let verification_method = proof
@@ -623,7 +640,7 @@ async fn verify(
         .as_ref()
         .ok_or(Error::MissingVerificationMethod)?;
     let key = resolve_key(verification_method, resolver).await?;
-    let message = to_jws_payload(document, proof).await?;
+    let message = to_jws_payload(document, proof, context_loader).await?;
     crate::jws::detached_verify(jws, &message, &key)?;
     Ok(Default::default())
 }
@@ -632,6 +649,7 @@ async fn verify_nojws(
     proof: &Proof,
     document: &(dyn LinkedDataDocument + Sync),
     resolver: &dyn DIDResolver,
+    context_loader: &mut ContextLoader,
     algorithm: Algorithm,
 ) -> Result<VerificationWarnings, Error> {
     let proof_value = proof
@@ -643,7 +661,7 @@ async fn verify_nojws(
         .as_ref()
         .ok_or(Error::MissingVerificationMethod)?;
     let key = resolve_key(verification_method, resolver).await?;
-    let message = to_jws_payload(document, proof).await?;
+    let message = to_jws_payload(document, proof, context_loader).await?;
     let (_base, sig) = multibase::decode(proof_value)?;
     crate::jws::verify_bytes_warnable(algorithm, &message, &key, &sig)
 }
@@ -657,6 +675,7 @@ impl ProofSuite for RsaSignature2018 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -664,6 +683,7 @@ impl ProofSuite for RsaSignature2018 {
             document,
             options,
             resolver,
+            context_loader,
             key,
             "RsaSignature2018",
             Algorithm::RS256,
@@ -676,6 +696,7 @@ impl ProofSuite for RsaSignature2018 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -683,6 +704,7 @@ impl ProofSuite for RsaSignature2018 {
             document,
             options,
             resolver,
+            context_loader,
             public_key,
             "RsaSignature2018",
             Algorithm::RS256,
@@ -695,8 +717,9 @@ impl ProofSuite for RsaSignature2018 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
-        verify(proof, document, resolver).await
+        verify(proof, document, resolver, context_loader).await
     }
     async fn complete(
         &self,
@@ -716,6 +739,7 @@ impl ProofSuite for Ed25519Signature2018 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -723,6 +747,7 @@ impl ProofSuite for Ed25519Signature2018 {
             document,
             options,
             resolver,
+            context_loader,
             key,
             "Ed25519Signature2018",
             Algorithm::EdDSA,
@@ -735,6 +760,7 @@ impl ProofSuite for Ed25519Signature2018 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -742,6 +768,7 @@ impl ProofSuite for Ed25519Signature2018 {
             document,
             options,
             resolver,
+            context_loader,
             public_key,
             "Ed25519Signature2018",
             Algorithm::EdDSA,
@@ -754,8 +781,9 @@ impl ProofSuite for Ed25519Signature2018 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
-        verify(proof, document, resolver).await
+        verify(proof, document, resolver, context_loader).await
     }
     async fn complete(
         &self,
@@ -775,12 +803,14 @@ impl ProofSuite for Ed25519Signature2020 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
         sign_nojws(
             document,
             options,
+            context_loader,
             key,
             "Ed25519Signature2020",
             Algorithm::EdDSA,
@@ -794,20 +824,23 @@ impl ProofSuite for Ed25519Signature2020 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
-        verify_nojws(proof, document, resolver, Algorithm::EdDSA).await
+        verify_nojws(proof, document, resolver, context_loader, Algorithm::EdDSA).await
     }
     async fn prepare(
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         prepare_nojws(
             document,
             options,
+            context_loader,
             public_key,
             "Ed25519Signature2020",
             Algorithm::EdDSA,
@@ -836,6 +869,7 @@ impl ProofSuite for EcdsaSecp256k1Signature2019 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -843,6 +877,7 @@ impl ProofSuite for EcdsaSecp256k1Signature2019 {
             document,
             options,
             resolver,
+            context_loader,
             key,
             "EcdsaSecp256k1Signature2019",
             Algorithm::ES256K,
@@ -855,6 +890,7 @@ impl ProofSuite for EcdsaSecp256k1Signature2019 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -862,6 +898,7 @@ impl ProofSuite for EcdsaSecp256k1Signature2019 {
             document,
             options,
             resolver,
+            context_loader,
             public_key,
             "EcdsaSecp256k1Signature2019",
             Algorithm::ES256K,
@@ -874,8 +911,9 @@ impl ProofSuite for EcdsaSecp256k1Signature2019 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
-        verify(proof, document, resolver).await
+        verify(proof, document, resolver, context_loader).await
     }
     async fn complete(
         &self,
@@ -895,6 +933,7 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -914,7 +953,7 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        sign_proof(document, proof, key, Algorithm::ES256KR).await
+        sign_proof(document, proof, key, Algorithm::ES256KR, context_loader).await
     }
 
     async fn prepare(
@@ -922,6 +961,7 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -936,7 +976,7 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        prepare_proof(document, proof, Algorithm::ES256KR).await
+        prepare_proof(document, proof, Algorithm::ES256KR, context_loader).await
     }
 
     async fn complete(
@@ -952,6 +992,7 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let jws = proof.jws.as_ref().ok_or(Error::MissingProofSignature)?;
         let verification_method = proof
@@ -965,7 +1006,7 @@ impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
         {
             return Err(Error::VerificationMethodMismatch);
         }
-        let message = to_jws_payload(document, proof).await?;
+        let message = to_jws_payload(document, proof, context_loader).await?;
         let (_header, jwk) = crate::jws::detached_recover(jws, &message)?;
         let mut warnings = VerificationWarnings::default();
         if let Err(_e) = vm.match_jwk(&jwk) {
@@ -991,6 +1032,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1014,7 +1056,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
                 .with_options(options)
                 .with_properties(props)
         };
-        sign_proof(document, proof, key, Algorithm::EdBlake2b).await
+        sign_proof(document, proof, key, Algorithm::EdBlake2b, context_loader).await
     }
 
     async fn prepare(
@@ -1022,6 +1064,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1039,7 +1082,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
                 .with_options(options)
                 .with_properties(props)
         };
-        prepare_proof(document, proof, Algorithm::EdBlake2b).await
+        prepare_proof(document, proof, Algorithm::EdBlake2b, context_loader).await
     }
 
     async fn complete(
@@ -1055,6 +1098,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let jws = proof.jws.as_ref().ok_or(Error::MissingProofSignature)?;
         let jwk: JWK = match proof.property_set {
@@ -1071,7 +1115,7 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
             .ok_or(Error::MissingVerificationMethod)?;
         let vm = resolve_vm(verification_method, resolver).await?;
         vm.match_jwk(&jwk)?;
-        let message = to_jws_payload(document, proof).await?;
+        let message = to_jws_payload(document, proof, context_loader).await?;
         crate::jws::detached_verify(jws, &message, &jwk)?;
         Ok(Default::default())
     }
@@ -1087,6 +1131,7 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1109,7 +1154,7 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
                 .with_options(options)
                 .with_properties(props)
         };
-        sign_proof(document, proof, key, Algorithm::ESBlake2b).await
+        sign_proof(document, proof, key, Algorithm::ESBlake2b, context_loader).await
     }
 
     async fn prepare(
@@ -1117,6 +1162,7 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1134,7 +1180,7 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
                 .with_options(options)
                 .with_properties(props)
         };
-        prepare_proof(document, proof, Algorithm::ESBlake2b).await
+        prepare_proof(document, proof, Algorithm::ESBlake2b, context_loader).await
     }
 
     async fn complete(
@@ -1150,6 +1196,7 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let jws = proof.jws.as_ref().ok_or(Error::MissingProofSignature)?;
         let jwk: JWK = match proof.property_set {
@@ -1166,7 +1213,7 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
             .ok_or(Error::MissingVerificationMethod)?;
         let vm = resolve_vm(verification_method, resolver).await?;
         vm.match_jwk(&jwk)?;
-        let message = to_jws_payload(document, proof).await?;
+        let message = to_jws_payload(document, proof, context_loader).await?;
         crate::jws::detached_verify(jws, &message, &jwk)?;
         Ok(Default::default())
     }
@@ -1183,6 +1230,7 @@ impl ProofSuite for Eip712Signature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1193,7 +1241,7 @@ impl ProofSuite for Eip712Signature2021 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        let typed_data = TypedData::from_document_and_options(document, &proof).await?;
+        let typed_data = TypedData::from_document_and_options(document, &proof, context_loader).await?;
         let bytes = typed_data.bytes()?;
         let ec_params = match &key.params {
             JWKParams::EC(ec) => ec,
@@ -1215,6 +1263,7 @@ impl ProofSuite for Eip712Signature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1224,7 +1273,7 @@ impl ProofSuite for Eip712Signature2021 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        let typed_data = TypedData::from_document_and_options(document, &proof).await?;
+        let typed_data = TypedData::from_document_and_options(document, &proof, context_loader).await?;
         Ok(ProofPreparation {
             proof,
             jws_header: None,
@@ -1247,6 +1296,7 @@ impl ProofSuite for Eip712Signature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let sig_hex = proof
             .proof_value
@@ -1263,7 +1313,7 @@ impl ProofSuite for Eip712Signature2021 {
             "EcdsaSecp256k1RecoveryMethod2020" => (),
             _ => return Err(Error::VerificationMethodMismatch),
         };
-        let typed_data = TypedData::from_document_and_options(document, proof).await?;
+        let typed_data = TypedData::from_document_and_options(document, proof, context_loader).await?;
         let bytes = typed_data.bytes()?;
         if !sig_hex.starts_with("0x") {
             return Err(Error::HexString);
@@ -1304,6 +1354,7 @@ impl ProofSuite for EthereumEip712Signature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        _context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1344,6 +1395,7 @@ impl ProofSuite for EthereumEip712Signature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        _context_loader: &mut ContextLoader,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1383,6 +1435,7 @@ impl ProofSuite for EthereumEip712Signature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        _context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let sig_hex = proof
             .proof_value
@@ -1438,6 +1491,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1448,7 +1502,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        let signing_string = string_from_document_and_options(document, &proof).await?;
+        let signing_string = string_from_document_and_options(document, &proof, context_loader).await?;
         let hash = crate::keccak_hash::prefix_personal_message(&signing_string);
         let ec_params = match &key.params {
             JWKParams::EC(ec) => ec,
@@ -1470,6 +1524,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1479,7 +1534,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        let signing_string = string_from_document_and_options(document, &proof).await?;
+        let signing_string = string_from_document_and_options(document, &proof, context_loader).await?;
         Ok(ProofPreparation {
             proof,
             jws_header: None,
@@ -1504,6 +1559,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let sig_hex = proof
             .proof_value
@@ -1526,7 +1582,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         let rec_id = k256::ecdsa::recoverable::Id::try_from(dec_sig[64] % 27)?;
         let sig = k256::ecdsa::Signature::try_from(&dec_sig[..64])?;
         let sig = k256::ecdsa::recoverable::Signature::new(&sig, rec_id)?;
-        let signing_string = string_from_document_and_options(document, proof).await?;
+        let signing_string = string_from_document_and_options(document, proof, context_loader).await?;
         let hash = crate::keccak_hash::prefix_personal_message(&signing_string);
         let recovered_key = sig.recover_verify_key(&hash)?;
         use crate::jwk::ECParams;
@@ -1551,9 +1607,10 @@ impl ProofSuite for EthereumPersonalSignature2021 {
 async fn micheline_from_document_and_options(
     document: &(dyn LinkedDataDocument + Sync),
     proof: &Proof,
+    context_loader: &mut ContextLoader,
 ) -> Result<Vec<u8>, Error> {
-    let sigopts_dataset = proof.to_dataset_for_signing(Some(document)).await?;
-    let doc_dataset = document.to_dataset_for_signing(None).await?;
+    let sigopts_dataset = proof.to_dataset_for_signing(Some(document), context_loader).await?;
+    let doc_dataset = document.to_dataset_for_signing(None, context_loader).await?;
     let doc_dataset_normalized = urdna2015::normalize(&doc_dataset)?;
     let doc_normalized = doc_dataset_normalized.to_nquads()?;
     let sigopts_dataset_normalized = urdna2015::normalize(&sigopts_dataset)?;
@@ -1582,9 +1639,10 @@ async fn micheline_from_document_and_options_jcs(
 async fn string_from_document_and_options(
     document: &(dyn LinkedDataDocument + Sync),
     proof: &Proof,
+    context_loader: &mut ContextLoader,
 ) -> Result<String, Error> {
-    let sigopts_dataset = proof.to_dataset_for_signing(Some(document)).await?;
-    let doc_dataset = document.to_dataset_for_signing(None).await?;
+    let sigopts_dataset = proof.to_dataset_for_signing(Some(document), context_loader).await?;
+    let doc_dataset = document.to_dataset_for_signing(None, context_loader).await?;
     let doc_dataset_normalized = urdna2015::normalize(&doc_dataset)?;
     let doc_normalized = doc_dataset_normalized.to_nquads()?;
     let sigopts_dataset_normalized = urdna2015::normalize(&sigopts_dataset)?;
@@ -1602,6 +1660,7 @@ impl ProofSuite for TezosSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1617,7 +1676,7 @@ impl ProofSuite for TezosSignature2021 {
                 .with_options(options)
                 .with_properties(props)
         };
-        let micheline = micheline_from_document_and_options(document, &proof).await?;
+        let micheline = micheline_from_document_and_options(document, &proof, context_loader).await?;
         let sig = crate::jws::sign_bytes(algorithm, &micheline, key)?;
         let mut sig_prefixed = Vec::new();
         let prefix: &[u8] = match algorithm {
@@ -1638,6 +1697,7 @@ impl ProofSuite for TezosSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1654,7 +1714,7 @@ impl ProofSuite for TezosSignature2021 {
                 .with_options(options)
                 .with_properties(props)
         };
-        let micheline = micheline_from_document_and_options(document, &proof).await?;
+        let micheline = micheline_from_document_and_options(document, &proof, context_loader).await?;
         let micheline_string = hex::encode(micheline);
         Ok(ProofPreparation {
             proof,
@@ -1680,6 +1740,7 @@ impl ProofSuite for TezosSignature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let sig_bs58 = proof
             .proof_value
@@ -1703,7 +1764,7 @@ impl ProofSuite for TezosSignature2021 {
             return Err(Error::VerificationMethodMismatch);
         }
 
-        let micheline = micheline_from_document_and_options(document, proof).await?;
+        let micheline = micheline_from_document_and_options(document, proof, context_loader).await?;
         let account_id_opt: Option<BlockchainAccountId> = match vm.blockchain_account_id {
             Some(account_id_string) => Some(account_id_string.parse()?),
             None => None,
@@ -1740,6 +1801,7 @@ impl ProofSuite for TezosJcsSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1756,7 +1818,7 @@ impl ProofSuite for TezosJcsSignature2021 {
                 .with_options(options)
                 .with_properties(props)
         };
-        let micheline = micheline_from_document_and_options(document, &proof).await?;
+        let micheline = micheline_from_document_and_options(document, &proof, context_loader).await?;
         let sig = crate::jws::sign_bytes(algorithm, &micheline, key)?;
         let mut sig_prefixed = Vec::new();
         let prefix: &[u8] = match algorithm {
@@ -1777,6 +1839,7 @@ impl ProofSuite for TezosJcsSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        _context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1821,6 +1884,7 @@ impl ProofSuite for TezosJcsSignature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        _context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let sig_bs58 = proof
             .proof_value
@@ -1894,6 +1958,7 @@ impl ProofSuite for SolanaSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -1903,7 +1968,7 @@ impl ProofSuite for SolanaSignature2021 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        let message = to_jws_payload(document, &proof).await?;
+        let message = to_jws_payload(document, &proof, context_loader).await?;
         let tx = crate::soltx::LocalSolanaTransaction::with_message(&message);
         let bytes = tx.to_bytes();
         let sig = crate::jws::sign_bytes(Algorithm::EdDSA, &bytes, key)?;
@@ -1917,6 +1982,7 @@ impl ProofSuite for SolanaSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -1926,7 +1992,7 @@ impl ProofSuite for SolanaSignature2021 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        let message = to_jws_payload(document, &proof).await?;
+        let message = to_jws_payload(document, &proof, context_loader).await?;
         let tx = crate::soltx::LocalSolanaTransaction::with_message(&message);
         let bytes = tx.to_bytes();
         Ok(ProofPreparation {
@@ -1951,6 +2017,7 @@ impl ProofSuite for SolanaSignature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let sig_b58 = proof
             .proof_value
@@ -1965,7 +2032,7 @@ impl ProofSuite for SolanaSignature2021 {
             return Err(Error::VerificationMethodMismatch);
         }
         let key = vm.public_key_jwk.ok_or(Error::MissingKey)?;
-        let message = to_jws_payload(document, proof).await?;
+        let message = to_jws_payload(document, proof, context_loader).await?;
         let tx = crate::soltx::LocalSolanaTransaction::with_message(&message);
         let bytes = tx.to_bytes();
         let sig = bs58::decode(&sig_b58).into_vec()?;
@@ -2036,6 +2103,7 @@ impl ProofSuite for AleoSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -2050,7 +2118,7 @@ impl ProofSuite for AleoSignature2021 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        let message = to_jws_payload(document, &proof).await?;
+        let message = to_jws_payload(document, &proof, context_loader).await?;
         let sig = crate::aleo::sign(&message, &key)?;
         let sig_mb = multibase::encode(multibase::Base::Base58Btc, sig);
         proof.proof_value = Some(sig_mb);
@@ -2062,6 +2130,7 @@ impl ProofSuite for AleoSignature2021 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -2071,7 +2140,7 @@ impl ProofSuite for AleoSignature2021 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        let message = to_jws_payload(document, &proof).await?;
+        let message = to_jws_payload(document, &proof, context_loader).await?;
         Ok(ProofPreparation {
             proof,
             jws_header: None,
@@ -2094,6 +2163,7 @@ impl ProofSuite for AleoSignature2021 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         const NETWORK_ID: &str = "1";
         const NAMESPACE: &str = "aleo";
@@ -2124,7 +2194,7 @@ impl ProofSuite for AleoSignature2021 {
                 account_id.chain_id.namespace.to_string(),
             ));
         }
-        let message = to_jws_payload(document, proof).await?;
+        let message = to_jws_payload(document, proof, context_loader).await?;
         crate::aleo::verify(&message, &account_id.account_address, &sig)?;
         Ok(Default::default())
     }
@@ -2139,6 +2209,7 @@ impl ProofSuite for EcdsaSecp256r1Signature2019 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -2146,6 +2217,7 @@ impl ProofSuite for EcdsaSecp256r1Signature2019 {
             document,
             options,
             resolver,
+            context_loader,
             key,
             "EcdsaSecp256r1Signature2019",
             Algorithm::ES256,
@@ -2158,6 +2230,7 @@ impl ProofSuite for EcdsaSecp256r1Signature2019 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -2165,6 +2238,7 @@ impl ProofSuite for EcdsaSecp256r1Signature2019 {
             document,
             options,
             resolver,
+            context_loader,
             public_key,
             "EcdsaSecp256r1Signature2019",
             Algorithm::ES256,
@@ -2177,8 +2251,9 @@ impl ProofSuite for EcdsaSecp256r1Signature2019 {
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
-        verify(proof, document, resolver).await
+        verify(proof, document, resolver, context_loader).await
     }
     async fn complete(
         &self,
@@ -2209,6 +2284,7 @@ impl ProofSuite for JsonWebSignature2020 {
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -2225,13 +2301,14 @@ impl ProofSuite for JsonWebSignature2020 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        sign_proof(document, proof, key, algorithm).await
+        sign_proof(document, proof, key, algorithm, context_loader).await
     }
     async fn prepare(
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
         _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -2248,13 +2325,14 @@ impl ProofSuite for JsonWebSignature2020 {
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
-        prepare_proof(document, proof, algorithm).await
+        prepare_proof(document, proof, algorithm, context_loader).await
     }
     async fn verify(
         &self,
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let jws = proof.jws.as_ref().ok_or(Error::MissingProofSignature)?;
         let verification_method = proof
@@ -2262,7 +2340,7 @@ impl ProofSuite for JsonWebSignature2020 {
             .as_ref()
             .ok_or(Error::MissingVerificationMethod)?;
         let (header_b64, signature_b64) = crate::jws::split_detached_jws(jws)?;
-        let message = to_jws_payload(document, proof).await?;
+        let message = to_jws_payload(document, proof, context_loader).await?;
         let crate::jws::DecodedJWS {
             header,
             signing_input,
@@ -2355,6 +2433,7 @@ mod tests {
         async fn to_dataset_for_signing(
             &self,
             _parent: Option<&(dyn LinkedDataDocument + Sync)>,
+            _context_loader: &mut ContextLoader,
         ) -> Result<DataSet, Error> {
             use crate::rdf;
             let mut dataset = DataSet::default();
@@ -2388,8 +2467,9 @@ mod tests {
             ..Default::default()
         };
         let resolver = DIDExample;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let doc = ExampleDocument;
-        let _proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &key, None)
+        let _proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &mut context_loader, &key, None)
             .await
             .unwrap();
     }
@@ -2406,7 +2486,8 @@ mod tests {
         };
         let doc = ExampleDocument;
         let resolver = DIDExample;
-        let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &key, None)
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &mut context_loader, &key, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string(&proof).unwrap());
@@ -2426,7 +2507,8 @@ mod tests {
         };
         let doc = ExampleDocument;
         let resolver = DIDExample;
-        let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &key, None)
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &mut context_loader, &key, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string(&proof).unwrap());
@@ -2445,7 +2527,8 @@ mod tests {
         };
         let doc = ExampleDocument;
         let resolver = DIDExample;
-        let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &key, None)
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let proof = LinkedDataProofs::sign(&doc, &issue_options, &resolver, &mut context_loader, &key, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string(&proof).unwrap());
@@ -2551,8 +2634,9 @@ mod tests {
         for proof in vc.proof.iter().flatten() {
             n_proofs += 1;
             let resolver = ExampleResolver;
+            let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
             let warnings = EcdsaSecp256k1RecoverySignature2020
-                .verify(&proof, &vc, &resolver)
+                .verify(&proof, &vc, &resolver, &mut context_loader)
                 .await
                 .unwrap();
             assert!(warnings.is_empty());
@@ -2676,23 +2760,24 @@ mod tests {
         };
 
         let resolver = ED2020ExampleResolver { issuer_document };
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
 
         println!("{}", serde_json::to_string(&vc).unwrap());
         // reissue VC
         let new_proof = Ed25519Signature2020
-            .sign(&vc, &issue_options, &resolver, &sk_jwk, None)
+            .sign(&vc, &issue_options, &resolver, &mut context_loader, &sk_jwk, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string(&new_proof).unwrap());
 
         // check new VC proof and original proof
         Ed25519Signature2020
-            .verify(&new_proof, &vc, &resolver)
+            .verify(&new_proof, &vc, &resolver, &mut context_loader)
             .await
             .unwrap();
         let orig_proof = vc.proof.iter().flatten().next().unwrap();
         Ed25519Signature2020
-            .verify(orig_proof, &vc, &resolver)
+            .verify(orig_proof, &vc, &resolver, &mut context_loader)
             .await
             .unwrap();
 
@@ -2707,26 +2792,26 @@ mod tests {
             ..Default::default()
         };
         let new_proof = Ed25519Signature2020
-            .sign(&vp, &vp_issue_options, &resolver, &sk_jwk, None)
+            .sign(&vp, &vp_issue_options, &resolver, &mut context_loader, &sk_jwk, None)
             .await
             .unwrap();
         println!("{}", serde_json::to_string(&new_proof).unwrap());
 
         // check new VP proof and original proof
         Ed25519Signature2020
-            .verify(&new_proof, &vp, &resolver)
+            .verify(&new_proof, &vp, &resolver, &mut context_loader)
             .await
             .unwrap();
         let orig_proof = vp.proof.iter().flatten().next().unwrap();
         Ed25519Signature2020
-            .verify(orig_proof, &vp, &resolver)
+            .verify(orig_proof, &vp, &resolver, &mut context_loader)
             .await
             .unwrap();
 
         // Try using prepare/complete
         let pk_jwk = sk_jwk.to_public();
         let prep = Ed25519Signature2020
-            .prepare(&vp, &vp_issue_options, &resolver, &pk_jwk, None)
+            .prepare(&vp, &vp_issue_options, &resolver, &mut context_loader, &pk_jwk, None)
             .await
             .unwrap();
         let signing_input_bytes = match prep.signing_input {
@@ -2737,7 +2822,7 @@ mod tests {
         let sig_mb = multibase::encode(multibase::Base::Base58Btc, sig);
         let completed_proof = Ed25519Signature2020.complete(prep, &sig_mb).await.unwrap();
         Ed25519Signature2020
-            .verify(&completed_proof, &vp, &resolver)
+            .verify(&completed_proof, &vp, &resolver, &mut context_loader)
             .await
             .unwrap();
     }
@@ -2797,6 +2882,7 @@ mod tests {
         let vc_str = include_str!("../tests/lds-aleo2021-vc0.jsonld");
         let mut vc = Credential::from_json_unsigned(vc_str).unwrap();
         let resolver = ExampleResolver;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
 
         if vc.proof.iter().flatten().next().is_none() {
             // Issue VC / Generate Test Vector
@@ -2807,7 +2893,7 @@ mod tests {
                 ..Default::default()
             };
             let proof = AleoSignature2021
-                .sign(&vc, &vc_issue_options, &resolver, &private_key, None)
+                .sign(&vc, &vc_issue_options, &resolver, &mut context_loader, &private_key, None)
                 .await
                 .unwrap();
             credential.add_proof(proof.clone());
@@ -2824,7 +2910,7 @@ mod tests {
         // Verify VC
         let proof = vc.proof.iter().flatten().next().unwrap();
         let warnings = AleoSignature2021
-            .verify(&proof, &vc, &resolver)
+            .verify(&proof, &vc, &resolver, &mut context_loader)
             .await
             .unwrap();
         assert!(warnings.is_empty());

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -1,5 +1,5 @@
 use crate::did_resolve::DIDResolver;
-use crate::jsonld::{REVOCATION_LIST_2020_V1_CONTEXT, STATUS_LIST_2021_V1_CONTEXT};
+use crate::jsonld::{ContextLoader, REVOCATION_LIST_2020_V1_CONTEXT, STATUS_LIST_2021_V1_CONTEXT};
 use crate::one_or_many::OneOrMany;
 use crate::vc::{Credential, CredentialStatus, Issuer, VerificationResult, URI};
 use async_trait::async_trait;
@@ -333,6 +333,7 @@ impl CredentialStatus for RevocationList2020Status {
         &self,
         credential: &Credential,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
         let mut result = VerificationResult::new();
         // TODO: prefix errors or change return type
@@ -396,7 +397,7 @@ impl CredentialStatus for RevocationList2020Status {
             }
             Ok(()) => {}
         }
-        let vc_result = revocation_list_credential.verify(None, resolver).await;
+        let vc_result = revocation_list_credential.verify(None, resolver, context_loader).await;
         for warning in vc_result.warnings {
             result
                 .warnings
@@ -465,6 +466,7 @@ impl CredentialStatus for StatusList2021Entry {
         &self,
         credential: &Credential,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
         let mut result = VerificationResult::new();
         // TODO: prefix errors or change return type
@@ -525,7 +527,7 @@ impl CredentialStatus for StatusList2021Entry {
             }
             Ok(()) => {}
         }
-        let vc_result = status_list_credential.verify(None, resolver).await;
+        let vc_result = status_list_credential.verify(None, resolver, context_loader).await;
         for warning in vc_result.warnings {
             result.warnings.push(format!("Status list: {}", warning));
         }

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -2565,7 +2565,7 @@ pub(crate) mod tests {
             .unwrap();
         println!("{:?}", signed_jwt);
 
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let (vc_opt, verification_result) =
             Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
@@ -2610,7 +2610,7 @@ pub(crate) mod tests {
             .unwrap();
         println!("{:?}", signed_jwt);
 
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let (vc1_opt, verification_result) =
             Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
@@ -2669,7 +2669,7 @@ pub(crate) mod tests {
             .unwrap();
         println!("{:?}", signed_jwt);
 
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let (vc1_opt, verification_result) =
             Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
@@ -2694,7 +2694,7 @@ pub(crate) mod tests {
 
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = vc
             .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
             .await
@@ -2742,7 +2742,7 @@ pub(crate) mod tests {
 
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String("did:example:foo#key3".to_string()));
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = vc
             .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
             .await
@@ -2789,7 +2789,7 @@ pub(crate) mod tests {
 
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = vc
             .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
             .await
@@ -2821,7 +2821,7 @@ pub(crate) mod tests {
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.proof_purpose = Some(ProofPurpose::AssertionMethod);
         issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let algorithm = key.get_algorithm().unwrap();
         let public_key = key.to_public();
 
@@ -2895,7 +2895,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
                 Ok(self.0.clone())
             }
         }
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let parent = ProofContexts(json!(["https://w3id.org/security/v1", DEFAULT_CONTEXT]));
         let proof_dataset = proof.to_dataset_for_signing(Some(&parent), &mut context_loader).await.unwrap();
         let proof_dataset_normalized = urdna2015::normalize(&proof_dataset).unwrap();
@@ -2928,7 +2928,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 <http://example.com/credentials/4643> <https://www.w3.org/2018/credentials#issuer> <https://example.com/issuers/14> .
 "#;
         let vc: Credential = serde_json::from_str(credential_str).unwrap();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let credential_dataset = vc.to_dataset_for_signing(None, &mut context_loader).await.unwrap();
         let credential_dataset_normalized = urdna2015::normalize(&credential_dataset).unwrap();
         let credential_urdna2015 = credential_dataset_normalized.to_nquads().unwrap();
@@ -2939,11 +2939,11 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 
     #[async_std::test]
     async fn credential_verify() {
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         good_vc(include_str!("../examples/vc.jsonld"), &mut context_loader).await;
 
         let vc_jwt = include_str!("../examples/vc.jwt");
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let (vc_opt, result) = Credential::decode_verify_jwt(vc_jwt, None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", result);
         let vc = vc_opt.unwrap();
@@ -2972,7 +2972,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         // These test vectors were generated using examples/issue.rs with the verify part disabled,
         // and with changes made to contexts/lds-jws2020-v1.jsonld, and then copying the context
         // object into the VC.
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         good_vc(include_str!("../examples/vc-jws2020-inline-context.jsonld"), &mut context_loader).await;
         bad_vc(include_str!("../examples/vc-jws2020-bad-type.jsonld"), &mut context_loader).await;
         bad_vc(include_str!("../examples/vc-jws2020-bad-purpose.jsonld"), &mut context_loader).await;
@@ -3001,7 +3001,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         let mut vc: Value = serde_json::from_str(vc_str).unwrap();
         vc["newProp"] = json!("foo");
         let vc: Credential = serde_json::from_value(vc).unwrap();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", result);
         assert!(!result.errors.is_empty());
@@ -3015,7 +3015,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         let vp = Presentation::from_json(vp_str).unwrap();
         let mut verify_options = LinkedDataProofOptions::default();
         verify_options.proof_purpose = Some(ProofPurpose::Authentication);
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let result = vp.verify(Some(verify_options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", result);
         assert!(result.errors.is_empty());
@@ -3129,7 +3129,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             ..Default::default()
         };
 
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         // Issue unrevoked VC
         let proof = unrevoked_vc
             .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
@@ -3189,7 +3189,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
           }
         }))
         .unwrap();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let vres = unrevoked_credential.check_status(&DIDExample, &mut context_loader).await;
         println!("{:#?}", vres);
         assert_eq!(vres.errors.len(), 0);
@@ -3216,7 +3216,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
           }
         }))
         .unwrap();
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let vres = revoked_credential.check_status(&DIDExample, &mut context_loader).await;
         println!("{:#?}", vres);
         assert_ne!(vres.errors.len(), 0);
@@ -3244,7 +3244,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         vc_issue_options.verification_method = Some(URI::String(vc_issuer_vm));
         vc_issue_options.proof_purpose = Some(ProofPurpose::AssertionMethod);
         vc_issue_options.checks = None;
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
         let vc_proof = vc
             .generate_proof(&key, &vc_issue_options, &DIDExample, &mut context_loader)
             .await

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use crate::did_resolve::DIDResolver;
 use crate::error::Error;
-use crate::jsonld::{json_to_dataset, StaticLoader};
+use crate::jsonld::{ContextLoader, json_to_dataset};
 use crate::jwk::{JWTKeys, JWK};
 use crate::jws::Header;
 use crate::ldp::{
@@ -256,6 +256,7 @@ pub trait CredentialStatus: Sync {
         &self,
         credential: &Credential,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult;
 }
 
@@ -1058,8 +1059,9 @@ impl Credential {
         jwt: &str,
         options_opt: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
-        let (_vc, result) = Self::decode_verify_jwt(jwt, options_opt, resolver).await;
+        let (_vc, result) = Self::decode_verify_jwt(jwt, options_opt, resolver, context_loader).await;
         result
     }
 
@@ -1067,6 +1069,7 @@ impl Credential {
         jwt: &str,
         options_opt: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> (Option<Self>, VerificationResult) {
         let checks = options_opt
             .as_ref()
@@ -1178,7 +1181,7 @@ impl Credential {
         }
         // Try verifying each proof until one succeeds
         for proof in proofs {
-            let mut result = proof.verify(&vc, resolver).await;
+            let mut result = proof.verify(&vc, resolver, context_loader).await;
             results.append(&mut result);
             if results.errors.is_empty() {
                 results.checks.push(Check::Proof);
@@ -1186,7 +1189,7 @@ impl Credential {
             };
         }
         if checks.contains(&Check::CredentialStatus) {
-            results.append(&mut vc.check_status(resolver).await);
+            results.append(&mut vc.check_status(resolver, context_loader).await);
         }
         (Some(vc), results)
     }
@@ -1301,6 +1304,7 @@ impl Credential {
         &self,
         options: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
         let checks = options
             .as_ref()
@@ -1319,7 +1323,7 @@ impl Credential {
         let mut results = VerificationResult::new();
         // Try verifying each proof until one succeeds
         for proof in proofs {
-            let mut result = proof.verify(self, resolver).await;
+            let mut result = proof.verify(self, resolver, context_loader).await;
             results.append(&mut result);
             if result.errors.is_empty() {
                 results.checks.push(Check::Proof);
@@ -1327,7 +1331,7 @@ impl Credential {
             };
         }
         if checks.contains(&Check::CredentialStatus) {
-            results.append(&mut self.check_status(resolver).await);
+            results.append(&mut self.check_status(resolver, context_loader).await);
         }
         results
     }
@@ -1340,8 +1344,9 @@ impl Credential {
         jwk: &JWK,
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<Proof, Error> {
-        LinkedDataProofs::sign(self, options, resolver, jwk, None).await
+        LinkedDataProofs::sign(self, options, resolver, context_loader, jwk, None).await
     }
 
     /// Prepare to generate a linked data proof. Returns the signing input for the caller to sign
@@ -1351,8 +1356,9 @@ impl Credential {
         public_key: &JWK,
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<ProofPreparation, Error> {
-        LinkedDataProofs::prepare(self, options, resolver, public_key, None).await
+        LinkedDataProofs::prepare(self, options, resolver, context_loader, public_key, None).await
     }
 
     pub fn add_proof(&mut self, proof: Proof) {
@@ -1369,7 +1375,7 @@ impl Credential {
     }
 
     /// Check the credentials [status](https://www.w3.org/TR/vc-data-model/#status)
-    pub async fn check_status(&self, resolver: &dyn DIDResolver) -> VerificationResult {
+    pub async fn check_status(&self, resolver: &dyn DIDResolver, context_loader: &mut ContextLoader) -> VerificationResult {
         let status = match self.credential_status {
             Some(ref status) => status,
             None => return VerificationResult::error("Missing credentialStatus"),
@@ -1392,7 +1398,7 @@ impl Credential {
                 ))
             }
         };
-        let mut result = checkable_status.check(self, resolver).await;
+        let mut result = checkable_status.check(self, resolver, context_loader).await;
         if !result.errors.is_empty() {
             return result;
         }
@@ -1406,10 +1412,11 @@ impl CheckableStatus {
         &self,
         credential: &Credential,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
         match self {
-            Self::RevocationList2020Status(status) => status.check(credential, resolver).await,
-            Self::StatusList2021Entry(status) => status.check(credential, resolver).await,
+            Self::RevocationList2020Status(status) => status.check(credential, resolver, context_loader).await,
+            Self::StatusList2021Entry(status) => status.check(credential, resolver, context_loader).await,
         }
     }
 }
@@ -1424,6 +1431,7 @@ impl LinkedDataDocument for Credential {
     async fn to_dataset_for_signing(
         &self,
         parent: Option<&(dyn LinkedDataDocument + Sync)>,
+        context_loader: &mut ContextLoader,
     ) -> Result<DataSet, Error> {
         let mut copy = self.clone();
         copy.proof = None;
@@ -1432,8 +1440,7 @@ impl LinkedDataDocument for Credential {
             Some(parent) => parent.get_contexts()?,
             None => None,
         };
-        let mut loader = StaticLoader;
-        json_to_dataset(&json, more_contexts.as_ref(), false, None, &mut loader).await
+        json_to_dataset(&json, more_contexts.as_ref(), false, None, context_loader).await
     }
 
     fn to_value(&self) -> Result<Value, Error> {
@@ -1587,6 +1594,7 @@ impl Presentation {
         jwt: &str,
         options_opt: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> (Option<Self>, VerificationResult) {
         let checks = options_opt
             .as_ref()
@@ -1708,7 +1716,7 @@ impl Presentation {
         }
         // Try verifying each proof until one succeeds
         for proof in proofs {
-            let mut result = proof.verify(&vp, resolver).await;
+            let mut result = proof.verify(&vp, resolver, context_loader).await;
             if result.errors.is_empty() {
                 result.checks.push(Check::Proof);
                 return (Some(vp), result);
@@ -1722,8 +1730,9 @@ impl Presentation {
         jwt: &str,
         options_opt: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
-        let (_vp, result) = Self::decode_verify_jwt(jwt, options_opt, resolver).await;
+        let (_vp, result) = Self::decode_verify_jwt(jwt, options_opt, resolver, context_loader).await;
         result
     }
 
@@ -1761,8 +1770,9 @@ impl Presentation {
         jwk: &JWK,
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<Proof, Error> {
-        LinkedDataProofs::sign(self, options, resolver, jwk, None).await
+        LinkedDataProofs::sign(self, options, resolver, context_loader, jwk, None).await
     }
 
     /// Prepare to generate a linked data proof. Returns the signing input for the caller to sign
@@ -1772,8 +1782,9 @@ impl Presentation {
         public_key: &JWK,
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> Result<ProofPreparation, Error> {
-        LinkedDataProofs::prepare(self, options, resolver, public_key, None).await
+        LinkedDataProofs::prepare(self, options, resolver, context_loader, public_key, None).await
     }
 
     pub fn add_proof(&mut self, proof: Proof) {
@@ -1849,6 +1860,7 @@ impl Presentation {
         &self,
         options: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
         let checks = options
             .as_ref()
@@ -1873,7 +1885,7 @@ impl Presentation {
         let mut results = VerificationResult::new();
         // Try verifying each proof until one succeeds
         for proof in proofs {
-            let mut result = proof.verify(self, resolver).await;
+            let mut result = proof.verify(self, resolver, context_loader).await;
             if result.errors.is_empty() {
                 result.checks.push(Check::Proof);
                 return result;
@@ -1955,6 +1967,7 @@ impl LinkedDataDocument for Presentation {
     async fn to_dataset_for_signing(
         &self,
         parent: Option<&(dyn LinkedDataDocument + Sync)>,
+        context_loader: &mut ContextLoader,
     ) -> Result<DataSet, Error> {
         let mut copy = self.clone();
         copy.proof = None;
@@ -1963,8 +1976,7 @@ impl LinkedDataDocument for Presentation {
             Some(parent) => parent.get_contexts()?,
             None => None,
         };
-        let mut loader = StaticLoader;
-        json_to_dataset(&json, more_contexts.as_ref(), false, None, &mut loader).await
+        json_to_dataset(&json, more_contexts.as_ref(), false, None, context_loader).await
     }
 
     fn to_value(&self) -> Result<Value, Error> {
@@ -2068,8 +2080,9 @@ impl Proof {
         &self,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
-        LinkedDataProofs::verify(self, document, resolver)
+        LinkedDataProofs::verify(self, document, resolver, context_loader)
             .await
             .into()
     }
@@ -2155,6 +2168,7 @@ impl LinkedDataDocument for Proof {
     async fn to_dataset_for_signing(
         &self,
         parent: Option<&(dyn LinkedDataDocument + Sync)>,
+        context_loader: &mut ContextLoader,
     ) -> Result<DataSet, Error> {
         let mut copy = self.clone();
         copy.jws = None;
@@ -2164,9 +2178,8 @@ impl LinkedDataDocument for Proof {
             Some(parent) => parent.get_contexts()?,
             None => None,
         };
-        let mut loader = StaticLoader;
         let dataset =
-            json_to_dataset(&json, more_contexts.as_ref(), false, None, &mut loader).await?;
+            json_to_dataset(&json, more_contexts.as_ref(), false, None, context_loader).await?;
         verify_proof_consistency(self, &dataset)?;
         Ok(dataset)
     }
@@ -2552,8 +2565,9 @@ pub(crate) mod tests {
             .unwrap();
         println!("{:?}", signed_jwt);
 
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let (vc_opt, verification_result) =
-            Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample).await;
+            Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         let _vc = vc_opt.unwrap();
         assert_eq!(verification_result.errors.len(), 0);
@@ -2596,8 +2610,9 @@ pub(crate) mod tests {
             .unwrap();
         println!("{:?}", signed_jwt);
 
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let (vc1_opt, verification_result) =
-            Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample).await;
+            Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
         let vc1 = vc1_opt.unwrap();
@@ -2613,7 +2628,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
         let (_vc_opt, verification_result) =
-            Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample).await;
+            Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.len() > 0);
     }
@@ -2654,8 +2669,9 @@ pub(crate) mod tests {
             .unwrap();
         println!("{:?}", signed_jwt);
 
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let (vc1_opt, verification_result) =
-            Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample).await;
+            Credential::decode_verify_jwt(&signed_jwt, Some(options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
     }
@@ -2678,14 +2694,15 @@ pub(crate) mod tests {
 
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let proof = vc
-            .generate_proof(&key, &issue_options, &DIDExample)
+            .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDExample).await;
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
@@ -2701,7 +2718,7 @@ pub(crate) mod tests {
             },
         }
         println!("{}", serde_json::to_string_pretty(&vc).unwrap());
-        let verification_result = vc.verify(None, &DIDExample).await;
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.len() >= 1);
     }
@@ -2725,14 +2742,15 @@ pub(crate) mod tests {
 
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String("did:example:foo#key3".to_string()));
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let proof = vc
-            .generate_proof(&key, &issue_options, &DIDExample)
+            .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDExample).await;
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
@@ -2748,7 +2766,7 @@ pub(crate) mod tests {
             },
         }
         println!("{}", serde_json::to_string_pretty(&vc).unwrap());
-        let verification_result = vc.verify(None, &DIDExample).await;
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.len() >= 1);
     }
@@ -2771,14 +2789,15 @@ pub(crate) mod tests {
 
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let proof = vc
-            .generate_proof(&key, &issue_options, &DIDExample)
+            .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDExample).await;
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
     }
@@ -2802,11 +2821,12 @@ pub(crate) mod tests {
         let mut issue_options = LinkedDataProofOptions::default();
         issue_options.proof_purpose = Some(ProofPurpose::AssertionMethod);
         issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let algorithm = key.get_algorithm().unwrap();
         let public_key = key.to_public();
 
         let preparation = vc
-            .prepare_proof(&public_key, &issue_options, &DIDExample)
+            .prepare_proof(&public_key, &issue_options, &DIDExample, &mut context_loader)
             .await
             .unwrap();
         let signing_input = match preparation.signing_input {
@@ -2820,7 +2840,7 @@ pub(crate) mod tests {
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDExample).await;
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
 
@@ -2836,7 +2856,7 @@ pub(crate) mod tests {
             },
         }
         println!("{}", serde_json::to_string_pretty(&vc).unwrap());
-        let verification_result = vc.verify(None, &DIDExample).await;
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.len() >= 1);
     }
@@ -2866,6 +2886,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             async fn to_dataset_for_signing(
                 &self,
                 _parent: Option<&(dyn LinkedDataDocument + Sync)>,
+                _context_loader: &mut ContextLoader,
             ) -> Result<DataSet, Error> {
                 Err(Error::NotImplemented)
             }
@@ -2874,8 +2895,9 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
                 Ok(self.0.clone())
             }
         }
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let parent = ProofContexts(json!(["https://w3id.org/security/v1", DEFAULT_CONTEXT]));
-        let proof_dataset = proof.to_dataset_for_signing(Some(&parent)).await.unwrap();
+        let proof_dataset = proof.to_dataset_for_signing(Some(&parent), &mut context_loader).await.unwrap();
         let proof_dataset_normalized = urdna2015::normalize(&proof_dataset).unwrap();
         let proof_urdna2015 = proof_dataset_normalized.to_nquads().unwrap();
         eprintln!("proof:\n{}", proof_urdna2015);
@@ -2906,7 +2928,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 <http://example.com/credentials/4643> <https://www.w3.org/2018/credentials#issuer> <https://example.com/issuers/14> .
 "#;
         let vc: Credential = serde_json::from_str(credential_str).unwrap();
-        let credential_dataset = vc.to_dataset_for_signing(None).await.unwrap();
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let credential_dataset = vc.to_dataset_for_signing(None, &mut context_loader).await.unwrap();
         let credential_dataset_normalized = urdna2015::normalize(&credential_dataset).unwrap();
         let credential_urdna2015 = credential_dataset_normalized.to_nquads().unwrap();
         eprintln!("credential:\n{}", credential_urdna2015);
@@ -2916,10 +2939,12 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 
     #[async_std::test]
     async fn credential_verify() {
-        good_vc(include_str!("../examples/vc.jsonld")).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        good_vc(include_str!("../examples/vc.jsonld"), &mut context_loader).await;
 
         let vc_jwt = include_str!("../examples/vc.jwt");
-        let (vc_opt, result) = Credential::decode_verify_jwt(vc_jwt, None, &DIDExample).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let (vc_opt, result) = Credential::decode_verify_jwt(vc_jwt, None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", result);
         let vc = vc_opt.unwrap();
         println!("{:#?}", vc);
@@ -2927,17 +2952,17 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         assert!(result.warnings.is_empty());
     }
 
-    async fn good_vc(vc_str: &str) {
+    async fn good_vc(vc_str: &str, context_loader: &mut ContextLoader) {
         let vc = Credential::from_json(vc_str).unwrap();
-        let result = vc.verify(None, &DIDExample).await;
+        let result = vc.verify(None, &DIDExample, context_loader).await;
         println!("{:#?}", result);
         assert!(result.errors.is_empty());
         assert!(result.warnings.is_empty());
     }
 
-    async fn bad_vc(vc_str: &str) {
+    async fn bad_vc(vc_str: &str, context_loader: &mut ContextLoader) {
         let vc = Credential::from_json(vc_str).unwrap();
-        let result = vc.verify(None, &DIDExample).await;
+        let result = vc.verify(None, &DIDExample, context_loader).await;
         println!("{:#?}", result);
         assert!(result.errors.len() > 0);
     }
@@ -2947,18 +2972,25 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         // These test vectors were generated using examples/issue.rs with the verify part disabled,
         // and with changes made to contexts/lds-jws2020-v1.jsonld, and then copying the context
         // object into the VC.
-        good_vc(include_str!("../examples/vc-jws2020-inline-context.jsonld")).await;
-        bad_vc(include_str!("../examples/vc-jws2020-bad-type.jsonld")).await;
-        bad_vc(include_str!("../examples/vc-jws2020-bad-purpose.jsonld")).await;
-        bad_vc(include_str!("../examples/vc-jws2020-bad-method.jsonld")).await;
-        bad_vc(include_str!("../examples/vc-jws2020-bad-type-json.jsonld")).await;
-        bad_vc(include_str!(
-            "../examples/vc-jws2020-bad-purpose-json.jsonld"
-        ))
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        good_vc(include_str!("../examples/vc-jws2020-inline-context.jsonld"), &mut context_loader).await;
+        bad_vc(include_str!("../examples/vc-jws2020-bad-type.jsonld"), &mut context_loader).await;
+        bad_vc(include_str!("../examples/vc-jws2020-bad-purpose.jsonld"), &mut context_loader).await;
+        bad_vc(include_str!("../examples/vc-jws2020-bad-method.jsonld"), &mut context_loader).await;
+        bad_vc(include_str!("../examples/vc-jws2020-bad-type-json.jsonld"), &mut context_loader).await;
+        bad_vc(
+            include_str!(
+                "../examples/vc-jws2020-bad-purpose-json.jsonld"
+            ),
+            &mut context_loader,
+        )
         .await;
-        bad_vc(include_str!(
-            "../examples/vc-jws2020-bad-method-json.jsonld"
-        ))
+        bad_vc(
+            include_str!(
+                "../examples/vc-jws2020-bad-method-json.jsonld"
+            ),
+            &mut context_loader,
+        )
         .await;
     }
 
@@ -2969,7 +3001,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         let mut vc: Value = serde_json::from_str(vc_str).unwrap();
         vc["newProp"] = json!("foo");
         let vc: Credential = serde_json::from_value(vc).unwrap();
-        let result = vc.verify(None, &DIDExample).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", result);
         assert!(!result.errors.is_empty());
         assert!(result.warnings.is_empty());
@@ -2982,7 +3015,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         let vp = Presentation::from_json(vp_str).unwrap();
         let mut verify_options = LinkedDataProofOptions::default();
         verify_options.proof_purpose = Some(ProofPurpose::Authentication);
-        let result = vp.verify(Some(verify_options.clone()), &DIDExample).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let result = vp.verify(Some(verify_options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", result);
         assert!(result.errors.is_empty());
         assert!(result.warnings.is_empty());
@@ -2990,14 +3024,14 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             Some(CredentialOrJWT::Credential(vc)) => vc,
             _ => unreachable!(),
         };
-        let result = vc.verify(None, &DIDExample).await;
+        let result = vc.verify(None, &DIDExample, &mut context_loader).await;
         assert!(result.errors.is_empty());
         assert!(result.warnings.is_empty());
 
         // LDP VC in JWT VP
         let vp_jwt = include_str!("../examples/vp.jwt");
         let (vp_opt, result) =
-            Presentation::decode_verify_jwt(vp_jwt, Some(verify_options.clone()), &DIDExample)
+            Presentation::decode_verify_jwt(vp_jwt, Some(verify_options.clone()), &DIDExample, &mut context_loader)
                 .await;
         println!("{:#?}", result);
         assert!(result.errors.is_empty());
@@ -3007,14 +3041,14 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             Some(CredentialOrJWT::Credential(vc)) => vc,
             _ => unreachable!(),
         };
-        let result = vc.verify(None, &DIDExample).await;
+        let result = vc.verify(None, &DIDExample, &mut context_loader).await;
         assert!(result.errors.is_empty());
         assert!(result.warnings.is_empty());
 
         // JWT VC in LDP VP
         let vp_str = include_str!("../examples/vp-jwtvc.jsonld");
         let vp = Presentation::from_json(vp_str).unwrap();
-        let result = vp.verify(Some(verify_options.clone()), &DIDExample).await;
+        let result = vp.verify(Some(verify_options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", result);
         assert!(result.errors.is_empty());
         assert!(result.warnings.is_empty());
@@ -3022,14 +3056,14 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             Some(CredentialOrJWT::JWT(jwt)) => jwt,
             _ => unreachable!(),
         };
-        let result = Credential::verify_jwt(&vc_jwt, None, &DIDExample).await;
+        let result = Credential::verify_jwt(&vc_jwt, None, &DIDExample, &mut context_loader).await;
         assert!(result.errors.is_empty());
         assert!(result.warnings.is_empty());
 
         // JWT VC in JWT VP
         let vp_jwt = include_str!("../examples/vp-jwtvc.jwt");
         let (vp_opt, result) =
-            Presentation::decode_verify_jwt(vp_jwt, Some(verify_options.clone()), &DIDExample)
+            Presentation::decode_verify_jwt(vp_jwt, Some(verify_options.clone()), &DIDExample, &mut context_loader)
                 .await;
         println!("{:#?}", result);
         let vp = vp_opt.unwrap();
@@ -3040,7 +3074,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             Some(CredentialOrJWT::JWT(jwt)) => jwt,
             _ => unreachable!(),
         };
-        let result = Credential::verify_jwt(&vc_jwt, None, &DIDExample).await;
+        let result = Credential::verify_jwt(&vc_jwt, None, &DIDExample, &mut context_loader).await;
         assert!(result.errors.is_empty());
         assert!(result.warnings.is_empty());
     }
@@ -3095,9 +3129,10 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             ..Default::default()
         };
 
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         // Issue unrevoked VC
         let proof = unrevoked_vc
-            .generate_proof(&key, &issue_options, &DIDExample)
+            .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
@@ -3106,7 +3141,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 
         // Issue revoked VC
         let proof = revoked_vc
-            .generate_proof(&key, &issue_options, &DIDExample)
+            .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
             .await
             .unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
@@ -3115,13 +3150,13 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 
         // Verify unrevoked VC
         let verification_result = unrevoked_vc
-            .verify(Some(verify_options.clone()), &DIDExample)
+            .verify(Some(verify_options.clone()), &DIDExample, &mut context_loader)
             .await;
         println!("{:#?}", verification_result);
         assert_eq!(verification_result.errors.len(), 0);
 
         // Verify revoked VC
-        let verification_result = revoked_vc.verify(Some(verify_options), &DIDExample).await;
+        let verification_result = revoked_vc.verify(Some(verify_options), &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
         assert_ne!(verification_result.errors.len(), 0);
     }
@@ -3154,7 +3189,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
           }
         }))
         .unwrap();
-        let vres = unrevoked_credential.check_status(&DIDExample).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let vres = unrevoked_credential.check_status(&DIDExample, &mut context_loader).await;
         println!("{:#?}", vres);
         assert_eq!(vres.errors.len(), 0);
 
@@ -3180,7 +3216,8 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
           }
         }))
         .unwrap();
-        let vres = revoked_credential.check_status(&DIDExample).await;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let vres = revoked_credential.check_status(&DIDExample, &mut context_loader).await;
         println!("{:#?}", vres);
         assert_ne!(vres.errors.len(), 0);
     }
@@ -3207,14 +3244,15 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         vc_issue_options.verification_method = Some(URI::String(vc_issuer_vm));
         vc_issue_options.proof_purpose = Some(ProofPurpose::AssertionMethod);
         vc_issue_options.checks = None;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
         let vc_proof = vc
-            .generate_proof(&key, &vc_issue_options, &DIDExample)
+            .generate_proof(&key, &vc_issue_options, &DIDExample, &mut context_loader)
             .await
             .unwrap();
         vc.add_proof(vc_proof);
         println!("VC: {}", serde_json::to_string_pretty(&vc).unwrap());
         vc.validate().unwrap();
-        let vc_verification_result = vc.verify(None, &DIDExample).await;
+        let vc_verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", vc_verification_result);
         assert!(vc_verification_result.errors.is_empty());
 
@@ -3224,7 +3262,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             .generate_jwt(Some(&key), &vc_issue_options, &DIDExample)
             .await
             .unwrap();
-        let vc_verification_result = Credential::verify_jwt(&vc_jwt, None, &DIDExample).await;
+        let vc_verification_result = Credential::verify_jwt(&vc_jwt, None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", vc_verification_result);
         assert!(vc_verification_result.errors.is_empty());
 
@@ -3247,13 +3285,13 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         vp_issue_options.checks = None;
         let vp_proof = vp
-            .generate_proof(&key, &vp_issue_options, &DIDExample)
+            .generate_proof(&key, &vp_issue_options, &DIDExample, &mut context_loader)
             .await
             .unwrap();
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();
-        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDExample).await;
+        let vp_verification_result = vp.verify(Some(vp_issue_options.clone()), &DIDExample, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.is_empty());
 
@@ -3269,7 +3307,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             _ => unreachable!(),
         }
         let vp_verification_result = vp1
-            .verify(Some(vp_issue_options.clone()), &DIDExample)
+            .verify(Some(vp_issue_options.clone()), &DIDExample, &mut context_loader)
             .await;
         println!("{:#?}", vp_verification_result);
         assert!(vp_verification_result.errors.len() >= 1);
@@ -3277,7 +3315,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         // test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:example:bad".to_string()));
-        assert!(vp2.verify(None, &DIDExample).await.errors.len() > 0);
+        assert!(vp2.verify(None, &DIDExample, &mut context_loader).await.errors.len() > 0);
 
         // Test JWT VP
         let vp_jwt_issue_options = LinkedDataProofOptions {
@@ -3295,7 +3333,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             ..Default::default()
         };
         let verification_result =
-            Presentation::verify_jwt(&vp_jwt, Some(vp_jwt_verify_options.clone()), &DIDExample)
+            Presentation::verify_jwt(&vp_jwt, Some(vp_jwt_verify_options.clone()), &DIDExample, &mut context_loader)
                 .await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
@@ -3305,6 +3343,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             &vp_jwt_bad,
             Some(vp_jwt_verify_options.clone()),
             &DIDExample,
+            &mut context_loader,
         )
         .await;
         assert!(verification_result.errors.len() > 0);
@@ -3318,14 +3357,14 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 
         // LDP VP
         let proof = vp_jwtvc
-            .generate_proof(&key, &vp_issue_options.clone(), &DIDExample)
+            .generate_proof(&key, &vp_issue_options.clone(), &DIDExample, &mut context_loader)
             .await
             .unwrap();
         let mut vp_jwtvc_ldp = vp_jwtvc.clone();
         vp_jwtvc_ldp.add_proof(proof);
         let vp_verify_options = vp_issue_options.clone();
         let verification_result = vp_jwtvc_ldp
-            .verify(Some(vp_verify_options.clone()), &DIDExample)
+            .verify(Some(vp_verify_options.clone()), &DIDExample, &mut context_loader)
             .await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());
@@ -3336,7 +3375,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             .await
             .unwrap();
         let verification_result =
-            Presentation::verify_jwt(&vp_vc_jwt, Some(vp_jwt_verify_options.clone()), &DIDExample)
+            Presentation::verify_jwt(&vp_vc_jwt, Some(vp_jwt_verify_options.clone()), &DIDExample, &mut context_loader)
                 .await;
         println!("{:#?}", verification_result);
         assert!(verification_result.errors.is_empty());

--- a/src/zcap.rs
+++ b/src/zcap.rs
@@ -483,7 +483,7 @@ mod tests {
     #[async_std::test]
     async fn round_trip() {
         let dk = DIDExample;
-        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
+        let mut context_loader = crate::jsonld::ContextLoader::default();
 
         let alice_did = "did:example:foo";
         let alice_vm = format!("{}#key2", alice_did);

--- a/src/zcap.rs
+++ b/src/zcap.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 
 use crate::did_resolve::DIDResolver;
 use crate::error::Error;
-use crate::jsonld::{json_to_dataset, StaticLoader, SECURITY_V2_CONTEXT};
+use crate::jsonld::{ContextLoader, json_to_dataset, SECURITY_V2_CONTEXT};
 use crate::jwk::JWK;
 use crate::ldp::{LinkedDataDocument, LinkedDataProofs, ProofPreparation};
 use crate::one_or_many::OneOrMany;
@@ -79,11 +79,12 @@ where
         &self,
         _options: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
         match &self.proof {
             None => VerificationResult::error("No applicable proof"),
             Some(proof) => {
-                let mut result = proof.verify(self, resolver).await;
+                let mut result = proof.verify(self, resolver, context_loader).await;
                 if proof.proof_purpose != Some(ProofPurpose::CapabilityDelegation) {
                     result.errors.push("Incorrect Proof Purpose".into());
                 };
@@ -150,6 +151,7 @@ where
         jwk: &JWK,
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         capability_chain: &[&str],
     ) -> Result<Proof, Error> {
         let mut ps = Map::<String, Value>::new();
@@ -157,7 +159,7 @@ where
             "capabilityChain".into(),
             serde_json::to_value(capability_chain)?,
         );
-        LinkedDataProofs::sign(self, options, resolver, jwk, Some(ps)).await
+        LinkedDataProofs::sign(self, options, resolver, context_loader, jwk, Some(ps)).await
     }
 
     /// Prepare to generate a linked data proof. Returns the signing input for the caller to sign
@@ -167,6 +169,7 @@ where
         public_key: &JWK,
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         capability_chain: &[&str],
     ) -> Result<ProofPreparation, Error> {
         let mut ps = Map::<String, Value>::new();
@@ -174,7 +177,7 @@ where
             "capabilityChain".into(),
             serde_json::to_value(capability_chain)?,
         );
-        LinkedDataProofs::prepare(self, options, resolver, public_key, Some(ps)).await
+        LinkedDataProofs::prepare(self, options, resolver, context_loader, public_key, Some(ps)).await
     }
 
     pub fn set_proof(self, proof: Proof) -> Self {
@@ -199,6 +202,7 @@ where
     async fn to_dataset_for_signing(
         &self,
         parent: Option<&(dyn LinkedDataDocument + Sync)>,
+        context_loader: &mut ContextLoader,
     ) -> Result<DataSet, Error> {
         let mut copy = self.clone();
         copy.proof = None;
@@ -207,8 +211,7 @@ where
             Some(parent) => parent.get_contexts()?,
             None => None,
         };
-        let mut loader = StaticLoader;
-        json_to_dataset(&json, more_contexts.as_ref(), false, None, &mut loader).await
+        json_to_dataset(&json, more_contexts.as_ref(), false, None, context_loader).await
     }
 
     fn to_value(&self) -> Result<Value, Error> {
@@ -260,6 +263,7 @@ where
         &self,
         options: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         // TODO make this a list for delegation chains
         target_capability: &Delegation<C, P>,
     ) -> VerificationResult
@@ -268,7 +272,7 @@ where
         P: Serialize + Send + Sync + Clone,
     {
         let mut result = target_capability.validate_invocation(self);
-        let mut r2 = self.verify_signature(options, resolver).await;
+        let mut r2 = self.verify_signature(options, resolver, context_loader).await;
         result.append(&mut r2);
         result
     }
@@ -277,11 +281,12 @@ where
         &self,
         _options: Option<LinkedDataProofOptions>,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
     ) -> VerificationResult {
         match &self.proof {
             None => VerificationResult::error("No applicable proof"),
             Some(proof) => {
-                let mut result = proof.verify(self, resolver).await;
+                let mut result = proof.verify(self, resolver, context_loader).await;
                 if proof.proof_purpose != Some(ProofPurpose::CapabilityInvocation) {
                     result.errors.push("Incorrect Proof Purpose".into());
                 };
@@ -299,11 +304,12 @@ where
         jwk: &JWK,
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         target: &URI,
     ) -> Result<Proof, Error> {
         let mut ps = Map::<String, Value>::new();
         ps.insert("capability".into(), serde_json::to_value(target)?);
-        LinkedDataProofs::sign(self, options, resolver, jwk, Some(ps)).await
+        LinkedDataProofs::sign(self, options, resolver, context_loader, jwk, Some(ps)).await
     }
 
     /// Prepare to generate a linked data proof. Returns the signing input for the caller to sign
@@ -313,11 +319,12 @@ where
         public_key: &JWK,
         options: &LinkedDataProofOptions,
         resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
         target: &URI,
     ) -> Result<ProofPreparation, Error> {
         let mut ps = Map::<String, Value>::new();
         ps.insert("capability".into(), serde_json::to_value(target)?);
-        LinkedDataProofs::prepare(self, options, resolver, public_key, Some(ps)).await
+        LinkedDataProofs::prepare(self, options, resolver, context_loader, public_key, Some(ps)).await
     }
 
     pub fn set_proof(self, proof: Proof) -> Self {
@@ -341,6 +348,7 @@ where
     async fn to_dataset_for_signing(
         &self,
         parent: Option<&(dyn LinkedDataDocument + Sync)>,
+        context_loader: &mut ContextLoader,
     ) -> Result<DataSet, Error> {
         let mut copy = self.clone();
         copy.proof = None;
@@ -349,8 +357,7 @@ where
             Some(parent) => parent.get_contexts()?,
             None => None,
         };
-        let mut loader = StaticLoader;
-        json_to_dataset(&json, more_contexts.as_ref(), false, None, &mut loader).await
+        json_to_dataset(&json, more_contexts.as_ref(), false, None, context_loader).await
     }
 
     fn to_value(&self) -> Result<Value, Error> {
@@ -476,6 +483,7 @@ mod tests {
     #[async_std::test]
     async fn round_trip() {
         let dk = DIDExample;
+        let mut context_loader = crate::jsonld::CONTEXT_LOADER.clone();
 
         let alice_did = "did:example:foo";
         let alice_vm = format!("{}#key2", alice_did);
@@ -515,22 +523,22 @@ mod tests {
             ..Default::default()
         };
         let signed_del = del.clone().set_proof(
-            del.generate_proof(&alice, &ldpo_alice, &dk, &[])
+            del.generate_proof(&alice, &ldpo_alice, &dk, &mut context_loader, &[])
                 .await
                 .unwrap(),
         );
         let signed_inv = inv.clone().set_proof(
-            inv.generate_proof(&bob, &ldpo_bob, &dk, &del.id)
+            inv.generate_proof(&bob, &ldpo_bob, &dk, &mut context_loader, &del.id)
                 .await
                 .unwrap(),
         );
 
         // happy path
-        let s_d_v = signed_del.verify(None, &dk).await;
+        let s_d_v = signed_del.verify(None, &dk, &mut context_loader).await;
         assert!(s_d_v.errors.is_empty());
         assert!(s_d_v.checks.iter().any(|c| c == &Check::Proof));
 
-        let s_i_v = signed_inv.verify(None, &dk, &signed_del).await;
+        let s_i_v = signed_inv.verify(None, &dk, &mut context_loader, &signed_del).await;
         assert!(s_i_v.errors.is_empty());
         assert!(s_i_v.checks.iter().any(|c| c == &Check::Proof));
 
@@ -544,9 +552,9 @@ mod tests {
         };
 
         // invalid proof for data
-        assert!(!bad_sig_del.verify(None, &dk).await.errors.is_empty());
+        assert!(!bad_sig_del.verify(None, &dk, &mut context_loader).await.errors.is_empty());
         assert!(!bad_sig_inv
-            .verify(None, &dk, &signed_del)
+            .verify(None, &dk, &mut context_loader, &signed_del)
             .await
             .errors
             .is_empty());
@@ -557,12 +565,12 @@ mod tests {
             ..del.clone()
         };
         let proof = wrong_del
-            .generate_proof(&alice, &ldpo_alice, &dk, &[])
+            .generate_proof(&alice, &ldpo_alice, &dk, &mut context_loader, &[])
             .await
             .unwrap();
         let signed_wrong_del = wrong_del.set_proof(proof);
         assert!(!signed_inv
-            .verify(None, &dk, &signed_wrong_del)
+            .verify(None, &dk, &mut context_loader, &signed_wrong_del)
             .await
             .errors
             .is_empty());


### PR DESCRIPTION
This is an improved version of a previous PR which introduces a `ContextLoader` type, whose purpose is to allow for definition of JSONLD context objects beyond the ones built into the `ssi` crate.  Important points:
- This does break backward compatibility for several functions, as a `ContextLoader` object must be passed into various functions for use in signing and verifying.  See notes below.
- `StaticLoader` still exists, and still enjoys per-context `lazy_static` initialization as before.
- The `ContextLoader` object will by default be equivalent to `StaticLoader`, so it gives a backward-compatible starting point (though the function calls still require an additional parameter).  Additional contexts can be optionally added.  Furthermore, `ContextLoader` can start "empty" (no built-in contexts) and any additional contexts will comprise the entire set of contexts (say if the set of allowable contexts were meant to be rigidly prescribed).

Notes
- I don't really like how it was necessary to add a `ContextLoader` parameter to many functions throughout the codebase.
- The way that `StaticLoader` was used is as an impl of the `json_ld::Loader` trait, which is very poorly designed; (1) it isn't an object-safe trait, so it can't be passed around as `dyn`, (2) its sole method uses `&mut self`, which IMO is wrong (I think any caching that a Loader impl does should be a hidden impl detail).  `ContextLoader` was based on `StaticLoader`, so it has the same warts.  There might be a way to wrap `json_ld::Loader`'s warts, but I didn't think one up off the top of my head.  If we could do this, and make it object safe, so that it could be passed around as `dyn`, then things could potentially be simplified.
- I've noticed that there are basically 3 categories of functions that require `ContextLoader`:
    - Functions that only need `&mut ContextLoader`, e.g. `LinkedDataDocument::to_dataset_for_signing`
    - Sign/Prepare/Prove type functions, having arguments including types:
        - `&LinkedDataProofOptions`
        - `&dyn DIDResolver`
        - `&mut ContextLoader`
    - Verify type functions, having arguments including types:
        - `&dyn DIDResolver`
        - `&mut ContextLoader`

Given this grouping, it might be smart, in terms of being able to avoid breaking compatibility, to define two context types (forgive the overloading of the word context) which simply encapsulate whatever data is needed in the various functions that do signing/preparing/proving/verifying.  This would: (1) Clean up the function call sites, (2) probably clarify what data flows where and therefore what exactly is happening in each case (useful since DIDs/VCs are a rather complex system), and (3) obviate the need to perhaps ever change those function signatures again; the context type can be amended and through careful design (say using builder patterns to define those context objects), perhaps even avoid any API breakage.  I'd suggest two context objects:
- ProveContext, which has LinkedDataProofOptions, DIDResolver, and ContextLoader, and
- VerifyContext, which has DIDResolver and ContextLoader.
There are probably better names for these that avoid overloading "context".

This PR is complete and functional, even if it has warts, and I have nearly complete corresponding changes to `didkit` (except for the C API portion).  Though I think a bit of a discussion as to how to proceed is warranted before thinking about merging.


