### PR TITLE
UCAN implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ snarkvm-algorithms = { version= "0.7.9", optional = true }
 snarkvm-curves = { version= "0.7.9", optional = true }
 snarkvm-utilities = { version = "0.7.9", optional = true }
 snarkvm-parameters = { version = "0.7.9", optional = true }
+serde_with = "1.14"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ simple_asn1 = "^0.5.2"
 num-bigint = "0.4"
 async-std = { version = "1.9", features = ["attributes"] }
 async-trait = "0.1"
+async-recursion = "1.0"
 json = "^0.12"
 futures = "0.3"
 iref = "^2.0.3"

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -596,10 +596,18 @@ pub fn encode_sign(algorithm: Algorithm, payload: &str, key: &JWK) -> Result<Str
         key_id: key.key_id.clone(),
         ..Default::default()
     };
-    let header_b64 = base64_encode_json(&header)?;
+    encode_sign_custom_header(payload, key, &header)
+}
+
+pub fn encode_sign_custom_header(
+    payload: &str,
+    key: &JWK,
+    header: &Header,
+) -> Result<String, Error> {
+    let header_b64 = base64_encode_json(header)?;
     let payload_b64 = base64::encode_config(payload, base64::URL_SAFE_NO_PAD);
     let signing_input = header_b64 + "." + &payload_b64;
-    let sig_b64 = sign_bytes_b64(algorithm, signing_input.as_bytes(), key)?;
+    let sig_b64 = sign_bytes_b64(header.algorithm, signing_input.as_bytes(), key)?;
     let jws = [signing_input, sig_b64].join(".");
     Ok(jws)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod ripemd;
 pub mod soltx;
 pub mod ssh;
 pub mod tzkey;
+pub mod ucan;
 pub mod urdna2015;
 pub mod vc;
 pub mod zcap;

--- a/src/ucan.rs
+++ b/src/ucan.rs
@@ -1,13 +1,120 @@
 use crate::{
+    did::{Resource, VerificationMethod},
+    did_resolve::{dereference, Content, DIDResolver},
     error::Error,
     jwk::{Algorithm, JWK},
-    jws::{encode_sign_custom_header, Header},
+    jws::{decode_jws_parts, encode_sign_custom_header, split_jws, verify_bytes, Header},
     jwt::decode_verify,
     vc::{NumericDate, URI},
 };
+use futures::future::try_join_all;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
+
+#[derive(Clone)]
+pub struct Ucan<F = JsonValue, A = HashMap<String, JsonValue>> {
+    pub header: Header,
+    pub payload: Payload<F, A>,
+    pub signature: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct DecodedUcanTree<F = JsonValue, A = HashMap<String, JsonValue>> {
+    pub ucan: Ucan<F, A>,
+    pub parents: Vec<DecodedUcanTree<F, A>>,
+}
+
+impl<F, A> Ucan<F, A> {
+    pub async fn decode_verify(
+        jwt: &str,
+        resolver: &dyn DIDResolver,
+    ) -> Result<DecodedUcanTree<F, A>, Error>
+    where
+        F: DeserializeOwned,
+        A: DeserializeOwned,
+    {
+        let parts = split_jws(jwt).and_then(|(h, p, s)| decode_jws_parts(h, p.as_bytes(), s))?;
+        let payload: Payload<F, A> = serde_json::from_slice(&parts.payload)?;
+
+        // extract or deduce signing key
+        let key: &JWK = match (
+            payload.issuer.split(':').nth(1),
+            &parts.header.jwk,
+            dereference(resolver, &payload.issuer, &Default::default())
+                .await
+                .1,
+        ) {
+            // did:pkh with and without fragment
+            (Some("pkh"), Some(jwk), Content::DIDDocument(_) | Content::Object(_)) => jwk,
+            // did:key without fragment
+            (Some("key"), _, Content::DIDDocument(d)) => &d
+                .verification_method
+                .iter()
+                .flatten()
+                .next()
+                .and_then(|v| match v {
+                    VerificationMethod::Map(vm) => Some(vm),
+                    _ => None,
+                })
+                .ok_or_else(|| Error::VerificationMethodMismatch)?
+                .get_jwk()?,
+            // general case, did with fragment
+            (Some(_), _, Content::Object(Resource::VerificationMethod(vm))) => &vm.get_jwk()?,
+            _ => return Err(Error::VerificationMethodMismatch),
+        };
+
+        verify_bytes(
+            parts.header.algorithm,
+            &parts.signing_input,
+            &key,
+            &parts.signature,
+        )?;
+
+        Ok(DecodedUcanTree {
+            // decode and verify parents
+            parents: try_join_all(
+                payload
+                    .proof
+                    .iter()
+                    .map(|s| Self::decode_verify(s, resolver)),
+            )
+            .await?,
+            ucan: Ucan {
+                header: parts.header,
+                payload,
+                signature: parts.signature,
+            },
+        })
+    }
+
+    pub fn decode(jwt: &str) -> Result<Self, Error>
+    where
+        F: DeserializeOwned,
+        A: DeserializeOwned,
+    {
+        let parts = split_jws(jwt).and_then(|(h, p, s)| decode_jws_parts(h, p.as_bytes(), s))?;
+        let payload: Payload<F, A> = serde_json::from_slice(&parts.payload)?;
+        Ok(Self {
+            header: parts.header,
+            payload,
+            signature: parts.signature,
+        })
+    }
+
+    pub fn parents(&self) -> ParentIter {
+        self.payload.parents()
+    }
+}
+
+pub struct ParentIter<'a>(std::slice::Iter<'a, String>);
+
+impl<'a> Iterator for ParentIter<'a> {
+    type Item = Result<Ucan, Error>;
+    fn next(&mut self) -> Option<Result<Ucan, Error>> {
+        self.0.next().map(|s| Ucan::decode(s))
+    }
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum DecodeError<E> {
@@ -90,7 +197,13 @@ impl<F, A> Payload<F, A> {
     {
         let p = decode_verify(jwt, key)?;
         // TODO check that the issuing key matches/is part of the DID Doc
+
+        // TODO check parents!! we need to extract the issuing key somehow from them
         Ok(p)
+    }
+
+    pub fn parents(&self) -> ParentIter {
+        ParentIter(self.payload.proof.iter())
     }
 }
 
@@ -113,5 +226,5 @@ fn now() -> f64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
-        .as_secs() as f64
+        .as_secs_f64()
 }

--- a/src/ucan.rs
+++ b/src/ucan.rs
@@ -1,0 +1,185 @@
+use crate::vc::URI;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::{collections::HashMap, convert::TryFrom};
+
+pub struct UCAN<S = Vec<u8>, F = JsonValue, A = HashMap<String, JsonValue>> {
+    pub header: Header,
+    pub payload: Payload<F, A>,
+    pub signature: S,
+    // to preserve exact signed bytes in case of out-of-order
+    // fields when deserialising
+    // ugh setting this during "b64_encode" will require &mut self :(
+    // signed_data: Vec<u8>,
+}
+
+impl<S, F, A> UCAN<S, F, A>
+where
+    S: AsRef<[u8]>,
+    F: Serialize,
+    A: Serialize,
+{
+    pub fn b64_encode(&self) -> Result<String, serde_json::Error> {
+        Ok([
+            b64encode(&serde_json::to_vec(&self.header)?),
+            b64encode(&serde_json::to_vec(&self.payload)?),
+            b64encode(&self.signature),
+        ]
+        .join("."))
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DecodeError<E> {
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Base64(#[from] base64::DecodeError),
+    #[error("Invalid JWT Structure")]
+    Form,
+    #[error(transparent)]
+    Signature(E),
+}
+
+impl<'de, S, F, A> UCAN<S, F, A>
+where
+    S: TryFrom<Vec<u8>>,
+    F: Deserialize<'de>,
+    A: Deserialize<'de>,
+{
+    pub fn b64_decode(b64: &str) -> Result<Self, DecodeError<S::Error>> {
+        use serde_json::from_slice;
+
+        let mut parts = b64.split('.').map(b64decode);
+        let header = from_slice(&parts.next().transpose()?.ok_or(DecodeError::Form)?)?;
+        let payload = from_slice(&parts.next().transpose()?.ok_or(DecodeError::Form)?)?;
+        let signature = S::try_from(parts.next().transpose()?.ok_or(DecodeError::Form)?)
+            .map_err(DecodeError::Signature)?;
+
+        if parts.next() != None {
+            Err(DecodeError::Form)
+        } else {
+            Ok(Self {
+                header,
+                payload,
+                signature,
+            })
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Payload<F = JsonValue, A = HashMap<String, JsonValue>> {
+    #[serde(rename = "iss")]
+    pub issuer: String,
+    #[serde(rename = "aud")]
+    pub audience: String,
+    #[serde(rename = "nbf", skip_serializing_if = "Option::is_none")]
+    pub not_before: Option<u64>,
+    #[serde(rename = "exp")]
+    pub expiration: u64,
+    #[serde(rename = "nnc", skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+    #[serde(rename = "fct", skip_serializing_if = "Option::is_none")]
+    pub facts: Option<F>,
+    #[serde(rename = "prf")]
+    pub proof: Vec<String>,
+    #[serde(rename = "att")]
+    pub attenuation: Vec<Capability<A>>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum TimeInvalid {
+    #[error("UCAN not yet valid")]
+    TooEarly,
+    #[error("UCAN has expired")]
+    TooLate,
+}
+
+impl<F, A> Payload<F, A> {
+    pub fn validate_time(&self, time: Option<u64>) -> Result<(), TimeInvalid> {
+        let t = time.unwrap_or_else(now);
+        match (self.not_before, t > self.expiration) {
+            (_, true) => Err(TimeInvalid::TooLate),
+            (Some(nbf), _) if t < nbf => Err(TimeInvalid::TooEarly),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// 3.2.5 A JSON capability MUST include the with and can fields and
+/// MAY have additional fields needed to describe the capability
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Capability<A = HashMap<String, JsonValue>> {
+    pub with: URI,
+    pub can: String,
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub additional_fields: Option<A>,
+}
+
+/// 3.1 Header
+/// The header is a standard JWT header, with an additional REQUIRED field ucv.
+/// This field sets the version of the UCAN specification used in the payload.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Header {
+    #[serde(rename = "alg")]
+    algorithm: String,
+    typ: Typ,
+    ucv: UCV,
+}
+
+impl Header {
+    pub fn new(alg: &str) -> Self {
+        Self {
+            algorithm: alg.to_string(),
+            typ: Typ::JWT,
+            ucv: UCV::V0_8_1,
+        }
+    }
+    pub fn version(&self) -> &str {
+        "0.8.1"
+    }
+    pub fn algorithm(&self) -> &str {
+        &self.algorithm
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+enum Typ {
+    JWT,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+enum UCV {
+    #[serde(rename = "0.8.1")]
+    V0_8_1,
+}
+
+fn b64encode<D: AsRef<[u8]>>(d: &D) -> String {
+    base64::encode_config(d.as_ref(), base64::URL_SAFE_NO_PAD)
+}
+
+fn b64decode(s: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    base64::decode_config(s, base64::URL_SAFE_NO_PAD)
+}
+
+fn now() -> u64 {
+    #[cfg(target_arch = "wasm32")]
+    use instant::SystemTime;
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::time::SystemTime;
+
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+#[test]
+fn header() {
+    let h = Header::new("alg");
+    assert_eq!(
+        serde_json::to_string(&h).unwrap(),
+        r#"{"alg":"alg","typ":"JWT","ucv":"0.8.1"}"#
+    );
+}

--- a/src/ucan.rs
+++ b/src/ucan.rs
@@ -1,33 +1,13 @@
-use crate::vc::URI;
-use serde::{Deserialize, Serialize};
+use crate::{
+    error::Error,
+    jwk::{Algorithm, JWK},
+    jws::{encode_sign_custom_header, Header},
+    jwt::decode_verify,
+    vc::{NumericDate, URI},
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use std::{collections::HashMap, convert::TryFrom};
-
-pub struct UCAN<S = Vec<u8>, F = JsonValue, A = HashMap<String, JsonValue>> {
-    pub header: Header,
-    pub payload: Payload<F, A>,
-    pub signature: S,
-    // to preserve exact signed bytes in case of out-of-order
-    // fields when deserialising
-    // ugh setting this during "b64_encode" will require &mut self :(
-    // signed_data: Vec<u8>,
-}
-
-impl<S, F, A> UCAN<S, F, A>
-where
-    S: AsRef<[u8]>,
-    F: Serialize,
-    A: Serialize,
-{
-    pub fn b64_encode(&self) -> Result<String, serde_json::Error> {
-        Ok([
-            b64encode(&serde_json::to_vec(&self.header)?),
-            b64encode(&serde_json::to_vec(&self.payload)?),
-            b64encode(&self.signature),
-        ]
-        .join("."))
-    }
-}
+use std::collections::HashMap;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DecodeError<E> {
@@ -41,33 +21,6 @@ pub enum DecodeError<E> {
     Signature(E),
 }
 
-impl<'de, S, F, A> UCAN<S, F, A>
-where
-    S: TryFrom<Vec<u8>>,
-    F: Deserialize<'de>,
-    A: Deserialize<'de>,
-{
-    pub fn b64_decode(b64: &str) -> Result<Self, DecodeError<S::Error>> {
-        use serde_json::from_slice;
-
-        let mut parts = b64.split('.').map(b64decode);
-        let header = from_slice(&parts.next().transpose()?.ok_or(DecodeError::Form)?)?;
-        let payload = from_slice(&parts.next().transpose()?.ok_or(DecodeError::Form)?)?;
-        let signature = S::try_from(parts.next().transpose()?.ok_or(DecodeError::Form)?)
-            .map_err(DecodeError::Signature)?;
-
-        if parts.next() != None {
-            Err(DecodeError::Form)
-        } else {
-            Ok(Self {
-                header,
-                payload,
-                signature,
-            })
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Payload<F = JsonValue, A = HashMap<String, JsonValue>> {
     #[serde(rename = "iss")]
@@ -75,9 +28,9 @@ pub struct Payload<F = JsonValue, A = HashMap<String, JsonValue>> {
     #[serde(rename = "aud")]
     pub audience: String,
     #[serde(rename = "nbf", skip_serializing_if = "Option::is_none")]
-    pub not_before: Option<u64>,
+    pub not_before: Option<NumericDate>,
     #[serde(rename = "exp")]
-    pub expiration: u64,
+    pub expiration: NumericDate,
     #[serde(rename = "nnc", skip_serializing_if = "Option::is_none")]
     pub nonce: Option<String>,
     #[serde(rename = "fct", skip_serializing_if = "Option::is_none")]
@@ -97,13 +50,47 @@ pub enum TimeInvalid {
 }
 
 impl<F, A> Payload<F, A> {
-    pub fn validate_time(&self, time: Option<u64>) -> Result<(), TimeInvalid> {
+    pub fn validate_time(&self, time: Option<f64>) -> Result<(), TimeInvalid> {
         let t = time.unwrap_or_else(now);
-        match (self.not_before, t > self.expiration) {
+        match (self.not_before, t > self.expiration.as_seconds()) {
             (_, true) => Err(TimeInvalid::TooLate),
-            (Some(nbf), _) if t < nbf => Err(TimeInvalid::TooEarly),
+            (Some(nbf), _) if t < nbf.as_seconds() => Err(TimeInvalid::TooEarly),
             _ => Ok(()),
         }
+    }
+
+    // NOTE IntoIter::new is deprecated, but into_iter() returns references until we move to 2021 edition
+    #[allow(deprecated)]
+    pub fn encode_sign(&self, algorithm: Algorithm, key: &JWK) -> Result<String, Error>
+    where
+        F: Serialize,
+        A: Serialize,
+    {
+        encode_sign_custom_header(
+            &serde_json::to_string(&self)?,
+            key,
+            &Header {
+                algorithm,
+                key_id: key.key_id.clone(),
+                type_: Some("JWT".to_string()),
+                additional_parameters: std::array::IntoIter::new([(
+                    "ucv".to_string(),
+                    serde_json::Value::String("0.8.1".to_string()),
+                )])
+                .collect(),
+                ..Default::default()
+            },
+        )
+    }
+
+    pub fn decode_verify(jwt: &str, key: &JWK) -> Result<Self, Error>
+    where
+        F: DeserializeOwned,
+        A: DeserializeOwned,
+    {
+        let p = decode_verify(jwt, key)?;
+        // TODO check that the issuing key matches/is part of the DID Doc
+        Ok(p)
     }
 }
 
@@ -117,53 +104,7 @@ pub struct Capability<A = HashMap<String, JsonValue>> {
     pub additional_fields: Option<A>,
 }
 
-/// 3.1 Header
-/// The header is a standard JWT header, with an additional REQUIRED field ucv.
-/// This field sets the version of the UCAN specification used in the payload.
-#[derive(Serialize, Deserialize, Clone)]
-pub struct Header {
-    #[serde(rename = "alg")]
-    algorithm: String,
-    typ: Typ,
-    ucv: UCV,
-}
-
-impl Header {
-    pub fn new(alg: &str) -> Self {
-        Self {
-            algorithm: alg.to_string(),
-            typ: Typ::JWT,
-            ucv: UCV::V0_8_1,
-        }
-    }
-    pub fn version(&self) -> &str {
-        "0.8.1"
-    }
-    pub fn algorithm(&self) -> &str {
-        &self.algorithm
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-enum Typ {
-    JWT,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-enum UCV {
-    #[serde(rename = "0.8.1")]
-    V0_8_1,
-}
-
-fn b64encode<D: AsRef<[u8]>>(d: &D) -> String {
-    base64::encode_config(d.as_ref(), base64::URL_SAFE_NO_PAD)
-}
-
-fn b64decode(s: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    base64::decode_config(s, base64::URL_SAFE_NO_PAD)
-}
-
-fn now() -> u64 {
+fn now() -> f64 {
     #[cfg(target_arch = "wasm32")]
     use instant::SystemTime;
     #[cfg(not(target_arch = "wasm32"))]
@@ -172,14 +113,5 @@ fn now() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
-        .as_secs()
-}
-
-#[test]
-fn header() {
-    let h = Header::new("alg");
-    assert_eq!(
-        serde_json::to_string(&h).unwrap(),
-        r#"{"alg":"alg","typ":"JWT","ucv":"0.8.1"}"#
-    );
+        .as_secs() as f64
 }

--- a/src/ucan.rs
+++ b/src/ucan.rs
@@ -224,13 +224,5 @@ pub struct Capability<A = HashMap<String, JsonValue>> {
 }
 
 fn now() -> f64 {
-    #[cfg(target_arch = "wasm32")]
-    use instant::SystemTime;
-    #[cfg(not(target_arch = "wasm32"))]
-    use std::time::SystemTime;
-
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs_f64()
+    (chrono::prelude::Utc::now().timestamp_nanos() as f64) / 1e+9_f64
 }

--- a/src/ucan.rs
+++ b/src/ucan.rs
@@ -289,37 +289,6 @@ mod tests {
         }
     }
 
-    const DOC_JSON: &'static str = r#"{
-  "@context": [
-    "https://www.w3.org/ns/did/v1",
-    {
-      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
-      "publicKeyJwk": {
-        "@id": "https://w3id.org/security#publicKeyJwk",
-        "@type": "@json"
-      }
-    }
-  ],
-  "id": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
-  "verificationMethod": [
-    {
-      "id": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk#z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
-      "type": "Ed25519VerificationKey2018",
-      "controller": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
-      "publicKeyJwk": {
-        "kty": "OKP",
-        "crv": "Ed25519",
-        "x": "Ell93DzMeUkCSs6CSuc2NxH5pYV5ozw9ro97b5sXRM8"
-      }
-    }
-  ],
-  "authentication": [
-    "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk#z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk"
-  ],
-  "assertionMethod": [
-    "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk#z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk"
-  ]
-}"#;
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl DIDResolver for DIDExample {
@@ -332,13 +301,12 @@ mod tests {
             Option<Document>,
             Option<DocumentMetadata>,
         ) {
-            if did != "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk" {
-                return (ResolutionMetadata::from_error(ERROR_NOT_FOUND), None, None);
-            }
-            let doc: Document = match serde_json::from_str(DOC_JSON) {
-                Ok(doc) => doc,
-                Err(err) => {
-                    return (ResolutionMetadata::from_error(&err.to_string()), None, None);
+            let dids: HashMap<String, Document> =
+                serde_json::from_str(include_str!("../tests/did-key-statics.json")).unwrap();
+            let doc: Document = match dids.get(did) {
+                Some(doc) => doc.clone(),
+                _ => {
+                    return (ResolutionMetadata::from_error(ERROR_NOT_FOUND), None, None);
                 }
             };
             (

--- a/tests/did-key-statics.json
+++ b/tests/did-key-statics.json
@@ -1,0 +1,405 @@
+{
+    "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk#z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "Ell93DzMeUkCSs6CSuc2NxH5pYV5ozw9ro97b5sXRM8"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk#z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk#z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk"
+  ]
+    },
+    "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae#z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "HrIKuYKVsvFsm4Y-p8tUb_tjckhNDR6F3PIarxYBYbM"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae#z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae#z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae"
+  ]
+    },
+    "did:key:z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt#z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "KgPD7nADfVMZNGKrWOzic7d4uSRCrRBmGQvYTLtDHW0"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt#z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt#z6MkhHGVtWMm59wPARQ8ThmB4qvtmXnqyuGKNHJmEVsGyiYt"
+  ]
+    },
+    "did:key:z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn#z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "c1tJ2eRiZFmGX_i4OPn0eTMr8OVC6AuqzP0H2su_sis"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn#z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn"
+  ],
+  "assertionMethod": [
+    "did:key:z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn#z6MknDZfd6E2c8YEDds5GXLR1bQzFFTVEnzpaHqX5HUxg5Yn"
+  ]
+    },
+    "did:key:z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG#z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "qGRymY_wzB39vQdLPFMYti5Eit7AEM1DkebyX4hAVHE"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG#z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG#z6MkqnbNi9vdtD4DKQhrH2YGWtBgwB3n412AQT8LgR7A67EG"
+  ]
+    },
+    "did:key:z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV#z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "E9srYJSjgsZChJXTP6UOcqGVPz7SVyYFYLy18CeyH1g"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV#z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV#z6MkfnmdH8sNmChUskhQnKCN2MphMCLfAmRAG4ioMvBVtQuV"
+  ]
+    },
+    "did:key:z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp#z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "CEa5PDau3x_HaS-KQLbSZHmw3g79l92036sGDNNXwwE"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp#z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp"
+  ],
+  "assertionMethod": [
+    "did:key:z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp#z6Mkf1ZrZegKZdQ8rhsGNCjigJCjKaJUTCxmA4B1FXzoEkkp"
+  ]
+    },
+    "did:key:z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz#z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "WfjvBq4aOF254U71H2Q-NmuEpEijKVdlz0bGpuS4AOM"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz#z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz#z6MkkWUVJav6FJdopt3JghJYeaBkQRkKM66ces1w38hZ16Qz"
+  ]
+    },
+    "did:key:z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV#z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "KolAfUP_s8nJwQNZgUPnzGnrFfeuNSwkPZKx64opaAw"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV#z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV#z6MkhKJZ9WoWWgeWjJwwAMxT8xskLzRsmDXK6u6KnV9gGJBV"
+  ]
+    },
+    "did:key:z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW#z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "JvkpoNFDe4RUzJdPpkwWxJRFS8rJ82Yj62fdbbMZiYk"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW#z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW"
+  ],
+  "assertionMethod": [
+    "did:key:z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW#z6Mkh5Pu5NwUfPNDiW6ZGXM81DmGK2D9CMp1n4myaNht1XBW"
+  ]
+    },
+    "did:key:z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo#z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "ZieA4DRLJ8Rymx-4dNSvCvVIBXX91GjtzrGJ6UPZWXw"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo#z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo#z6MkmL2ZsvFWTabUeEUSe6gMYBXphBXvxG5ddkuNr5DKa1Yo"
+  ]
+    },
+    "did:key:z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH#z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "2Tnvfj1o7gwclFKmbnNpfaxvq3yi3ufDrQOTT6XAQ4Y"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH#z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH"
+  ],
+  "assertionMethod": [
+    "did:key:z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH#z6Mku5DkhvbQ3FyKNHyh8YBT1JteXYfHdyVyP5iVB5hSf9gH"
+  ]
+    },
+    "did:key:z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi#z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "d-JbdLAGFqJoS-z_29YKbSaZZkhMmRkIR3HQupyZoWM"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi#z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi"
+  ],
+  "assertionMethod": [
+    "did:key:z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi#z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi"
+  ]
+    }
+}

--- a/tests/did-key-statics.json
+++ b/tests/did-key-statics.json
@@ -401,5 +401,67 @@
   "assertionMethod": [
     "did:key:z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi#z6MknXEkdPJBCh44hvFfqUZM7coqt98b7eiKCiicyJCeKnpi"
   ]
+    },
+    "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
     }
+  ],
+  "id": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX#z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "WKVUKeCdKC1n_fs08Kqy5yYrLsn9ykuwyjb9dbzfbNI"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX#z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX#z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX"
+  ]
+},
+    "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze": {
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    {
+      "Ed25519VerificationKey2018": "https://w3id.org/security#Ed25519VerificationKey2018",
+      "publicKeyJwk": {
+        "@id": "https://w3id.org/security#publicKeyJwk",
+        "@type": "@json"
+      }
+    }
+  ],
+  "id": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze#z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "jPXfwC83KJIPVh9Z9vTFEDHTF-Qej_ObcP_IwpbDvbs"
+      }
+    }
+  ],
+  "authentication": [
+    "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze#z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze"
+  ],
+  "assertionMethod": [
+    "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze#z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze"
+  ]
+}
 }

--- a/tests/ucan-v0.8.1-invalid.json
+++ b/tests/ucan-v0.8.1-invalid.json
@@ -1,0 +1,842 @@
+[
+  {
+    "comment": "UCAN sections contain invalid base64 characters",
+    "token": "@@JhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtySnpWZVk3RXd2cVdNc3ROeDJ4SDdiZGVnYWREZGFjOHVGams2NTlnemJkeCIsImF1ZCI6ImRpZDprZXk6ek0wMG04RHhXU3dRaGhaWWJnUGprQ05qbUx2dmEzRDdxQnNHUHZ3ejJneW5TaWFKIiwiZXhwIjoxNjQ4MDc2MDQ0LCJhdHQiOltdLCJwcmYiOltdfQ.vLgf-O3Xrc94toabVJKoI15EmAO-d9SqHGFbxTkw3wyEZb-Q7YXA-6mWJv6b-b7kFQHiilMcdIl5s5IuXxsSAw",
+    "assertions": {
+      "validationErrors": [
+        "base64Invalid"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN header section is malformed",
+    "token": "eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.FgKew6C7oUMxZzjE_ER-rRaOObtXqMlvfdKZVus1krDYIbcn5PBSFpInBJ7izUYauuKDVkonfGOojq7afstUCg",
+    "assertions": {
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "headerMalformed"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN payload section is malformed",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.FgKew6C7oUMxZzjE_ER-rRaOObtXqMlvfdKZVus1krDYIbcn5PBSFpInBJ7izUYauuKDVkonfGOojq7afstUCg",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "validationErrors": [
+        "payloadMalformed"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN signature is malformed",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "signatureMalformed"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN has expired",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjoxNjQ4MDM3ODA1LCJhdHQiOltdLCJwcmYiOltdfQ.5yRVSF4q1JbBT2ARnvgvkqPP16Mlt-D0BYt_IxTNkRZnuuCTCMCP2Xakl2lMswUhICHOz3BgRsGHrQuO-VVdDQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 1648037805,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "expExpired"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN is not ready to be used",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwibmJmIjo0ODA0MTQzNDA1LCJleHAiOjQ4MzU2Nzk0MDUsImF0dCI6W10sInByZiI6W119.9CrzdFvYmfKoCLbqBV5jENhjenxXHad5UD_A1-A_ghHg_StfkTXXzhi0tY68UR_9a-zMpHiH9q52WSjuVQARAA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "nbf": 4804143405,
+        "exp": 4835679405,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "nbfNotReady"
+      ]
+    }
+  },
+  {
+    "comment": "Witnesses expire before the delegated UCAN",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo3OTU5ODE3MDA1LCJhdHQiOltdLCJwcmYiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1T0M0eEluMC5leUpwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3RuY3pSeFYwVlJSMjl0TmxKcmNtMU5RbGRNVFZCMWExWk5hVUZ2U0hKS1MyWndSR1F4VlROMFlWbHJTQ0lzSW1GMVpDSTZJbVJwWkRwclpYazZlalpOYTJ0U1NqazJjSFJRTVZOaU1UUTVaSGwyVkVOWFowNXRPVlJoTVZwMGRXSmxURVI0T1ZwNVVYUm9iMjlZSWl3aVpYaHdJam8xTkRNMU1qazFOREExTENKaGRIUWlPbHRkTENKd2NtWWlPbHRkZlEuMUVha3N3aF9FYVVDaVBTdGgxbFFqVHNPaEptOGdiTmxEN196VlVqTkdWd3ZNTzhNaGRERzJuODh0N3BjNUZPbE5fX00xUlJCaGota25iMWNyMkppRGciXX0.evaRA0em05EXUwbboF4aAQhz4Ic1Bx3GJOC6MbW-rS8eP_9VUhHJ2ApzG9-fjbZHiwdgV_Y3bzYORLsH16g3Cg",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 7959817005,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtnczRxV0VRR29tNlJrcm1NQldMTVB1a1ZNaUFvSHJKS2ZwRGQxVTN0YVlrSCIsImF1ZCI6ImRpZDprZXk6ejZNa2tSSjk2cHRQMVNiMTQ5ZHl2VENXZ05tOVRhMVp0dWJlTER4OVp5UXRob29YIiwiZXhwIjo1NDM1Mjk1NDA1LCJhdHQiOltdLCJwcmYiOltdfQ.1Eakswh_EaUCiPSth1lQjTsOhJm8gbNlD7_zVUjNGVwvMO8MhdDG2n88t7pc5FOlN__M1RRBhj-knb1cr2JiDg"
+        ]
+      },
+      "validationErrors": [
+        "expWitnessTimeBoundExceeded"
+      ]
+    }
+  },
+  {
+    "comment": "Witnesses are not ready to be used before the delegated UCAN",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwibmJmIjoxNjQ4NDY5ODA1LCJleHAiOjU0MzUyOTU0MDUsImF0dCI6W10sInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdHBaRTVPWkdWVU4yUkhjM281V0hjeE5YVkRaWGh4YXpVelJqUjVRV0puWWpOdFFuUllSV04xUlVoT2RDSXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMnRTU2prMmNIUlFNVk5pTVRRNVpIbDJWRU5YWjA1dE9WUmhNVnAwZFdKbFRFUjRPVnA1VVhSb2IyOVlJaXdpYm1KbUlqbzBPREEwTVRRek5EQTFMQ0psZUhBaU9qVTBNelV5T1RVME1EVXNJbUYwZENJNlcxMHNJbkJ5WmlJNlcxMTkuenFfQjk1UUZNQ2NFeFd1OUI5NDhJc0k5M0x3RW15WDhyNGJGMC1nWVlSLTJrZWtBWFFNdjYxOXNVMDFvdnlLdHU4Y2RjcTkwcUNZY3VkVVFyT1FrRGciXX0.TeXkfcjEYgODnCO55iMRYxoLUy7kaKhWF7N0Cz32uDd-Ea_c7Wmq4WC-3wCQc9eKI1lqpDe7tfBWGHl_a14hAA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "nbf": 1648469805,
+        "exp": 5435295405,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtpZE5OZGVUN2RHc3o5WHcxNXVDZXhxazUzRjR5QWJnYjNtQnRYRWN1RUhOdCIsImF1ZCI6ImRpZDprZXk6ejZNa2tSSjk2cHRQMVNiMTQ5ZHl2VENXZ05tOVRhMVp0dWJlTER4OVp5UXRob29YIiwibmJmIjo0ODA0MTQzNDA1LCJleHAiOjU0MzUyOTU0MDUsImF0dCI6W10sInByZiI6W119.zq_B95QFMCcExWu9B948IsI93LwEmyX8r4bF0-gYYR-2kekAXQMv619sU01ovyKtu8cdcq90qCYcudUQrOQkDg"
+        ]
+      },
+      "validationErrors": [
+        "expWitnessTimeBoundExceeded"
+      ]
+    }
+  },
+  {
+    "comment": "Witness issuer audience DID does not align with delegated issuer DID",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1T0M0eEluMC5leUpwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3RvZVhscGFGcFRNM0JyWTNaSGMzWnFaalZ3UjJJNVUyUkJZMHRyT0VaRWRGbHBlRmsyUWpkTWFIbHRRaUlzSW1GMVpDSTZJbVJwWkRwclpYazZlalpOYTIxRFYyZzFhRUZaYlhNMVptNVZNVk5vUWtoQ1RtRlZNMDB4UW1WdmVWbG5jWEpSY0dab2IyNTVORkJuSWl3aVpYaHdJam8wT0RBME1UUXpOREExTENKaGRIUWlPbHRkTENKd2NtWWlPbHRkZlEuNzl3MUxKc2k3S3dKX3lGOG1QVG40OVNfWTJqRW9tdEpHaGdSTm5YR0tSdkxtLVIyQWhLVnhsRjkxS0ZQZEpEcTBKcEx6OXljOWs1ZWt4eG9WWE1sRGciXX0.irc9bzJDgplnO3nsy_NebfgU51_TmvucXGMjw78I0a7fM0i4ZsJOMqJT83DzAn8usJrpBDeKHtJw6b8FnkYXDw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoeXlpaFpTM3BrY3ZHc3ZqZjVwR2I5U2RBY0trOEZEdFlpeFk2QjdMaHltQiIsImF1ZCI6ImRpZDprZXk6ejZNa21DV2g1aEFZbXM1Zm5VMVNoQkhCTmFVM00xQmVveVlncXJRcGZob255NFBnIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.79w1LJsi7KwJ_yF8mPTn49S_Y2jEomtJGhgRNnXGKRvLm-R2AhKVxlF91KFPdJDq0JpLz9yc9k5ekxxoVXMlDg"
+        ]
+      },
+      "validationErrors": [
+        "prfWitnessNotAligned"
+      ]
+    }
+  },
+  {
+    "comment": "Witness UCAN version does not match delegated UCAN version",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1TnlKOS5leUpwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3QyTmxsa2EzbGxhR1JpUjFZNVVIUnFjbkl5VTB0Wk9IRm1OVTV3YjIxak5GUnVRM2xCVTNwMWRYWktWQ0lzSW1GMVpDSTZJbVJwWkRwclpYazZlalpOYTJ0U1NqazJjSFJRTVZOaU1UUTVaSGwyVkVOWFowNXRPVlJoTVZwMGRXSmxURVI0T1ZwNVVYUm9iMjlZSWl3aVpYaHdJam8wT0RBME1UUXpOREExTENKaGRIUWlPbHRkTENKd2NtWWlPbHRkZlEubE8zVXp5ZEFXY21qaVNOUXlYUUNIemdyZjgzZU9CSGN1VkcxdS15dVVLaFl2ZFg4c2pIcTUtUU9OYmNGTmZKSW1tNTRKVXp1M3AwV0ZVUS00UkpQQnciXX0._dh16zftCRCx-Lsp8NbG1mtuRVPtsJ7uxcibQ6ZvCgXZrKnVsdkHd9YlYb2LDjd1mD2p2Auq97GBKInJDhx1BQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuNyJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWt2Nllka3llaGRiR1Y5UHRqcnIyU0tZOHFmNU5wb21jNFRuQ3lBU3p1dXZKVCIsImF1ZCI6ImRpZDprZXk6ejZNa2tSSjk2cHRQMVNiMTQ5ZHl2VENXZ05tOVRhMVp0dWJlTER4OVp5UXRob29YIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.lO3UzydAWcmjiSNQyXQCHzgrf83eOBHcuVG1u-yuUKhYvdX8sjHq5-QONbcFNfJImm54JUzu3p0WFUQ-4RJPBw"
+        ]
+      },
+      "validationErrors": [
+        "prfWitnessVersionMismatch"
+      ]
+    }
+  },
+  {
+    "comment": "Witness referenced in prf scheme does not exist",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOlt7IndpdGgiOiJwcmYvMiIsImNhbiI6InVjYW4vREVMRUdBVEUifV0sInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdHBVRFpIYmpSVlZuZHVTM0ZDV2pOalowVnhjMUkxTm5SVFJUZGFkR1IzTjNwMmFHOTRlbGx3Um01WFlTSXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMnRTU2prMmNIUlFNVk5pTVRRNVpIbDJWRU5YWjA1dE9WUmhNVnAwZFdKbFRFUjRPVnA1VVhSb2IyOVlJaXdpWlhod0lqbzBPREEwTVRRek5EQTFMQ0poZEhRaU9sdGRMQ0p3Y21ZaU9sdGRmUS5Fb0FJVHBSQThNcHA4MnlFVEN5S25CLWh6eURkQ21GR2tZMFdtaFZITFd5VHpFX2dob2hueEYwMC0ycjNRVHItNFJ3bWV0R1RLMnNmZV80OG5EbFZDdyJdfQ.Pym6NodLcZe7elBnnwDlxf5SP3VlEHluxvgTsNplwaKJ32KxBdVP9J9kY1T3ZA_d6XlvAOz8Ve8RQ0DPYpCxDA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [
+          {
+            "with": "prf/2",
+            "can": "ucan/DELEGATE"
+          }
+        ],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtpUDZHbjRVVnduS3FCWjNjZ0Vxc1I1NnRTRTdadGR3N3p2aG94ellwRm5XYSIsImF1ZCI6ImRpZDprZXk6ejZNa2tSSjk2cHRQMVNiMTQ5ZHl2VENXZ05tOVRhMVp0dWJlTER4OVp5UXRob29YIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.EoAITpRA8Mpp82yETCyKnB-hzyDdCmFGkY0WmhVHLWyTzE_ghohnxF00-2r3QTr-4RwmetGTK2sfe_48nDlVCw"
+        ]
+      },
+      "validationErrors": [
+        "prfWitnessDoesNotExist"
+      ]
+    }
+  },
+  {
+    "comment": "Header `alg` field should be a string",
+    "token": "eyJhbGciOjEsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.mIofiorxV3wY3gJciycO6vv2RfqG3pjykkhhtVH463jB0H_1v2qBwRA8c9LZH6gcMzfxRGriCunly6CwWP8rCA",
+    "assertions": {
+      "header": {
+        "alg": 1,
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "algWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Header is missing an `alg` field",
+    "token": "eyJ0eXAiOiJKV1QiLCJ1Y3YiOiIwLjguMSJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.7-Ta8h0oc10104OsgyK3OcTzm9pjTBFAHbKNogH0A6LOk3_su1fF50SFjt3ynqigdw5iO8dBwkavBL_BxqRwBQ",
+    "assertions": {
+      "header": {
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "algMissing"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN algorithm is not valid",
+    "token": "eyJhbGciOiIiLCJ0eXAiOiJKV1QiLCJ1Y3YiOiIwLjguMSJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.iIS8VeAQwb_jyTzVKpVxeYRauOcUBcUw4sB9y4J5r6vI__8ShuUxb7-D6vcfmncWyuTm5iq_tbqm5AEbhMG-Bg",
+    "assertions": {
+      "header": {
+        "alg": "",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "algInvalidAlgorithm"
+      ]
+    }
+  },
+  {
+    "comment": "Header `typ` field should be a string",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6MSwidWN2IjoiMC44LjEifQ.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.mMBMtK54tDYH2Vn6ym1yUu9COCidKj2LYqd1sSxeuDl8fslMRnguD55wSsb7gK7zxtg4E6Hm37Gso6DxuQsGAQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": 1,
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "typWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Header is missing a `typ` field",
+    "token": "eyJhbGciOiJFZERTQSIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.JA1JpfG6N2aGkISzM-DTKxqdCkUCm2MCFCUeqivOSE_mF0cQFb1RcTzL5Mj82W58g6IvvaY8K9cd-DUznrBMBg",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "typMissing"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN type is not valid",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IiIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.KWMTSNcsvNXX1phXsS948P0Pk_P-60iJViexlmmTsUeV0YFefzf425SW6u60MIZNytUKGM4ttUODYofEd_AQCA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "typInvalidType"
+      ]
+    }
+  },
+  {
+    "comment": "Header `ucv` field should be a string",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6MX0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA1LCJhdHQiOltdLCJwcmYiOltdfQ.BeJGYQHJzLWTOgW43hHN50KbZnGwOdXO6_SjxRsvEG6_VXKqJgM-Twzhg8hZ5sP9rI3Z_aN1p_78sBC34S8HBg",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": 1
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143405,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "ucvWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Header is missing a `ucv` field",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOltdfQ.3_mFfAQPuD0hCT9CwshexBzFWGvJG_fYsReGDEDocHrLUwPGUnlepJGQ0d7wXYybpthfTDcE7Q_K_NsRKnvADw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "ucvMissing"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN version is not valid",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuNyJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOltdfQ.w-9sCI_QqcUwV0onCYChk6ZUvpm6M59V9EX-95LAKjUDzaaExyXuI3TQ56VYiadj1w4CR4stxEFuRVRoC2QCCQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.7"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "ucvInvalidVersion"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `iss` field should be a did:key string",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOjEsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOltdfQ.7NMS0rGRKgUSsK4VcN7zT1nU53UkpYtIegx4kE9bM5jdYSdBTbANUjq3JIvGaSeEWQy2nnUeAxmeFhEqJrmZAQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": 1,
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "issWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload is missing an `iss` field",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJhdWQiOiJkaWQ6a2V5Ono2TWtvd1dhS3VNYnFGY2Q3dlhyb0dzRDk4d1hid1B3U3Y2RnZXR2pkaHRQNE56ZSIsImV4cCI6NDgwNDE0MzQwNiwiYXR0IjpbXSwicHJmIjpbXX0.p1Csgk2_Gpc_bNUECJjRNQCM2OJGed39zlSEiZaPZMHpyRK3DxoMhpQPlxgxPjF6_-48W5aUX7iU76TfxBq6DA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "issMissing"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN issuer did:key is not valid",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiIiLCJhdWQiOiJkaWQ6a2V5Ono2TWtvd1dhS3VNYnFGY2Q3dlhyb0dzRDk4d1hid1B3U3Y2RnZXR2pkaHRQNE56ZSIsImV4cCI6NDgwNDE0MzQwNiwiYXR0IjpbXSwicHJmIjpbXX0.6dLlKFCQaeM27_LNIDndbkkVnd2hvicJEjBwcIxaRvkBlsdgQg02Ct_g4XEAeIpX74gj79J9UKkuKnPY-ToZBg",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "issInvalidDidKey"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN issuer did:key is not valid",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5OnpNKyttOER4V1N3UWhoWlliZ1Bqa0NOam1MdnZhM0Q3cUJzR1B2d3oyZ3luU2lhSiIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOltdfQ.kO73jhpzsyhMNUtV7LlcGBKi66gTbSVp6DD4K6k9ugA_a0ijbq_i9ga_LQWYrQAAeWxe52NN7rNHm0uTX07SBA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:zM++m8DxWSwQhhZYbgPjkCNjmLvva3D7qBsGPvwz2gynSiaJ",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "issInvalidDidKey"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `aud` field should be a did:key string",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6MSwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOltdfQ.fjpb0dviYqmjryGTayTdeMWu0MrF0ozSKWDbsgW6DKJ53wn6Ai9YttOnASEcgwkK_fXALtU7vifhC5DCGbGpDw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": 1,
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "audWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload is missing an `aud` field",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImV4cCI6NDgwNDE0MzQwNiwiYXR0IjpbXSwicHJmIjpbXX0.Yuv80MkYlalcFrMNfJfnPHXBtvWdadnvt6CTBJJem8iaklmbTvCxJoTpWL2vtl5BnKapdlJvF73BvYIJLErvDA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "audMissing"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN audience did:key is not valid",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ek0rK204RHhXU3dRaGhaWWJnUGprQ05qbUx2dmEzRDdxQnNHUHZ3ejJneW5TaWFKIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOltdfQ.YB9ltNMczA9GM1CnXXCy_WdquMWjFVlUg-uC53O9Axe1Zy0nNbDQym-vc5SpsRna0PayYQso6JBRr27PGYyQBw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:zM++m8DxWSwQhhZYbgPjkCNjmLvva3D7qBsGPvwz2gynSiaJ",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "audInvalidDidKey"
+      ]
+    }
+  },
+  {
+    "comment": "UCAN audience did:key is not valid",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6IiIsImV4cCI6NDgwNDE0MzQwNiwiYXR0IjpbXSwicHJmIjpbXX0.kcKCzMYP0LLlKlGn66baSaDF0C1v8FM_M7yRtb8r2VIOhXaNX8xhGKLE49LQB9xOc9QZNajlgF3X8dGCWvc1DA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "validationErrors": [
+        "audInvalidDidKey"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `nbf` field should be a number",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwibmJmIjoic3RyaW5nIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOltdfQ.HNLRPWSnwzNF7XxSg_ua1hydQYWekXZZxkC-axf3_V3SXosU2iGsBJ0OhxO8DshqXJj2DvW44wKvdGxegtxVBw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "nbf": "string",
+        "exp": 4804143406,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "nbfWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `exp` field should be a string",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjoic3RyaW5nIiwiYXR0IjpbXSwicHJmIjpbXX0.n-3o1pAo11o9dMQTlsu-FjxozJTFnw_TcogtERyFv08T09bsdw8ASzjQcS_aIiw-C_VYFxBTuYAAqREbSOAOBQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": "string",
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "expWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload is missing an `exp` field",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiYXR0IjpbXSwicHJmIjpbXX0.q-ic-mRrH8ycagOZKUEal3HlP5l2LNPEd9w_doS8yHlXyxhF9_L6IfzfcyTCnfQSj11pDF0ckc50fN62Xi4dAw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "expMissing"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `ncc` field should be a string",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJubmMiOjEsImF0dCI6W10sInByZiI6W119.9e_eP6WXGEZ9I1P0qH4XTB2Wnweull2N75CBkovWAAANDUZkhUujXIw0UcnEmDdpGzky4NVBoj-dlEjVrtdABQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "nnc": 1,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "nncWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `fct` field should be an array of json",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJmY3QiOjEsImF0dCI6W10sInByZiI6W119.ZflRtjq1OnLS9jLM30ElokOKkrjFqNDR5fn50z9YTdzjgl7HTp4SSHomPLvTVuV7Dm42GE9_IqZzkftNZA9dAQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "fct": 1,
+        "att": [],
+        "prf": []
+      },
+      "typeErrors": [
+        "fctWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `prf` field should be an array of strings",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOjF9.59ZbiOUjVpriTAMfdG8zBAxEv9-gAeBxM9dsjhHXhqpLyCEsLiG8p4m0UpV1ndqHhlzOq2UYvwFHA7RF29hACg",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [],
+        "prf": 1
+      },
+      "typeErrors": [
+        "prfWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `prf` field should be an array of strings",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOlsxXX0.i7zJZKCmY5LJRoT4cPfaL-_2LVH-OfVKqBlHQeWGuxVZAMGCLh_UEo_XGz4OffsTGuliUy-9oK7IgdwwY2NVCw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [],
+        "prf": [
+          1
+        ]
+      },
+      "typeErrors": [
+        "prfWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload is missing an `prf` field",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdfQ.8Z9f9C-Bx0c2o6AIv7ap28bz0ZIKYihNXv1c5GEct_ub7_HNO_Yp9C1JjXDEitIp62tg7m1fOnrw6YZkIKG8Dw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": []
+      },
+      "typeErrors": [
+        "prfMissing"
+      ]
+    }
+  },
+  {
+    "comment": "Payload `att` field should be an array of json",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOjEsInByZiI6W119.PPJv9sDl-1kAULjslUx6kyXgb5uRDAxWyOvjiMk545nPMu6MFAtR_dmeQBWykIrKsQdmhdiGtyySaqyhAywgDA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": 1,
+        "prf": []
+      },
+      "typeErrors": [
+        "attWrongType"
+      ]
+    }
+  },
+  {
+    "comment": "Payload is missing an `att` field",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJwcmYiOltdfQ.GjLODnc4DFVycTq_lM7UFBArE31AYBBFfhwJGA2pGqf9vdD-M7JzWYCOI9RWKXXdrJroVvSfp7-MG_fSoGZHCw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "prf": []
+      },
+      "typeErrors": [
+        "attMissing"
+      ]
+    }
+  },
+  {
+    "comment": "Attenuation resource is not a URI",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOlt7IndpdGgiOiJ0YW1lZHVuLmZpc3Npb24uYXBwL3B1YmxpYy9waG90b3MvIiwiY2FuIjoid25mcy9BUFBFTkQifV0sInByZiI6W119.iEs4qr18c73cIKfTIigLTJAsTdpYdUihWmymNp3Ahw3_9lHdOOlIhl3o3PP0iS6OWKEIBN7k_w8o_j4UD1dwCA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [
+          {
+            "with": "tamedun.fission.app/public/photos/",
+            "can": "wnfs/APPEND"
+          }
+        ],
+        "prf": []
+      },
+      "validationErrors": [
+        "attInvalidResource"
+      ]
+    }
+  },
+  {
+    "comment": "Attenuation ability is not namespaced",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ejZNa293V2FLdU1icUZjZDd2WHJvR3NEOTh3WGJ3UHdTdjZGdldHamRodFA0TnplIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOlt7IndpdGgiOiJ3bmZzOi8vdGFtZWR1bi5maXNzaW9uLmFwcC9wdWJsaWMvcGhvdG9zLyIsImNhbiI6IkFQUEVORCJ9XSwicHJmIjpbXX0.7pdDA5Uz73Unl7_Tu-jtKFv_3GjVEQ8vhknK0UeF09KcjLGr7rdduNamqD0XUsb-BBtfXb62HhfTDENf88URCw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
+        "aud": "did:key:z6MkowWaKuMbqFcd7vXroGsD98wXbwPwSv6FvWGjdhtP4Nze",
+        "exp": 4804143406,
+        "att": [
+          {
+            "with": "wnfs://tamedun.fission.app/public/photos/",
+            "can": "APPEND"
+          }
+        ],
+        "prf": []
+      },
+      "validationErrors": [
+        "attInvalidAbility"
+      ]
+    }
+  }
+]

--- a/tests/ucan-v0.8.1-invalid.json
+++ b/tests/ucan-v0.8.1-invalid.json
@@ -535,27 +535,6 @@
   },
   {
     "comment": "UCAN audience did:key is not valid",
-    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6ImRpZDprZXk6ek0rK204RHhXU3dRaGhaWWJnUGprQ05qbUx2dmEzRDdxQnNHUHZ3ejJneW5TaWFKIiwiZXhwIjo0ODA0MTQzNDA2LCJhdHQiOltdLCJwcmYiOltdfQ.YB9ltNMczA9GM1CnXXCy_WdquMWjFVlUg-uC53O9Axe1Zy0nNbDQym-vc5SpsRna0PayYQso6JBRr27PGYyQBw",
-    "assertions": {
-      "header": {
-        "alg": "EdDSA",
-        "typ": "JWT",
-        "ucv": "0.8.1"
-      },
-      "payload": {
-        "iss": "did:key:z6MkkRJ96ptP1Sb149dyvTCWgNm9Ta1ZtubeLDx9ZyQthooX",
-        "aud": "did:key:zM++m8DxWSwQhhZYbgPjkCNjmLvva3D7qBsGPvwz2gynSiaJ",
-        "exp": 4804143406,
-        "att": [],
-        "prf": []
-      },
-      "validationErrors": [
-        "audInvalidDidKey"
-      ]
-    }
-  },
-  {
-    "comment": "UCAN audience did:key is not valid",
     "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrUko5NnB0UDFTYjE0OWR5dlRDV2dObTlUYTFadHViZUxEeDlaeVF0aG9vWCIsImF1ZCI6IiIsImV4cCI6NDgwNDE0MzQwNiwiYXR0IjpbXSwicHJmIjpbXX0.kcKCzMYP0LLlKlGn66baSaDF0C1v8FM_M7yRtb8r2VIOhXaNX8xhGKLE49LQB9xOc9QZNajlgF3X8dGCWvc1DA",
     "assertions": {
       "header": {

--- a/tests/ucan-v0.8.1-valid.json
+++ b/tests/ucan-v0.8.1-valid.json
@@ -1,0 +1,339 @@
+[
+  {
+    "comment": "Delegated UCAN has rights amplification from combining witness capabilities",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJkYjovL3RhbWVkdW4uZmlzc2lvbi5hcHAvdXNlcnMiLCJjYW4iOiJkYi9XUklURSJ9LHsid2l0aCI6ImRiOi8vdGFtZWR1bi5maXNzaW9uLmFwcC91c2VycyIsImNhbiI6ImRiL1JFQUQifV0sInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdG9TRWRXZEZkTmJUVTVkMUJCVWxFNFZHaHRRalJ4ZG5SdFdHNXhlWFZIUzA1SVNtMUZWbk5IZVdsWmRDSXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMlpuZEZoclEyNWlPVXhZYmpoQ2JubHFlRkpOYmt0MFJtZGFZemMwVFRZNE56TjJOakZ4UTJOTFNHcHJJaXdpWlhod0lqbzBPREEwTVRRek5ERXlMQ0poZEhRaU9sdDdJbmRwZEdnaU9pSmtZam92TDNSaGJXVmtkVzR1Wm1semMybHZiaTVoY0hBdmRYTmxjbk1pTENKallXNGlPaUprWWk5U1JVRkVJbjFkTENKd2NtWWlPbHRkZlEueGVSck9FdmlEbWQ1elVXVVR2MWV4ZEpfUDN5YnlPSVhNSFdfcFFWUGoyZGFfTFU5YmI3N1ZZcHNxWV9KUkJUZVlyTzFzLThOQlZGU0xuNktBcERQRGciLCJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdHVSRnBtWkRaRk1tTTRXVVZFWkhNMVIxaE1VakZpVVhwR1JsUldSVzU2Y0dGSWNWZzFTRlY0WnpWWmJpSXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMlpuZEZoclEyNWlPVXhZYmpoQ2JubHFlRkpOYmt0MFJtZGFZemMwVFRZNE56TjJOakZ4UTJOTFNHcHJJaXdpWlhod0lqbzBPREEwTVRRek5ERXlMQ0poZEhRaU9sdDdJbmRwZEdnaU9pSmtZam92TDNSaGJXVmtkVzR1Wm1semMybHZiaTVoY0hBdmRYTmxjbk1pTENKallXNGlPaUprWWk5WFVrbFVSU0o5WFN3aWNISm1JanBiWFgwLllkN2V6eXg5bnN0UkNvaW93dXRYeU5IRDJJOHdfOWdzUm5DT00tTEZPMTJVSEtCSW1BVUNuLUVINTg5STduTy1VOEl6MWtxV0NWd05VbzE2NmEyckJnIl19.8sLGP84wv_RM5t5aWm6cdHH3TNKuDO3oTgMNBN8499VqYK2w6khl2u-2S3V3tbOXeKkYFDn5b_HYZs_Fa9zdCQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [
+          {
+            "with": "db://tamedun.fission.app/users",
+            "can": "db/WRITE"
+          },
+          {
+            "with": "db://tamedun.fission.app/users",
+            "can": "db/READ"
+          }
+        ],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoSEdWdFdNbTU5d1BBUlE4VGhtQjRxdnRtWG5xeXVHS05ISm1FVnNHeWlZdCIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJkYjovL3RhbWVkdW4uZmlzc2lvbi5hcHAvdXNlcnMiLCJjYW4iOiJkYi9SRUFEIn1dLCJwcmYiOltdfQ.xeRrOEviDmd5zUWUTv1exdJ_P3ybyOIXMHW_pQVPj2da_LU9bb77VYpsqY_JRBTeYrO1s-8NBVFSLn6KApDPDg",
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtuRFpmZDZFMmM4WUVEZHM1R1hMUjFiUXpGRlRWRW56cGFIcVg1SFV4ZzVZbiIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJkYjovL3RhbWVkdW4uZmlzc2lvbi5hcHAvdXNlcnMiLCJjYW4iOiJkYi9XUklURSJ9XSwicHJmIjpbXX0.Yd7ezyx9nstRCoiowutXyNHD2I8w_9gsRnCOM-LFO12UHKBImAUCn-EH589I7nO-U8Iz1kqWCVwNUo166a2rBg"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "Witness issuer audience did aligns with delegated issuer did",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1T0M0eEluMC5leUpwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3R4Ym1KT2FUbDJaSFJFTkVSTFVXaHlTREpaUjFkMFFtZDNRak51TkRFeVFWRlVPRXhuVWpkQk5qZEZSeUlzSW1GMVpDSTZJbVJwWkRwclpYazZlalpOYTJabmRGaHJRMjVpT1V4WWJqaENibmxxZUZKTmJrdDBSbWRhWXpjMFRUWTROek4yTmpGeFEyTkxTR3BySWl3aVpYaHdJam8wT0RBME1UUXpOREV5TENKaGRIUWlPbHRkTENKd2NtWWlPbHRkZlEuTUFudEhWZFVxZVc5N3Y0RVByU0pqWjBQOUdjTExGaEZJZEVZRUhBZG12NHgyQ0RmbnRVYXFEekFnTUN4d0tDTkJDQVhCRnZ5MUFUMTVaRkhzMDIyQVEiXX0.TA5ugLsiu7jrK3y9fzrLFNuaqnzFSA8ogjvwUS84_pEi8xYk2fGC7LhOQCo0DuMqvlT9ubYp3ywGizHlZ0waAA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtxbmJOaTl2ZHRENERLUWhySDJZR1d0Qmd3QjNuNDEyQVFUOExnUjdBNjdFRyIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOltdfQ.MAntHVdUqeW97v4EPrSJjZ0P9GcLLFhFIdEYEHAdmv4x2CDfntUaqDzAgMCxwKCNBCAXBFvy1AT15ZFHs022AQ"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "Witness UCAN version matches delegated UCAN version",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1T0M0eEluMC5leUpwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3RtYm0xa1NEaHpUbTFEYUZWemEyaFJia3REVGpKTmNHaE5RMHhtUVcxU1FVYzBhVzlOZGtKV2RGRjFWaUlzSW1GMVpDSTZJbVJwWkRwclpYazZlalpOYTJabmRGaHJRMjVpT1V4WWJqaENibmxxZUZKTmJrdDBSbWRhWXpjMFRUWTROek4yTmpGeFEyTkxTR3BySWl3aVpYaHdJam8wT0RBME1UUXpOREV5TENKaGRIUWlPbHRkTENKd2NtWWlPbHRkZlEub2NURHU5emlkMW11NG9qOVJkVDRwMzdudlRPbEh1aWZkLW9EamZUTjF1ZHJaWnhpRjJiNUJKYmNzNGtEU0tKaU91enExT1hEVUctay1JOXNGdlMwQmciXX0.ok2xB1mr04nShwF76rgdBgv5dnUrbpAacMHXkOJCP-0kqvO4GYOwhLDwW6j43mnD2XCvy4U20LTTh_mkumxYAQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmbm1kSDhzTm1DaFVza2hRbktDTjJNcGhNQ0xmQW1SQUc0aW9NdkJWdFF1ViIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOltdfQ.ocTDu9zid1mu4oj9RdT4p37nvTOlHuifd-oDjfTN1udrZZxiF2b5BJbcs4kDSKJiOuzq1OXDUG-k-I9sFvS0Bg"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "UCAN has not expired",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOltdfQ.NaguDFWi8SkedAZ5eplUvQgMkeIQyZLzvl6084mH4vxqTazMxyDbT8RdHGumGug2NmKSvHn0_t2ae0KJK5U-BQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [],
+        "prf": []
+      }
+    }
+  },
+  {
+    "comment": "UCAN is ready to be used",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwibmJmIjoxNjQ4MzgzNDEyLCJleHAiOjQ4MzU2Nzk0MTIsImF0dCI6W10sInByZiI6W119.oo9Jr-bTtfavOIR0xNt4jkm8KLcBwTkdvFGIlnBz4-CLYRIIkW8qMNTMI1c5JIl1gvvsdrOEwvIQyPiv_qZdAA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "nbf": 1648383412,
+        "exp": 4835679412,
+        "att": [],
+        "prf": []
+      }
+    }
+  },
+  {
+    "comment": "Witnesses expire after the delegated UCAN",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1T0M0eEluMC5leUpwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3RtTVZweVdtVm5TMXBrVVRoeWFITkhUa05xYVdkS1EycExZVXBWVkVONGJVRTBRakZHV0hwdlJXdHJjQ0lzSW1GMVpDSTZJbVJwWkRwclpYazZlalpOYTJabmRGaHJRMjVpT1V4WWJqaENibmxxZUZKTmJrdDBSbWRhWXpjMFRUWTROek4yTmpGeFEyTkxTR3BySWl3aVpYaHdJam8xTkRNMU1qazFOREV5TENKaGRIUWlPbHRkTENKd2NtWWlPbHRkZlEuSUxqM1RIYnYydy1jR3d4Z0lOcVMtU2NzQlYybjR3aHBNTWh5MW5hNHpUU0JQSGJQUWZiX3laTGFMRklLbm9KVlNxSHUyUFU5NVU2dHBlN2R6ckh4RFEiXX0.QiwjoOvTi2GSEy7lIBaZ0I5sjNmRsp4BDSvxkbV23jEHjiVMyYbgDmgfke5Bnzbt7GD0s6UcwRcQoB_LyAazDw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmMVpyWmVnS1pkUThyaHNHTkNqaWdKQ2pLYUpVVEN4bUE0QjFGWHpvRWtrcCIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo1NDM1Mjk1NDEyLCJhdHQiOltdLCJwcmYiOltdfQ.ILj3THbv2w-cGwxgINqS-ScsBV2n4whpMMhy1na4zTSBPHbPQfb_yZLaLFIKnoJVSqHu2PU95U6tpe7dzrHxDQ"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "Witnesses expire at the same time as delegated UCAN",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwibmJmIjoxNjQ4NDY5ODEyLCJleHAiOjQ4MDQxNDM0MTIsImF0dCI6W10sInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdHJWMVZXU21GMk5rWktaRzl3ZEROS1oyaEtXV1ZoUW10UlVtdExUVFkyWTJWek1YY3pPR2hhTVRaUmVpSXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMlpuZEZoclEyNWlPVXhZYmpoQ2JubHFlRkpOYmt0MFJtZGFZemMwVFRZNE56TjJOakZ4UTJOTFNHcHJJaXdpWlhod0lqbzBPREEwTVRRek5ERXlMQ0poZEhRaU9sdGRMQ0p3Y21ZaU9sdGRmUS5ySTFXa0pzTmNvVkx0Q3FDWDFBd1J2QmJjX3hZQ3lXMjNOTzloU3F2ZzZqSlV2Z0pwMkV3MGFnb3c4cGxMcnhmeV9WMEZMMVJxQ0M0VlhPemRHcDhDUSJdfQ.pfm2mtq3nhkJ27tTcc9hac9NXvOQeGgluNFhjGrFQpysWwr1fTxAJKzQbqMQIenMqOQnLT7wfGw3PRvSFTxgBw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "nbf": 1648469812,
+        "exp": 4804143412,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtrV1VWSmF2NkZKZG9wdDNKZ2hKWWVhQmtRUmtLTTY2Y2VzMXczOGhaMTZReiIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOltdfQ.rI1WkJsNcoVLtCqCX1AwRvBbc_xYCyW23NO9hSqvg6jJUvgJp2Ew0agow8plLrxfy_V0FL1RqCC4VXOzdGp8CQ"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "Witnesses are ready to be used before the delegated UCAN",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwibmJmIjo0ODM1Njc5NDEyLCJleHAiOjU0MzUyOTU0MTIsImF0dCI6W10sInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdG9TMHBhT1ZkdlYxZG5aVmRxU25kM1FVMTRWRGg0YzJ0TWVsSnpiVVJZU3paMU5rdHVWamxuUjBwQ1ZpSXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMlpuZEZoclEyNWlPVXhZYmpoQ2JubHFlRkpOYmt0MFJtZGFZemMwVFRZNE56TjJOakZ4UTJOTFNHcHJJaXdpYm1KbUlqbzBPREEwTVRRek5ERXlMQ0psZUhBaU9qVTBNelV5T1RVME1USXNJbUYwZENJNlcxMHNJbkJ5WmlJNlcxMTkudTIxY2Focjl3RV8tS1ZfV0habURSVWxVR3NNb21jOGppRE53TFlhLUVUeUp3Q2g4VnRmUFJTRHd4TkMzZzJzdjBobXFFOV80NjdpZHFfVDR3bkxkQkEiXX0.LivwBVQG_6nMs0CdnMrifHDl9L6dryc4Jz76f2E5Z8NikY1fha6ofeOIDhxKcRKcVbHhwbyAElnPq0mLmM2dBA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "nbf": 4835679412,
+        "exp": 5435295412,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoS0paOVdvV1dnZVdqSnd3QU14VDh4c2tMelJzbURYSzZ1NktuVjlnR0pCViIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwibmJmIjo0ODA0MTQzNDEyLCJleHAiOjU0MzUyOTU0MTIsImF0dCI6W10sInByZiI6W119.u21cahr9wE_-KV_WHZmDRUlUGsMomc8jiDNwLYa-ETyJwCh8VtfPRSDwxNC3g2sv0hmqE9_467idq_T4wnLdBA"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "Witness is ready to be used at the same time as the delegated UCAN",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwibmJmIjo0ODA0MTQzNDEyLCJleHAiOjU0MzUyOTU0MTIsImF0dCI6W10sInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdG9OVkIxTlU1M1ZXWlFUa1JwVnpaYVIxaE5PREZFYlVkTE1rUTVRMDF3TVc0MGJYbGhUbWgwTVZoQ1Z5SXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMlpuZEZoclEyNWlPVXhZYmpoQ2JubHFlRkpOYmt0MFJtZGFZemMwVFRZNE56TjJOakZ4UTJOTFNHcHJJaXdpYm1KbUlqbzBPREEwTVRRek5ERXlMQ0psZUhBaU9qVTBNelV5T1RVME1USXNJbUYwZENJNlcxMHNJbkJ5WmlJNlcxMTkubDM4MDFOQnJDdjdjY25WQWRRS1l3aDQ5S0xtanZXM3dLV3VyaXRWUTlNMG1ZOXhhcEhkZzI4Vk1zSlFVcDJHMHROdWRkbEJOb0NMcDNzU1JyYnh4RGciXX0.CF-EvquRHZb_STrnWb8lAIUqBG2xo-TtpHByDGF3RC2SgKmHfh5MgzqlbxHQzQU0WWFepZVmkBIq4ChkY3HiDQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "nbf": 4804143412,
+        "exp": 5435295412,
+        "att": [],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtoNVB1NU53VWZQTkRpVzZaR1hNODFEbUdLMkQ5Q01wMW40bXlhTmh0MVhCVyIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwibmJmIjo0ODA0MTQzNDEyLCJleHAiOjU0MzUyOTU0MTIsImF0dCI6W10sInByZiI6W119.l3801NBrCv7ccnVAdQKYwh49KLmjvW3wKWuritVQ9M0mY9xapHdg28VMsJQUp2G0tNuddlBNoCLp3sSRrbxxDg"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "Delegated UCAN can delegate",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJwcmYvMCIsImNhbiI6InVjYW4vREVMRUdBVEUifV0sInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdHRUREphYzNaR1YxUmhZbFZsUlZWVFpUWm5UVmxDV0hCb1FsaDJlRWMxWkdScmRVNXlOVVJMWVRGWmJ5SXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMlpuZEZoclEyNWlPVXhZYmpoQ2JubHFlRkpOYmt0MFJtZGFZemMwVFRZNE56TjJOakZ4UTJOTFNHcHJJaXdpWlhod0lqbzBPREEwTVRRek5ERXlMQ0poZEhRaU9sdGRMQ0p3Y21ZaU9sdGRmUS5QY0ZSS3YzTkFKbFlTN1VPTFNmZnN5alprVTZnVUVJMHJndllXSFZJUDhaUGcwSlR1cmdBZnlaeHAzWXhqMHlxbEdZZGpuNzI4Sl9vV2h2ZUlVdkJEQSJdfQ._QuS_Opa40kuLuy-TuyKax6GXji6E0VXghGl04j5nq1ezNguRfu1_KT3Qs6RYQFIPssQhUEibc2yCCMxakV-AA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [
+          {
+            "with": "prf/0",
+            "can": "ucan/DELEGATE"
+          }
+        ],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWttTDJac3ZGV1RhYlVlRVVTZTZnTVlCWHBoQlh2eEc1ZGRrdU5yNURLYTFZbyIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOltdfQ.PcFRKv3NAJlYS7UOLSffsyjZkU6gUEI0rgvYWHVIP8ZPg0JTurgAfyZxp3Yxj0yqlGYdjn728J_oWhveIUvBDA"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "UCAN is valid",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOltdLCJwcmYiOltdfQ.NaguDFWi8SkedAZ5eplUvQgMkeIQyZLzvl6084mH4vxqTazMxyDbT8RdHGumGug2NmKSvHn0_t2ae0KJK5U-BQ",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [],
+        "prf": []
+      }
+    }
+  },
+  {
+    "comment": "Payload `fct` is valid",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJmY3QiOlt7ImNoYWxsZW5nZSI6ImFiY2RlZiIsImZyb20iOiJleGFtcGxlLmNvbSJ9XSwiYXR0IjpbXSwicHJmIjpbXX0.PMKMCepWeHYk4KAqBeHlJM25go5zgN9fucA2aD6JErA3tTImEmUV_EIhxmgUHkKnEM9iske61NjeWmtOqTKzAg",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "fct": [
+          {
+            "challenge": "abcdef",
+            "from": "example.com"
+          }
+        ],
+        "att": [],
+        "prf": []
+      }
+    }
+  },
+  {
+    "comment": "Delegated UCAN is valid with multiple valid proofs",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJkYjovL3RhbWVkdW4uZmlzc2lvbi5hcHAvdXNlcnMiLCJjYW4iOiJkYi9XUklURSJ9LHsid2l0aCI6ImRiOi8vdGFtZWR1bi5maXNzaW9uLmFwcC91c2VycyIsImNhbiI6ImRiL1JFQUQifV0sInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdDFOVVJyYUhaaVVUTkdlVXRPU0hsb09GbENWREZLZEdWWVdXWklaSGxXZVZBMWFWWkNOV2hUWmpsblNDSXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMlpuZEZoclEyNWlPVXhZYmpoQ2JubHFlRkpOYmt0MFJtZGFZemMwVFRZNE56TjJOakZ4UTJOTFNHcHJJaXdpWlhod0lqbzBPREEwTVRRek5ERXlMQ0poZEhRaU9sdDdJbmRwZEdnaU9pSmtZam92TDNSaGJXVmtkVzR1Wm1semMybHZiaTVoY0hBdmRYTmxjbk1pTENKallXNGlPaUprWWk5U1JVRkVJbjFkTENKd2NtWWlPbHRkZlEuem5DRDVjaVlOUTVPdklrYTJFM3dOZW51ZElyUE5pUGM0RXMzdTBHT3lYX3FMY0dOSXo5Mk5kSDVrcFF5OUU1OE85eFNDMFBpbmRRQmpZcG5SNVN4Q2ciLCJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdHVXRVZyWkZCS1FrTm9ORFJvZGtabWNWVmFUVGRqYjNGME9UaGlOMlZwUzBOcGFXTjVTa05sUzI1d2FTSXNJbUYxWkNJNkltUnBaRHByWlhrNmVqWk5hMlpuZEZoclEyNWlPVXhZYmpoQ2JubHFlRkpOYmt0MFJtZGFZemMwVFRZNE56TjJOakZ4UTJOTFNHcHJJaXdpWlhod0lqbzBPREEwTVRRek5ERXlMQ0poZEhRaU9sdDdJbmRwZEdnaU9pSmtZam92TDNSaGJXVmtkVzR1Wm1semMybHZiaTVoY0hBdmRYTmxjbk1pTENKallXNGlPaUprWWk5WFVrbFVSU0o5WFN3aWNISm1JanBiWFgwLmkyVzN1VGFTOFFZUkVucWpSVDlBRVBFRW5pejBuOXNjWU1QSzRQdlV5WF9JTjMwVEc2aWczNWI2LWlBSk95UVFfLXR4c05IRlZ6TWhaUjAzaUg2TENRIl19.9suTMcVmUfkeejbjyxOZqp0cA_fZ_ncLLKu7teULXhm1uypOJNLpgHj8Xm_YqK-ChZmNBqFyNM9k2Yc4H6TXAw",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [
+          {
+            "with": "db://tamedun.fission.app/users",
+            "can": "db/WRITE"
+          },
+          {
+            "with": "db://tamedun.fission.app/users",
+            "can": "db/READ"
+          }
+        ],
+        "prf": [
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWt1NURraHZiUTNGeUtOSHloOFlCVDFKdGVYWWZIZHlWeVA1aVZCNWhTZjlnSCIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJkYjovL3RhbWVkdW4uZmlzc2lvbi5hcHAvdXNlcnMiLCJjYW4iOiJkYi9SRUFEIn1dLCJwcmYiOltdfQ.znCD5ciYNQ5OvIka2E3wNenudIrPNiPc4Es3u0GOyX_qLcGNIz92NdH5kpQy9E58O9xSC0PindQBjYpnR5SxCg",
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtuWEVrZFBKQkNoNDRodkZmcVVaTTdjb3F0OThiN2VpS0NpaWN5SkNlS25waSIsImF1ZCI6ImRpZDprZXk6ejZNa2ZndFhrQ25iOUxYbjhCbnlqeFJNbkt0RmdaYzc0TTY4NzN2NjFxQ2NLSGprIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJkYjovL3RhbWVkdW4uZmlzc2lvbi5hcHAvdXNlcnMiLCJjYW4iOiJkYi9XUklURSJ9XSwicHJmIjpbXX0.i2W3uTaS8QYREnqjRT9AEPEEniz0n9scYMPK4PvUyX_IN30TG6ig35b6-iAJOyQQ_-txsNHFVzMhZR03iH6LCQ"
+        ]
+      }
+    }
+  },
+  {
+    "comment": "UCAN attenuation has valid syntax",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJ3bmZzOi8vdGFtZWR1bi5maXNzaW9uLmFwcC9wdWJsaWMvcGhvdG9zLyIsImNhbiI6InduZnMvQVBQRU5EIn1dLCJwcmYiOltdfQ.47qMwu5lRjJV0MPMiYamJkE_0Fzou6134QeRHo75rwCDdx0e_GiqQ7aFqeMD85i3t9VG7mBcxweAlG9lDe32DA",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [
+          {
+            "with": "wnfs://tamedun.fission.app/public/photos/",
+            "can": "wnfs/APPEND"
+          }
+        ],
+        "prf": []
+      }
+    }
+  },
+  {
+    "comment": "UCAN attenuation is valid with multiple capabilities",
+    "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJpc3MiOiJkaWQ6a2V5Ono2TWtmZ3RYa0NuYjlMWG44Qm55anhSTW5LdEZnWmM3NE02ODczdjYxcUNjS0hqayIsImF1ZCI6ImRpZDprZXk6ejZNa2dYNWpqUlVidHlzZ2dFNHJhQ2FxQ1g4OEF6U3ZZcTgxV0prQm9BMW90OGFlIiwiZXhwIjo0ODA0MTQzNDEyLCJhdHQiOlt7IndpdGgiOiJkYjovL3RhbWVkdW4uZmlzc2lvbi5hcHAvdXNlcnMiLCJjYW4iOiJkYi9XUklURSJ9LHsid2l0aCI6ImRiOi8vdGFtZWR1bi5maXNzaW9uLmFwcC91c2VycyIsImNhbiI6ImRiL1JFQUQifV0sInByZiI6W119.tIvrONe1rpVOW1ttHOp-U-zG_l6ggdd-YLHfip2CzbiwT0Ri5mkZMboGmg-y2Syt_JjKQ6EA2zskOtXVCi4JCg",
+    "assertions": {
+      "header": {
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "ucv": "0.8.1"
+      },
+      "payload": {
+        "iss": "did:key:z6MkfgtXkCnb9LXn8BnyjxRMnKtFgZc74M6873v61qCcKHjk",
+        "aud": "did:key:z6MkgX5jjRUbtysggE4raCaqCX88AzSvYq81WJkBoA1ot8ae",
+        "exp": 4804143412,
+        "att": [
+          {
+            "with": "db://tamedun.fission.app/users",
+            "can": "db/WRITE"
+          },
+          {
+            "with": "db://tamedun.fission.app/users",
+            "can": "db/READ"
+          }
+        ],
+        "prf": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
Basic [UCAN](https://github.com/ucan-wg/spec) implementation taking advantage of SSI's JWT/JWS and DID tools.

- [x] UCAN payload structure
- [x] decoding from JWT form
- [x] signing using JWK and encoding to JWT form
- [x] verification based on `iss` DID and header `.jwk` field (if using `did:pkh`)
- [x] recursive decoding and verification of parent/proof UCANs
- [x] time validation
- [x] capability attenuation/amplification handling/verification
- [x] test vectors taken from spec repo

The capability handling is only [partially specced by design](https://github.com/ucan-wg/spec#4-reserved-capabilities)  but requires some behaviour injection (probably making `Capability.with` and `Capability.can` generic types and having a `where Capability<With, Can> impl` some trait)