### PR TITLE
Add functions to generate Ed25519 KeyPair from existing private key

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -234,6 +234,8 @@ pub enum Error {
     InvalidProofTypeType,
     /// Invalid key length
     InvalidKeyLength(usize),
+    /// Invalid seed length
+    InvalidSeedLength(usize, usize),
     /// Inconsistent DID Key
     InconsistentDIDKey,
     /// Crypto error from `ring` crate
@@ -505,6 +507,7 @@ impl fmt::Display for Error {
             Error::ResourceNotFound(id) => write!(f, "Resource not found: {}", id),
             Error::InvalidProofTypeType => write!(f, "Invalid ProofType type"),
             Error::InvalidKeyLength(len) => write!(f, "Invalid key length: {}", len),
+            Error::InvalidSeedLength(expected, actual) => write!(f, "Expected seed length {} but found {}", expected, actual),
             Error::InconsistentDIDKey => write!(f, "Inconsistent DID Key"),
             Error::DIDURL => write!(f, "Invalid DID URL"),
             Error::UnexpectedDIDFragment => write!(f, "Unexpected DID fragment"),

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -287,10 +287,6 @@ impl JWK {
 
     #[cfg(feature = "ed25519-dalek")]
     pub fn generate_ed25519() -> Result<JWK, Error> {
-        if bytes.len() != 32 {
-            return Err(Error::InvalidSeedLength(32, bytes.len()));
-        }
-
         let mut csprng = rand_old::rngs::OsRng {};
         let keypair = ed25519_dalek::Keypair::generate(&mut csprng);
         Ok(JWK::from(Params::OKP(OctetParams {
@@ -302,6 +298,10 @@ impl JWK {
 
     #[cfg(feature = "ed25519-dalek")]
     pub fn generate_ed25519_from_bytes(bytes: &[u8]) -> Result<JWK, Error> {
+        if bytes.len() != 32 {
+            return Err(Error::InvalidSeedLength(32, bytes.len()));
+        }
+
         let secret = ed25519_dalek::SecretKey::from_bytes(bytes)?;
         let public: ed25519_dalek::PublicKey = (&secret).into();
         Ok(JWK::from(Params::OKP(OctetParams {

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -265,6 +265,25 @@ impl JWK {
         })))
     }
 
+    #[cfg(feature = "ring")]
+    pub fn generate_ed25519_from_bytes(bytes: String) -> Result<JWK, Error> {
+        let rng = ring::test::rand::FixedSliceRandom {
+            bytes: bytes.as_bytes(),
+        };
+        let mut key_pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng)?
+            .as_ref()
+            .to_vec();
+        // reference: ring/src/ec/curve25519/ed25519/signing.rs
+        let private_key = key_pkcs8[0x10..0x30].to_vec();
+        let public_key = key_pkcs8[0x35..0x55].to_vec();
+        key_pkcs8.zeroize();
+        Ok(JWK::from(Params::OKP(OctetParams {
+            curve: "Ed25519".to_string(),
+            public_key: Base64urlUInt(public_key),
+            private_key: Some(Base64urlUInt(private_key)),
+        })))
+    }
+
     #[cfg(feature = "ed25519-dalek")]
     pub fn generate_ed25519() -> Result<JWK, Error> {
         let mut csprng = rand_old::rngs::OsRng {};
@@ -273,6 +292,18 @@ impl JWK {
             curve: "Ed25519".to_string(),
             public_key: Base64urlUInt(keypair.public.as_ref().to_vec()),
             private_key: Some(Base64urlUInt(keypair.secret.as_ref().to_vec())),
+        })))
+    }
+
+    #[cfg(feature = "ed25519-dalek")]
+    pub fn generate_ed25519_from_bytes(bytes: String) -> Result<JWK, Error> {
+        let bytes = bytes.as_bytes();
+        let secret = ed25519_dalek::SecretKey::from_bytes(bytes)?;
+        let public: ed25519_dalek::PublicKey = (&secret).into();
+        Ok(JWK::from(Params::OKP(OctetParams {
+            curve: "Ed25519".to_string(),
+            public_key: Base64urlUInt(public.as_ref().to_vec()),
+            private_key: Some(Base64urlUInt(secret.as_ref().to_vec())),
         })))
     }
 
@@ -1131,6 +1162,7 @@ mod tests {
     const RSA_DER: &'static [u8] = include_bytes!("../tests/rsa2048-2020-08-25.der");
     const RSA_PK_DER: &'static [u8] = include_bytes!("../tests/rsa2048-2020-08-25-pk.der");
     const ED25519_JSON: &'static str = include_str!("../tests/ed25519-2020-10-18.json");
+    const ED25519_A32_JSON: &'static str = include_str!("../tests/ed25519-a32.json");
 
     #[test]
     fn jwk_to_from_der_rsa() {
@@ -1155,6 +1187,15 @@ mod tests {
     #[test]
     fn generate_ed25519() {
         let _key = JWK::generate_ed25519().unwrap();
+    }
+
+    #[test]
+    fn generate_ed25519_from_bytes() {
+        let a32: JWK = serde_json::from_str(ED25519_A32_JSON).unwrap();
+        let generated_a_32 =
+            JWK::generate_ed25519_from_bytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string())
+                .unwrap();
+        assert_eq!(generated_a_32, a32);
     }
 
     #[test]

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -266,10 +266,8 @@ impl JWK {
     }
 
     #[cfg(feature = "ring")]
-    pub fn generate_ed25519_from_bytes(bytes: String) -> Result<JWK, Error> {
-        let rng = ring::test::rand::FixedSliceRandom {
-            bytes: bytes.as_bytes(),
-        };
+    pub fn generate_ed25519_from_bytes(bytes: &[u8]) -> Result<JWK, Error> {
+        let rng = ring::test::rand::FixedSliceRandom { bytes };
         let mut key_pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng)?
             .as_ref()
             .to_vec();
@@ -296,8 +294,7 @@ impl JWK {
     }
 
     #[cfg(feature = "ed25519-dalek")]
-    pub fn generate_ed25519_from_bytes(bytes: String) -> Result<JWK, Error> {
-        let bytes = bytes.as_bytes();
+    pub fn generate_ed25519_from_bytes(bytes: &[u8]) -> Result<JWK, Error> {
         let secret = ed25519_dalek::SecretKey::from_bytes(bytes)?;
         let public: ed25519_dalek::PublicKey = (&secret).into();
         Ok(JWK::from(Params::OKP(OctetParams {
@@ -1193,7 +1190,7 @@ mod tests {
     fn generate_ed25519_from_bytes() {
         let a32: JWK = serde_json::from_str(ED25519_A32_JSON).unwrap();
         let generated_a_32 =
-            JWK::generate_ed25519_from_bytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string())
+            JWK::generate_ed25519_from_bytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes())
                 .unwrap();
         assert_eq!(generated_a_32, a32);
     }

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -1196,15 +1196,15 @@ mod tests {
     #[test]
     fn generate_ed25519_from_bytes() {
         let a32: JWK = serde_json::from_str(ED25519_A32_JSON).unwrap();
-        let bytes = "a".repeat(32).as_bytes();
-        let generated_a_32 = JWK::generate_ed25519_from_bytes(bytes).unwrap();
+        let byte_string = "a".repeat(32);
+        let generated_a_32 = JWK::generate_ed25519_from_bytes(byte_string.as_bytes()).unwrap();
         assert_eq!(generated_a_32, a32);
     }
 
     #[test]
     fn generate_ed25519_from_bytes_checks_length() {
-        let bytes = "a".repeat(33).as_bytes();
-        let error = JWK::generate_ed25519_from_bytes(bytes);
+        let byte_string = "a".repeat(33);
+        let error = JWK::generate_ed25519_from_bytes(byte_string.as_bytes());
         assert!(error.is_err());
     }
 

--- a/tests/ed25519-a32.json
+++ b/tests/ed25519-a32.json
@@ -1,0 +1,6 @@
+{
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "rwaj4ykXFOTzVsGcmxXNGVHsbmZiqne-B1R_KJODNB0",
+    "d": "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE"
+}


### PR DESCRIPTION
This allows users to deterministically generate Ed25519 Key Pairs, which is a use case we need over here at LEF =)

For `ring` generation, I am using their `FixedSliceRandom` struct to mimic the existing generation with a given seed. For `ed25519_dalek` generation, it was a bit involved to mock RNG, especially with that crate using an older version of `rand`, so I instead decided to manually create the private/public key pair using their `SecretKey` and `PublicKey` structs.