### PR TITLE
Fix Hardcoded ssi Dirname

### DIFF
--- a/did-test/Cargo.toml
+++ b/did-test/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 
 [dependencies]
 ssi = { version = "0.4", path = "../" }
-did-method-key = { version = "0.1", path = "../../ssi/did-key", features = ["secp256k1", "secp256r1"] }
-did-tz = { version = "0.1", path = "../../ssi/did-tezos", default-features = false, features = ["secp256k1", "secp256r1"] }
-did-pkh = { version = "0.1", path = "../../ssi/did-pkh" }
-did-sol = { version = "0.0.1", path = "../../ssi/did-sol" }
-did-web = { version = "0.1", path = "../../ssi/did-web" }
-did-webkey = { version = "0.1", path = "../../ssi/did-webkey", features = ["p256"] }
-did-onion = { version = "0.1", path = "../../ssi/did-onion" }
+did-method-key = { version = "0.1", path = "../did-key", features = ["secp256k1", "secp256r1"] }
+did-tz = { version = "0.1", path = "../did-tezos", default-features = false, features = ["secp256k1", "secp256r1"] }
+did-pkh = { version = "0.1", path = "../did-pkh" }
+did-sol = { version = "0.0.1", path = "../did-sol" }
+did-web = { version = "0.1", path = "../did-web" }
+did-webkey = { version = "0.1", path = "../did-webkey", features = ["p256"] }
+did-onion = { version = "0.1", path = "../did-onion" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.12"


### PR DESCRIPTION
This is just a tiny bugfix for a problem I was having getting the tests to run on my fork. Inside `did-test`'s `Cargo.toml`, there are paths of the form `../../ssi`, which causes issues if you name the ssi directory something other than `ssi` (in my case I had named it `ssi-fork`.

To test this, change the name of your `ssi` directory to something else, then run `cargo test`. On `main` this will fail with weird, cryptic errors (especially if you have another directory named `ssi` next to this one!), on this branch it will pass!