### PR TITLE
Remove esrs2020-extra from contexts updater

### DIFF
--- a/contexts/update.sh
+++ b/contexts/update.sh
@@ -19,7 +19,6 @@ exec curl \
 	https://w3id.org/citizenship/v1 -o w3c-ccg-citizenship-v1.jsonld \
 	https://w3id.org/vaccination/v1 -o w3c-ccg-vaccination-v1.jsonld \
 	https://w3id.org/traceability/v1 -o w3c-ccg-traceability-v1.jsonld \
-	https://demo.spruceid.com/EcdsaSecp256k1RecoverySignature2020/esrs2020-extra-0.0.jsonld -o esrs2020-extra-0.0.jsonld \
 	https://w3id.org/security/bbs/v1 -o bbs-v1.jsonld \
 	https://identity.foundation/presentation-exchange/submission/v1 -o presentation-submission.jsonld \
 	https://w3id.org/vdl/v1 -o w3id-vdl-v1.jsonld \


### PR DESCRIPTION
The host is down, so this causes the updater to take extra time and then timeout fetching the URL.
This context file is deprecated (in favor of https://w3id.org/security/suites/secp256k1recovery-2020/v2) so I don't think we need to check it for updates anyway.