### PR TITLE
Make bbs optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ example-http-issuer = []
 json-ld = "0.4"
 # SAFETY: bbs and pairing-plus are set to specific versions due to a
 # dependency on internal struct representations using transmute in src/bbs.rs.
-bbs = "=0.4.1"
+bbs = { version = "=0.4.1", optional = true }
 pairing-plus = "=0.19.0"
 ff = { version = "0.6", package = "ff-zeroize" }
 hkdf = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 #[cfg(feature = "aleosig")]
 pub mod aleo;
 
+#[cfg(feature = "bbs")]
 pub mod bbs;
 pub mod blakesig;
 pub mod caip10;


### PR DESCRIPTION
Make bbs dependency optional (non-default) to make compilation easier.