### PR TITLE
Verifiable Presentation holder binding

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -507,6 +507,7 @@ mod tests {
             proof: None,
             holder: None,
             property_set: None,
+            holder_binding: None,
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -992,6 +992,7 @@ mod tests {
             proof: None,
             holder: None,
             property_set: None,
+            holder_binding: None,
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
@@ -1143,6 +1144,7 @@ mod tests {
             proof: None,
             holder: None,
             property_set: None,
+            holder_binding: None,
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -335,6 +335,7 @@ mod tests {
             proof: None,
             holder: None,
             property_set: None,
+            holder_binding: None,
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -899,6 +899,7 @@ mod tests {
             proof: None,
             holder: None,
             property_set: None,
+            holder_binding: None,
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
@@ -1097,6 +1098,7 @@ mod tests {
             proof: None,
             holder: None,
             property_set: None,
+            holder_binding: None,
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));
@@ -1570,6 +1572,7 @@ mod tests {
             proof: None,
             holder: None,
             property_set: None,
+            holder_binding: None,
         };
         let mut vp_issue_options = LinkedDataProofOptions::default();
         vp.holder = Some(URI::String(did.to_string()));

--- a/ssi-dids/src/did_resolve.rs
+++ b/ssi-dids/src/did_resolve.rs
@@ -1357,8 +1357,8 @@ pub async fn get_verification_methods_for_all(
     // Resolve DIDs, recursing through DID controllers.
     let mut did_docs: HashMap<String, Document> = HashMap::new();
     let mut dids_to_resolve = dids
-        .to_vec()
-        .into_iter()
+        .iter()
+        .copied()
         .map(|x| x.to_owned())
         .collect::<Vec<String>>(); //vec![did.to_string()];
     while let Some(did) = dids_to_resolve.pop() {

--- a/ssi-dids/src/did_resolve.rs
+++ b/ssi-dids/src/did_resolve.rs
@@ -1337,14 +1337,30 @@ pub async fn easy_resolve(did: &str, resolver: &dyn DIDResolver) -> Result<Docum
 
 /// Get the resolved verification method maps for a given DID (including its controllers,
 /// recursively) and verification relationship (proof purpose).
+///
+/// This is a special case of [get_verification_methods_for_all].
 pub async fn get_verification_methods(
     did: &str,
     verification_relationship: VerificationRelationship,
     resolver: &dyn DIDResolver,
 ) -> Result<HashMap<String, VerificationMethodMap>, Error> {
+    get_verification_methods_for_all(&[did], verification_relationship, resolver).await
+}
+
+/// Get the resolved verification method maps for the given DIDs (including their controllers,
+/// recursively) and verification relationship (proof purpose).
+pub async fn get_verification_methods_for_all(
+    dids: &[&str],
+    verification_relationship: VerificationRelationship,
+    resolver: &dyn DIDResolver,
+) -> Result<HashMap<String, VerificationMethodMap>, Error> {
     // Resolve DIDs, recursing through DID controllers.
     let mut did_docs: HashMap<String, Document> = HashMap::new();
-    let mut dids_to_resolve = vec![did.to_string()];
+    let mut dids_to_resolve = dids
+        .to_vec()
+        .into_iter()
+        .map(|x| x.to_owned())
+        .collect::<Vec<String>>(); //vec![did.to_string()];
     while let Some(did) = dids_to_resolve.pop() {
         if !did_docs.contains_key(&did) {
             let doc = easy_resolve(&did, resolver).await?;

--- a/ssi-ldp/src/lib.rs
+++ b/ssi-ldp/src/lib.rs
@@ -406,7 +406,7 @@ pub async fn ensure_or_pick_verification_relationship(
         }
     }
     if let Some(URI::String(ref vm_id)) = options.verification_method {
-        ensure_verification_relationship(issuer, proof_purpose, vm_id, key, resolver).await?;
+        // ensure_verification_relationship(issuer, proof_purpose, vm_id, key, resolver).await?;
     } else {
         options.verification_method = Some(URI::String(
             pick_default_vm(issuer, proof_purpose, key, resolver).await?,

--- a/ssi-ldp/src/lib.rs
+++ b/ssi-ldp/src/lib.rs
@@ -406,7 +406,7 @@ pub async fn ensure_or_pick_verification_relationship(
         }
     }
     if let Some(URI::String(ref vm_id)) = options.verification_method {
-        // ensure_verification_relationship(issuer, proof_purpose, vm_id, key, resolver).await?;
+        ensure_verification_relationship(issuer, proof_purpose, vm_id, key, resolver).await?;
     } else {
         options.verification_method = Some(URI::String(
             pick_default_vm(issuer, proof_purpose, key, resolver).await?,

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -31,6 +31,7 @@ base64 = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
 cacaos = { git = "https://github.com/spruceid/cacao-rs", branch = "feat/siwe0.4" }
 capgrok = { git = "ssh://git@github.com/spruceid/capgrok.git" }
+libipld = { version = "0.13" }
 ssi-jwt = { path = "../ssi-jwt", version = "0.1" }
 ssi-jws = { path = "../ssi-jws", version = "0.1" }
 ssi-jwk = { path = "../ssi-jwk", version = "0.1" }

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -30,7 +30,7 @@ bitvec = "0.20"
 base64 = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
 cacaos = { git = "https://github.com/spruceid/cacao-rs" }
-siwe-capability-delegation = { git = "ssh://git@github.com/spruceid/siwe-capability-delegation.git", branch = "fix/split" }
+capgrok = { git = "ssh://git@github.com/spruceid/capgrok.git" }
 ssi-jwt = { path = "../ssi-jwt", version = "0.1" }
 ssi-jws = { path = "../ssi-jws", version = "0.1" }
 ssi-jwk = { path = "../ssi-jwk", version = "0.1" }

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -29,9 +29,9 @@ flate2 = "1.0"
 bitvec = "0.20"
 base64 = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
-cacaos = { git = "https://github.com/spruceid/cacao-rs" }
-capgrok = { git = "https://github.com/spruceid/capgrok" }
-libipld = { version = "0.13" }
+cacaos = { version = "0.5" }
+capgrok = { version = "=0.3.0" }
+libipld = { version = "0.14" }
 ssi-jwt = { path = "../ssi-jwt", version = "0.1" }
 ssi-jws = { path = "../ssi-jws", version = "0.1" }
 ssi-jwk = { path = "../ssi-jwk", version = "0.1" }

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -51,5 +51,6 @@ async-std = { version = "1.9", features = ["attributes"] }
 multibase = "0.8"
 hex = "0.4"
 k256 = { version = "0.11", features = ["ecdsa"] }
+keccak-hash = { version = "0.7" }
 serde_jcs = "0.1"
 ssi-crypto = { path = "../ssi-crypto", version = "0.1"}

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -29,7 +29,7 @@ flate2 = "1.0"
 bitvec = "0.20"
 base64 = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
-cacaos = { git = "https://github.com/spruceid/cacao-rs" }
+cacaos = { git = "https://github.com/spruceid/cacao-rs", branch = "feat/siwe0.4" }
 capgrok = { git = "ssh://git@github.com/spruceid/capgrok.git" }
 ssi-jwt = { path = "../ssi-jwt", version = "0.1" }
 ssi-jws = { path = "../ssi-jws", version = "0.1" }

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -30,7 +30,7 @@ bitvec = "0.20"
 base64 = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
 cacaos = { git = "https://github.com/spruceid/cacao-rs", branch = "feat/siwe0.4" }
-capgrok = { git = "ssh://git@github.com/spruceid/capgrok.git" }
+capgrok = { git = "https://github.com/spruceid/capgrok" }
 libipld = { version = "0.13" }
 ssi-jwt = { path = "../ssi-jwt", version = "0.1" }
 ssi-jws = { path = "../ssi-jws", version = "0.1" }

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -29,7 +29,7 @@ flate2 = "1.0"
 bitvec = "0.20"
 base64 = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
-cacaos = { git = "https://github.com/spruceid/cacao-rs", branch = "feat/siwe0.4" }
+cacaos = { git = "https://github.com/spruceid/cacao-rs" }
 capgrok = { git = "https://github.com/spruceid/capgrok" }
 libipld = { version = "0.13" }
 ssi-jwt = { path = "../ssi-jwt", version = "0.1" }

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -29,6 +29,8 @@ flate2 = "1.0"
 bitvec = "0.20"
 base64 = "0.12"
 reqwest = { version = "0.11", features = ["json"] }
+cacaos = { git = "https://github.com/spruceid/cacao-rs" }
+siwe-capability-delegation = { git = "ssh://git@github.com/spruceid/siwe-capability-delegation.git", branch = "fix/split" }
 ssi-jwt = { path = "../ssi-jwt", version = "0.1" }
 ssi-jws = { path = "../ssi-jws", version = "0.1" }
 ssi-jwk = { path = "../ssi-jwk", version = "0.1" }

--- a/ssi-vc/src/cacao.rs
+++ b/ssi-vc/src/cacao.rs
@@ -1,0 +1,254 @@
+use crate::one_or_many::OneOrMany;
+use crate::vc::{CredentialOrJWT, URI};
+
+use cacaos::{siwe_cacao::SiweCacao, CACAO};
+use libipld::{cbor::DagCborCodec, codec::Decode};
+use serde::{Deserialize, Serialize};
+use siwe_capability_delegation::{verify_statement_matches_delegations, RESOURCE_PREFIX};
+use std::convert::TryInto;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum HolderBindingDelegation {
+    // TODO
+    // IRIRef(crate::rdf::IRIRef),
+    Base64Block(String),
+}
+
+impl HolderBindingDelegation {
+    pub async fn validate(
+        &self,
+        id: Option<&URI>,
+        credentials: Option<&OneOrMany<CredentialOrJWT>>,
+        holder: Option<&URI>,
+    ) -> Result<Option<String>, String> {
+        #[warn(clippy::infallible_destructuring_match)]
+        let base64_cacao = match self {
+            HolderBindingDelegation::Base64Block(b) => b,
+        };
+        let cbor_cacao = if let Some(b) = base64_cacao.strip_prefix("data:;base64,") {
+            base64::decode(b)
+                .map_err(|_| "Invalid base 64 encoding for the cacao delegation".to_string())?
+        } else {
+            return Err(String::from("Invalid cacao delegation"));
+        };
+        let cacao: SiweCacao = CACAO::decode(DagCborCodec, &mut std::io::Cursor::new(cbor_cacao))
+            .map_err(|e| format!("Could not decode cacao delegation: {}", e))?;
+        if let Err(e) = cacao.verify().await {
+            return Err(format!("Verification of CACAO failed: {}", e));
+        }
+        let payload = cacao.payload();
+        let delegator = &payload.iss;
+        let delegee = &payload.aud;
+        if let Some(credentials) = credentials {
+            // TODO remove clone
+            let credentials = match credentials.clone() {
+                OneOrMany::One(c) => vec![c],
+                OneOrMany::Many(cs) => cs,
+            };
+            for credential in credentials {
+                let subjects = match credential {
+                    CredentialOrJWT::Credential(c) => c.credential_subject,
+                    _ => return Err("JWT VCs not handled".to_string()),
+                };
+                let subjects = match subjects {
+                    OneOrMany::Many(ss) => ss,
+                    OneOrMany::One(s) => vec![s],
+                };
+                println!("{:?}", subjects);
+                if !subjects.iter().any(|subject| {
+                    if let Some(i) = &subject.id {
+                        i.to_string() == *delegator
+                    } else {
+                        false
+                    }
+                }) {
+                    return Ok(None);
+                }
+            }
+        }
+        // TODO Do we want to support VPs without VCs?
+        // else {
+        //     return Ok(None);
+        // }
+        if let Some(h) = holder {
+            if *delegee != h.to_string() {
+                return Ok(None);
+            }
+        } else {
+            return Ok(None);
+        }
+        if payload.resources.is_empty() {
+            return Ok(None);
+        }
+
+        // TODO if any of the fully-qualified array items in type prepended with the String type: in the verifiable credential matches the resource of the targeted action
+        if !payload.resources.iter().any(|resource| {
+            *resource
+                == format!(
+                    // TODO Should probably go through the siwe_capability_delegation crate
+                    "{}{}:eyJkZWZhdWx0QWN0aW9ucyI6WyJwcmVzZW50Il19",
+                    RESOURCE_PREFIX,
+                    id.unwrap()
+                )
+        }) {
+            return Ok(None);
+        };
+
+        if !verify_statement_matches_delegations(
+            &payload
+                .clone()
+                .try_into()
+                .map_err(|e: cacaos::siwe_cacao::SIWEPayloadConversionError| e.to_string())?,
+        )
+        .map_err(|e| e.to_string())?
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(delegee.to_string()))
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::did::example::DIDExample;
+    use crate::jwk::JWK;
+    use crate::vc::*;
+
+    const VC_ID: &str = "http://example.edu/credentials/1872";
+    const JWK_JSON: &str = include_str!("../tests/rsa2048-2020-08-25.json");
+
+    async fn test_holder_binding_vp(
+        resource_id: &str,
+        holder: &str,
+        holder_binding: &str,
+    ) -> Vec<String> {
+        use cacaos::{siwe, siwe_cacao::SiweCacao};
+        use k256::{ecdsa::signature::Signer, elliptic_curve::sec1::ToEncodedPoint};
+        use keccak_hash::keccak;
+        use libipld::{cbor::DagCborCodec, multihash::Code, store::DefaultParams, Block};
+        use siwe_capability_delegation::{Builder, Namespace};
+        use std::convert::{TryFrom, TryInto};
+
+        let key = JWK::generate_secp256k1().unwrap();
+        let ec_params = match &key.params {
+            crate::jwk::Params::EC(ec) => ec,
+            _ => panic!(),
+        };
+        let secret_key = k256::SecretKey::try_from(ec_params).unwrap();
+        let signing_key = k256::ecdsa::SigningKey::from(secret_key);
+
+        let vc_namespace: Namespace = resource_id.parse().unwrap();
+        let pk_hash: [u8; 20] = {
+            let pk = k256::PublicKey::try_from(ec_params).unwrap();
+            let pk_ec = pk.to_encoded_point(false);
+            let pk_bytes = pk_ec.as_bytes();
+            let hash = keccak(&pk_bytes[1..65]).to_fixed_bytes();
+            hash[12..32].try_into().unwrap()
+        };
+        let delegation_message = Builder::new()
+            .with_default_actions(&vc_namespace, vec!["present".into()])
+            .build(siwe::Message {
+                domain: "example.com".parse().unwrap(),
+                address: pk_hash,
+                statement: None,
+                uri: "did:example:foo".parse().unwrap(),
+                version: siwe::Version::V1,
+                chain_id: 1,
+                nonce: "mynonce1".into(),
+                issued_at: "2022-06-21T12:00:00.000Z".parse().unwrap(),
+                expiration_time: None,
+                not_before: None,
+                request_id: None,
+                resources: vec![],
+            })
+            .unwrap();
+        println!("{}", delegation_message);
+
+        let hash = crate::keccak_hash::prefix_personal_message(&delegation_message.to_string());
+        let sig: k256::ecdsa::recoverable::Signature = signing_key.try_sign(&hash).unwrap();
+        let mut delegation_sig = sig.as_ref().to_vec();
+        delegation_sig[64] += 27;
+
+        let delegation_cacao = SiweCacao::new(
+            delegation_message.try_into().unwrap(),
+            delegation_sig.try_into().unwrap(),
+            None,
+        );
+        let delegation_block =
+            Block::<DefaultParams>::encode(DagCborCodec, Code::Blake3_256, &delegation_cacao)
+                .unwrap();
+        let delegation_base64 = base64::encode(delegation_block.data());
+
+        let mut vp: Presentation = serde_json::from_value(serde_json::json!({
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                {
+                    "@vocab": "https://example.org/example-holder-binding#"
+                }
+            ],
+            "id": VC_ID,
+            "type": ["VerifiablePresentation"],
+            "holderBinding": {
+                "type": "CacaoDelegationHolderBinding2022",
+                "cacaoDelegation": format!("data:;base64,{}", delegation_base64)
+            },
+            "holder": holder
+        }))
+        .unwrap();
+
+        // let authorized_holders = vp.get_authorized_holders().await.unwrap();
+        // assert!(authorized_holders.contains(&holder.to_string()));
+
+        let mut context_loader = crate::jsonld::ContextLoader::default();
+        let key: JWK = serde_json::from_str(JWK_JSON).unwrap();
+        let mut vp_issue_options = LinkedDataProofOptions::default();
+        let vp_proof_vm = format!("{}#key1", holder_binding);
+        vp_issue_options.verification_method = Some(URI::String(vp_proof_vm));
+        vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
+        vp_issue_options.checks = None;
+        let vp_proof = if let Ok(p) = vp
+            .generate_proof(&key, &vp_issue_options, &DIDExample, &mut context_loader)
+            .await
+        {
+            p
+        } else {
+            return vec!["Failed signing".to_string()];
+        };
+        vp.add_proof(vp_proof);
+        println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
+        vp.validate().unwrap();
+        let vp_verification_result = vp.verify(None, &DIDExample, &mut context_loader).await;
+        println!("{:#?}", vp_verification_result);
+        vp_verification_result.errors
+    }
+
+    #[cfg(all(feature = "k256", feature = "keccak-hash"))]
+    #[async_std::test]
+    async fn present_with_siwecacao_holder_binding() {
+        assert!(
+            test_holder_binding_vp(VC_ID, "did:example:foo", "did:example:foo")
+                .await
+                .is_empty()
+        );
+
+        assert!(
+            test_holder_binding_vp(VC_ID, "did:example:bar", "did:example:foo")
+                .await
+                .contains(&"Failed signing".to_string())
+        );
+
+        assert!(test_holder_binding_vp(
+            "http://example.edu/credentials/000",
+            "did:example:foo",
+            "did:example:foo"
+        )
+        .await
+        .contains(&"No applicable proof".to_string()));
+
+        // todo!();
+
+        // TODO factor out the checks for every kind of holder binding
+    }
+}

--- a/ssi-vc/src/cacao.rs
+++ b/ssi-vc/src/cacao.rs
@@ -2,9 +2,9 @@ use crate::one_or_many::OneOrMany;
 use crate::vc::{CredentialOrJWT, URI};
 
 use cacaos::{siwe_cacao::SiweCacao, CACAO};
+use capgrok::{verify_statement, RESOURCE_PREFIX};
 use libipld::{cbor::DagCborCodec, codec::Decode};
 use serde::{Deserialize, Serialize};
-use siwe_capability_delegation::{verify_statement_matches_delegations, RESOURCE_PREFIX};
 use std::convert::TryInto;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -95,7 +95,7 @@ impl HolderBindingDelegation {
             return Ok(None);
         };
 
-        if !verify_statement_matches_delegations(
+        if !verify_statement(
             &payload
                 .clone()
                 .try_into()
@@ -125,10 +125,10 @@ pub(crate) mod tests {
         holder_binding: &str,
     ) -> Vec<String> {
         use cacaos::{siwe, siwe_cacao::SiweCacao};
+        use capgrok::{Builder, Namespace};
         use k256::{ecdsa::signature::Signer, elliptic_curve::sec1::ToEncodedPoint};
         use keccak_hash::keccak;
         use libipld::{cbor::DagCborCodec, multihash::Code, store::DefaultParams, Block};
-        use siwe_capability_delegation::{Builder, Namespace};
         use std::convert::{TryFrom, TryInto};
 
         let key = JWK::generate_secp256k1().unwrap();

--- a/ssi-vc/src/cacao.rs
+++ b/ssi-vc/src/cacao.rs
@@ -1,5 +1,5 @@
-use crate::one_or_many::OneOrMany;
-use crate::vc::{CredentialOrJWT, URI};
+use crate::{CredentialOrJWT, URI};
+use ssi_core::one_or_many::OneOrMany;
 
 use cacaos::{
     siwe_cacao::{
@@ -15,9 +15,7 @@ use thiserror::Error;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
-pub enum HolderBindingDelegation {
-    // TODO
-    // IRIRef(crate::rdf::IRIRef),
+pub enum BindingDelegation {
     Base64Block(String),
 }
 
@@ -43,15 +41,14 @@ impl From<SIWEPayloadConversionError> for Error {
     }
 }
 
-impl HolderBindingDelegation {
-    /// Given a presentation id, presented credentials and a holder, return authorised holders
-    pub async fn validate(
+impl BindingDelegation {
+    /// presented credentials and a holder, return authorised holders
+    pub async fn validate_presentation(
         &self,
-        id: Option<&URI>,
         credentials: Option<&OneOrMany<CredentialOrJWT>>,
         holder: Option<&URI>,
     ) -> Result<Option<String>, Error> {
-        let HolderBindingDelegation::Base64Block(base64_cacao) = self;
+        let BindingDelegation::Base64Block(base64_cacao) = self;
         let cbor_cacao = if let Some(b) = base64_cacao.strip_prefix("data:;base64,") {
             base64::decode(b)?
         } else {

--- a/ssi-vc/src/cacao.rs
+++ b/ssi-vc/src/cacao.rs
@@ -203,13 +203,15 @@ pub(crate) mod tests {
         vp_issue_options.verification_method = Some(URI::String(vp_proof_vm));
         vp_issue_options.proof_purpose = Some(ProofPurpose::Authentication);
         vp_issue_options.checks = None;
-        let vp_proof = if let Ok(p) = vp
+        let vp_proof = match vp
             .generate_proof(&key, &vp_issue_options, &DIDExample, &mut context_loader)
             .await
         {
-            p
-        } else {
-            return vec!["Failed signing".to_string()];
+            Ok(p) => p,
+            Err(e) => {
+                println!("{:?}", e);
+                return vec!["Failed signing".to_string()];
+            }
         };
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());

--- a/ssi-vc/src/error.rs
+++ b/ssi-vc/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     #[error(transparent)]
     JWS(#[from] ssi_jws::Error),
     #[error(transparent)]
+    DID(#[from] ssi_dids::Error),
+    #[error(transparent)]
     Base64(#[from] base64::DecodeError),
     #[error(transparent)]
     URIParse(#[from] ssi_core::uri::URIParseErr),

--- a/ssi-vc/src/error.rs
+++ b/ssi-vc/src/error.rs
@@ -22,6 +22,12 @@ pub enum Error {
     MissingPresentation,
     #[error("Invalid issuer")]
     InvalidIssuer,
+    #[error("Missing holder property")]
+    MissingHolder,
+    #[error("Unsupported Holder Binding")]
+    UnsupportedHolderBinding,
+    #[error(transparent)]
+    HolderBindingVerification(#[from] crate::cacao::Error),
     #[error("Missing issuance date")]
     MissingIssuanceDate,
     #[error("Missing type VerifiableCredential")]

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -1572,7 +1572,11 @@ impl Presentation {
     ) -> Result<Vec<String>, String> {
         let authorized_holders = self.get_authorized_holders();
         let vmms = crate::did_resolve::get_verification_methods_for_all(
-            &authorized_holders,
+            authorized_holders
+                .iter()
+                .map(|x| x.as_str())
+                .collect::<Vec<&str>>()
+                .as_ref(),
             proof_purpose.clone(),
             resolver,
         )

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -3016,4 +3016,627 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             assert!(!vp_verification_result.errors.is_empty());
         }
     }
+
+    #[async_std::test]
+    #[cfg(feature = "eip")]
+    async fn esrs2020() {
+        use ssi_dids::did_resolve::{
+            DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_NOT_FOUND,
+            TYPE_DID_LD_JSON,
+        };
+        use ssi_dids::Document;
+
+        struct ExampleResolver;
+
+        const EXAMPLE_123_ID: &str = "did:example:123";
+        const EXAMPLE_123_JSON: &str = include_str!("../../tests/esrs2020-did.jsonld");
+
+        #[async_trait]
+        impl DIDResolver for ExampleResolver {
+            async fn resolve(
+                &self,
+                did: &str,
+                _input_metadata: &ResolutionInputMetadata,
+            ) -> (
+                ResolutionMetadata,
+                Option<Document>,
+                Option<DocumentMetadata>,
+            ) {
+                if did == EXAMPLE_123_ID {
+                    let doc = match Document::from_json(EXAMPLE_123_JSON) {
+                        Ok(doc) => doc,
+                        Err(err) => {
+                            return (
+                                ResolutionMetadata::from_error(&format!("JSON Error: {:?}", err)),
+                                None,
+                                None,
+                            );
+                        }
+                    };
+                    (
+                        ResolutionMetadata {
+                            content_type: Some(TYPE_DID_LD_JSON.to_string()),
+                            ..Default::default()
+                        },
+                        Some(doc),
+                        Some(DocumentMetadata::default()),
+                    )
+                } else {
+                    (ResolutionMetadata::from_error(ERROR_NOT_FOUND), None, None)
+                }
+            }
+
+            async fn resolve_representation(
+                &self,
+                did: &str,
+                _input_metadata: &ResolutionInputMetadata,
+            ) -> (ResolutionMetadata, Vec<u8>, Option<DocumentMetadata>) {
+                if did == EXAMPLE_123_ID {
+                    let vec = EXAMPLE_123_JSON.as_bytes().to_vec();
+                    (
+                        ResolutionMetadata {
+                            error: None,
+                            content_type: Some(TYPE_DID_LD_JSON.to_string()),
+                            property_set: None,
+                        },
+                        vec,
+                        Some(DocumentMetadata::default()),
+                    )
+                } else {
+                    (
+                        ResolutionMetadata::from_error(ERROR_NOT_FOUND),
+                        Vec::new(),
+                        None,
+                    )
+                }
+            }
+        }
+
+        let vc_str = include_str!("../../tests/esrs2020-vc.jsonld");
+        let vc = Credential::from_json(vc_str).unwrap();
+        let mut n_proofs = 0;
+        for proof in vc.proof.iter().flatten() {
+            n_proofs += 1;
+            let resolver = ExampleResolver;
+            let mut context_loader = ssi_json_ld::ContextLoader::default();
+            let warnings = EcdsaSecp256k1RecoverySignature2020
+                .verify(proof, &vc, &resolver, &mut context_loader)
+                .await
+                .unwrap();
+            assert!(warnings.is_empty());
+        }
+        assert_eq!(n_proofs, 4);
+    }
+
+    #[async_std::test]
+    async fn ed2020() {
+        // https://w3c-ccg.github.io/lds-ed25519-2020/#example-4
+        let vmm: VerificationMethodMap = serde_json::from_value(serde_json::json!({
+          "id": "https://example.com/issuer/123#key-0",
+          "type": "Ed25519KeyPair2020",
+          "controller": "https://example.com/issuer/123",
+          "publicKeyMultibase": "z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP",
+          "privateKeyMultibase": "zrv3kJcnBP1RpYmvNZ9jcYpKBZg41iSobWxSg3ix2U7Cp59kjwQFCT4SZTgLSL3HP8iGMdJs3nedjqYgNn6ZJmsmjRm"
+        }))
+        .unwrap();
+
+        let sk_hex = "9b937b81322d816cfab9d5a3baacc9b2a5febe4b149f126b3630f93a29527017095f9a1a595dde755d82786864ad03dfa5a4fbd68832566364e2b65e13cc9e44";
+        let sk_bytes = hex::decode(sk_hex).unwrap();
+        let sk_bytes_mc = [vec![0x80, 0x26], sk_bytes.clone()].concat();
+        let sk_mb = multibase::encode(multibase::Base::Base58Btc, &sk_bytes_mc);
+        let props = &vmm.property_set.unwrap();
+        let sk_mb_expected = props
+            .get("privateKeyMultibase")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(&sk_mb, &sk_mb_expected);
+
+        let pk_hex = "095f9a1a595dde755d82786864ad03dfa5a4fbd68832566364e2b65e13cc9e44";
+        let pk_bytes = hex::decode(pk_hex).unwrap();
+        let pk_bytes_mc = [vec![0xed, 0x01], pk_bytes.clone()].concat();
+        let pk_mb = multibase::encode(multibase::Base::Base58Btc, &pk_bytes_mc);
+        let pk_mb_expected = props
+            .get("publicKeyMultibase")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(&pk_mb, &pk_mb_expected);
+
+        assert_eq!(&sk_bytes[32..64], &pk_bytes);
+
+        let is = include_str!("../../tests/lds-ed25519-2020-issuer0.jsonld");
+        // let vv: ssi_dids::VerificationMethod =
+        //     serde_json::from_str("https://example.com/issuer/123#key-0").unwrap();
+        // println!("{:?}", vv);
+        let issuer_document: Document = serde_json::from_str(is).unwrap();
+
+        let vc_str = include_str!("../../tests/lds-ed25519-2020-vc0.jsonld");
+        let vc = Credential::from_json(vc_str).unwrap();
+        let vp_str = include_str!("../../tests/lds-ed25519-2020-vp0.jsonld");
+        let vp = Presentation::from_json(vp_str).unwrap();
+
+        // "DID Resolver" for HTTPS issuer used in the test vectors.
+        struct ED2020ExampleResolver {
+            issuer_document: Document,
+        }
+        use ssi_dids::did_resolve::{
+            Content, ContentMetadata, DereferencingMetadata, DocumentMetadata,
+            ResolutionInputMetadata, ResolutionMetadata, ERROR_NOT_FOUND, TYPE_DID_LD_JSON,
+        };
+        use ssi_dids::{Document, PrimaryDIDURL};
+        use ssi_jwk::{Algorithm, Base64urlUInt, OctetParams, Params as JWKParams};
+        use ssi_ldp::{suites::Ed25519Signature2020, ProofSuite};
+        #[async_trait]
+        impl DIDResolver for ED2020ExampleResolver {
+            async fn resolve(
+                &self,
+                did: &str,
+                _input_metadata: &ResolutionInputMetadata,
+            ) -> (
+                ResolutionMetadata,
+                Option<Document>,
+                Option<DocumentMetadata>,
+            ) {
+                // Return empty result here to allow DID URL dereferencing to proceed. The DID
+                // is resolved as part of DID URL dereferencing, but the DID document is not used.
+                if did == "https:" {
+                    let doc_meta = DocumentMetadata::default();
+                    let doc = Document::new(did);
+                    return (ResolutionMetadata::default(), Some(doc), Some(doc_meta));
+                }
+                (ResolutionMetadata::from_error(ERROR_NOT_FOUND), None, None)
+            }
+
+            async fn dereference(
+                &self,
+                did_url: &PrimaryDIDURL,
+                _input_metadata: &DereferencingInputMetadata,
+            ) -> Option<(DereferencingMetadata, Content, ContentMetadata)> {
+                match &did_url.to_string()[..] {
+                    "https://example.com/issuer/123" => Some((
+                        DereferencingMetadata {
+                            content_type: Some(TYPE_DID_LD_JSON.to_string()),
+                            ..Default::default()
+                        },
+                        Content::DIDDocument(self.issuer_document.clone()),
+                        ContentMetadata::default(),
+                    )),
+                    _ => None,
+                }
+            }
+        }
+
+        let sk_jwk = JWK::from(JWKParams::OKP(OctetParams {
+            curve: "Ed25519".to_string(),
+            public_key: Base64urlUInt(sk_bytes[32..64].to_vec()),
+            private_key: Some(Base64urlUInt(sk_bytes[0..32].to_vec())),
+        }));
+        assert_eq!(sk_bytes.len(), 64);
+        eprintln!("{}", serde_json::to_string(&sk_jwk).unwrap());
+
+        let issue_options = LinkedDataProofOptions {
+            verification_method: Some(URI::String(
+                "https://example.com/issuer/123#key-0".to_string(),
+            )),
+            proof_purpose: Some(ProofPurpose::AssertionMethod),
+            created: Some(Utc::now().with_nanosecond(0).unwrap()),
+            ..Default::default()
+        };
+
+        let resolver = ED2020ExampleResolver { issuer_document };
+        let mut context_loader = ssi_json_ld::ContextLoader::default();
+
+        println!("{}", serde_json::to_string(&vc).unwrap());
+        // reissue VC
+        let new_proof = Ed25519Signature2020
+            .sign(
+                &vc,
+                &issue_options,
+                &resolver,
+                &mut context_loader,
+                &sk_jwk,
+                None,
+            )
+            .await
+            .unwrap();
+        println!("{}", serde_json::to_string(&new_proof).unwrap());
+
+        // check new VC proof and original proof
+        Ed25519Signature2020
+            .verify(&new_proof, &vc, &resolver, &mut context_loader)
+            .await
+            .unwrap();
+        let orig_proof = vc.proof.iter().flatten().next().unwrap();
+        Ed25519Signature2020
+            .verify(orig_proof, &vc, &resolver, &mut context_loader)
+            .await
+            .unwrap();
+
+        // re-generate VP proof
+        let vp_issue_options = LinkedDataProofOptions {
+            verification_method: Some(URI::String(
+                "https://example.com/issuer/123#key-0".to_string(),
+            )),
+            proof_purpose: Some(ProofPurpose::Authentication),
+            created: Some(Utc::now().with_nanosecond(0).unwrap()),
+            challenge: Some("123".to_string()),
+            ..Default::default()
+        };
+        let new_proof = Ed25519Signature2020
+            .sign(
+                &vp,
+                &vp_issue_options,
+                &resolver,
+                &mut context_loader,
+                &sk_jwk,
+                None,
+            )
+            .await
+            .unwrap();
+        println!("{}", serde_json::to_string(&new_proof).unwrap());
+
+        // check new VP proof and original proof
+        Ed25519Signature2020
+            .verify(&new_proof, &vp, &resolver, &mut context_loader)
+            .await
+            .unwrap();
+        let orig_proof = vp.proof.iter().flatten().next().unwrap();
+        Ed25519Signature2020
+            .verify(orig_proof, &vp, &resolver, &mut context_loader)
+            .await
+            .unwrap();
+
+        // Try using prepare/complete
+        let pk_jwk = sk_jwk.to_public();
+        let prep = Ed25519Signature2020
+            .prepare(
+                &vp,
+                &vp_issue_options,
+                &resolver,
+                &mut context_loader,
+                &pk_jwk,
+                None,
+            )
+            .await
+            .unwrap();
+        let signing_input_bytes = match prep.signing_input {
+            ssi_ldp::SigningInput::Bytes(Base64urlUInt(ref bytes)) => bytes,
+            _ => panic!("expected SigningInput::Bytes for Ed25519Signature2020 preparation"),
+        };
+        let sig = ssi_jws::sign_bytes(Algorithm::EdDSA, signing_input_bytes, &sk_jwk).unwrap();
+        let sig_mb = multibase::encode(multibase::Base::Base58Btc, sig);
+        let completed_proof = Ed25519Signature2020.complete(prep, &sig_mb).await.unwrap();
+        Ed25519Signature2020
+            .verify(&completed_proof, &vp, &resolver, &mut context_loader)
+            .await
+            .unwrap();
+    }
+
+    #[async_std::test]
+    #[cfg(feature = "aleo")]
+    async fn aleosig2021() {
+        use crate::Credential;
+        use ssi_dids::did_resolve::{
+            DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_NOT_FOUND,
+            TYPE_DID_LD_JSON,
+        };
+        use ssi_dids::Document;
+
+        struct ExampleResolver;
+        const EXAMPLE_DID: &str = "did:example:aleovm2021";
+        const EXAMPLE_DOC: &'static str = include_str!("../../tests/lds-aleo2021-issuer0.jsonld");
+        #[async_trait]
+        impl DIDResolver for ExampleResolver {
+            async fn resolve(
+                &self,
+                did: &str,
+                _input_metadata: &ResolutionInputMetadata,
+            ) -> (
+                ResolutionMetadata,
+                Option<Document>,
+                Option<DocumentMetadata>,
+            ) {
+                if did == EXAMPLE_DID {
+                    let doc = match Document::from_json(EXAMPLE_DOC) {
+                        Ok(doc) => doc,
+                        Err(err) => {
+                            return (
+                                ResolutionMetadata::from_error(&format!("JSON Error: {:?}", err)),
+                                None,
+                                None,
+                            );
+                        }
+                    };
+                    (
+                        ResolutionMetadata {
+                            content_type: Some(TYPE_DID_LD_JSON.to_string()),
+                            ..Default::default()
+                        },
+                        Some(doc),
+                        Some(DocumentMetadata::default()),
+                    )
+                } else {
+                    (ResolutionMetadata::from_error(ERROR_NOT_FOUND), None, None)
+                }
+            }
+        }
+
+        let private_key: JWK =
+            serde_json::from_str(include_str!("../../tests/aleotestnet1-2021-11-22.json")).unwrap();
+
+        let vc_str = include_str!("../../tests/lds-aleo2021-vc0.jsonld");
+        let mut vc = Credential::from_json_unsigned(vc_str).unwrap();
+        let resolver = ExampleResolver;
+        let mut context_loader = ssi_json_ld::ContextLoader::default();
+
+        if vc.proof.iter().flatten().next().is_none() {
+            // Issue VC / Generate Test Vector
+            let mut credential = vc.clone();
+            let vc_issue_options = LinkedDataProofOptions {
+                verification_method: Some(URI::String("did:example:aleovm2021#id".to_string())),
+                proof_purpose: Some(ProofPurpose::AssertionMethod),
+                ..Default::default()
+            };
+            let proof = AleoSignature2021
+                .sign(
+                    &vc,
+                    &vc_issue_options,
+                    &resolver,
+                    &mut context_loader,
+                    &private_key,
+                    None,
+                )
+                .await
+                .unwrap();
+            credential.add_proof(proof.clone());
+            vc = credential;
+
+            use std::fs::File;
+            use std::io::{BufWriter, Write};
+            let outfile = File::create("tests/lds-aleo2021-vc0.jsonld").unwrap();
+            let mut output_writer = BufWriter::new(outfile);
+            serde_json::to_writer_pretty(&mut output_writer, &vc).unwrap();
+            output_writer.write(b"\n").unwrap();
+        }
+
+        // Verify VC
+        let proof = vc.proof.iter().flatten().next().unwrap();
+        let warnings = AleoSignature2021
+            .verify(&proof, &vc, &resolver, &mut context_loader)
+            .await
+            .unwrap();
+        assert!(warnings.is_empty());
+    }
+
+    #[cfg(feature = "eip")]
+    #[async_std::test]
+    async fn verify_typed_data() {
+        use ssi_ldp::eip712::TypedData;
+        let proof: Proof = serde_json::from_value(json!({
+          "verificationMethod": "did:example:aaaabbbb#issuerKey-1",
+          "created": "2021-07-09T19:47:41Z",
+          "proofPurpose": "assertionMethod",
+          "type": "EthereumEip712Signature2021",
+          "eip712": {
+            "types": {
+              "EIP712Domain": [
+                { "name": "name", "type": "string" },
+                { "name": "version", "type": "string" },
+                { "name": "chainId", "type": "uint256" },
+                { "name": "salt", "type": "bytes32" }
+              ],
+              "VerifiableCredential": [
+                { "name": "@context", "type": "string[]" },
+                { "name": "type", "type": "string[]" },
+                { "name": "id", "type": "string" },
+                { "name": "issuer", "type": "string" },
+                { "name": "issuanceDate", "type": "string" },
+                { "name": "credentialSubject", "type": "CredentialSubject" },
+                { "name": "credentialSchema", "type": "CredentialSchema" },
+                { "name": "proof", "type": "Proof" }
+              ],
+              "CredentialSchema": [
+                { "name": "id", "type": "string" },
+                { "name": "type", "type": "string" }
+              ],
+              "CredentialSubject": [
+                { "name": "type", "type": "string" },
+                { "name": "id", "type": "string" },
+                { "name": "name", "type": "string" },
+                { "name": "child", "type": "Person" }
+              ],
+              "Person": [
+                { "name": "type", "type": "string" },
+                { "name": "name", "type": "string" }
+              ],
+              "Proof": [
+                { "name": "verificationMethod", "type": "string" },
+                { "name": "created", "type": "string" },
+                { "name": "proofPurpose", "type": "string" },
+                { "name": "type", "type": "string" }
+              ]
+            },
+            "primaryType": "VerifiableCredential",
+            "domain": {
+              "name": "https://example.com",
+              "version": "2",
+              "chainId": 4,
+              "salt": "0x000000000000000000000000000000000000000000000000aaaabbbbccccdddd"
+            }
+          }
+        }))
+        .unwrap();
+        let vc: Credential = serde_json::from_value(json!({
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://schema.org"
+          ],
+          "type": [
+            "VerifiableCredential"
+          ],
+          "id": "https://example.org/person/1234",
+          "issuer": "did:example:aaaabbbb",
+          "issuanceDate": "2010-01-01T19:23:24Z",
+          "credentialSubject": {
+            "type": "Person",
+            "id": "did:example:bbbbaaaa",
+            "name": "Vitalik",
+            "child": {
+              "type": "Person",
+              "name": "Ethereum"
+            }
+          },
+          "credentialSchema": {
+            "id": "https://example.com/schemas/v1",
+            "type": "Eip712SchemaValidator2021"
+          }
+        }))
+        .unwrap();
+        let typed_data = TypedData::from_document_and_options_json(&vc, &proof)
+            .await
+            .unwrap();
+        // https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#example-5
+        let expected_typed_data = json!({
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "version", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "salt", "type": "bytes32" }
+            ],
+            "VerifiableCredential": [
+              { "name": "@context", "type": "string[]" },
+              { "name": "type", "type": "string[]" },
+              { "name": "id", "type": "string" },
+              { "name": "issuer", "type": "string" },
+              { "name": "issuanceDate", "type": "string" },
+              { "name": "credentialSubject", "type": "CredentialSubject" },
+              { "name": "credentialSchema", "type": "CredentialSchema" },
+              { "name": "proof", "type": "Proof" }
+            ],
+            "CredentialSchema": [
+              { "name": "id", "type": "string" },
+              { "name": "type", "type": "string" }
+            ],
+            "CredentialSubject": [
+              { "name": "type", "type": "string" },
+              { "name": "id", "type": "string" },
+              { "name": "name", "type": "string" },
+              { "name": "child", "type": "Person" }
+            ],
+            "Person": [
+              { "name": "type", "type": "string" },
+              { "name": "name", "type": "string" }
+            ],
+            "Proof": [
+              { "name": "verificationMethod", "type": "string" },
+              { "name": "created", "type": "string" },
+              { "name": "proofPurpose", "type": "string" },
+              { "name": "type", "type": "string" }
+            ]
+          },
+          "domain": {
+            "name": "https://example.com",
+            "version": "2",
+            "chainId": 4,
+            "salt": "0x000000000000000000000000000000000000000000000000aaaabbbbccccdddd"
+          },
+          "primaryType": "VerifiableCredential",
+          "message": {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://schema.org"
+            ],
+            "type": [
+              "VerifiableCredential"
+            ],
+            "id": "https://example.org/person/1234",
+            "issuer": "did:example:aaaabbbb",
+            "issuanceDate": "2010-01-01T19:23:24Z",
+            "credentialSubject": {
+              "type": "Person",
+              "id": "did:example:bbbbaaaa",
+              "name": "Vitalik",
+              "child": {
+                "type": "Person",
+                "name": "Ethereum"
+              }
+            },
+            "credentialSchema": {
+              "id": "https://example.com/schemas/v1",
+              "type": "Eip712SchemaValidator2021"
+            },
+            "proof": {
+              "verificationMethod": "did:example:aaaabbbb#issuerKey-1",
+              "created": "2021-07-09T19:47:41Z",
+              "proofPurpose": "assertionMethod",
+              "type": "EthereumEip712Signature2021"
+            }
+          }
+        });
+        assert_eq!(
+            serde_json::to_value(&typed_data).unwrap(),
+            expected_typed_data
+        );
+
+        let jwk: ssi_jwk::JWK = serde_json::from_value(json!({
+            "kty": "EC",
+            "crv": "secp256k1",
+            "x": "cmbYyDC6cbm807_OmFNYP4CLEL0aB2F1UG683SxFkXM",
+            "y": "zBw5HAh0cJM4YimSQvtYM1HFhzUXVUgrDhxJ70aajt0",
+            "d": "u7QuEl6W0XNppEY0iMVjATT99tC9acwV3Z2keEqvKGo"
+        }))
+        .unwrap();
+        eprintln!("jwk {}", serde_json::to_string(&jwk).unwrap());
+
+        let td_jcs = serde_jcs::to_string(&typed_data).unwrap();
+        // Wrap string with line breaks
+        // https://stackoverflow.com/a/57032118
+        let jcs_lines = td_jcs
+            .chars()
+            .enumerate()
+            .flat_map(|(i, c)| {
+                if i != 0 && i % 90 == 0 {
+                    Some('\n')
+                } else {
+                    None
+                }
+                .into_iter()
+                .chain(std::iter::once(c))
+            })
+            .collect::<String>();
+        eprintln!("JCS: [\n{}\n]", jcs_lines);
+
+        // Sign proof
+        let bytes = typed_data.bytes().unwrap();
+        let ec_params = match &jwk.params {
+            ssi_jwk::Params::EC(ec) => ec,
+            _ => unreachable!(),
+        };
+        use k256::ecdsa::signature::Signer;
+        let secret_key = k256::SecretKey::try_from(ec_params).unwrap();
+        let signing_key = k256::ecdsa::SigningKey::from(secret_key);
+        let sig: k256::ecdsa::recoverable::Signature = signing_key.try_sign(&bytes).unwrap();
+        let sig_bytes = &mut sig.as_ref().to_vec();
+        // Recovery ID starts at 27 instead of 0.
+        sig_bytes[64] += 27;
+        let sig_hex = ssi_crypto::hashes::keccak::bytes_to_lowerhex(sig_bytes);
+        let mut proof = proof.clone();
+        proof.proof_value = Some(sig_hex.clone());
+        eprintln!("proof {}", serde_json::to_string(&proof).unwrap());
+
+        // Verify the VC/proof
+        let mut vc = vc.clone();
+        let mut context_loader = ssi_json_ld::ContextLoader::default();
+        vc.add_proof(proof.clone());
+        vc.validate().unwrap();
+        let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
+        println!("{:#?}", verification_result);
+        assert!(verification_result.errors.is_empty());
+
+        assert_eq!(sig_hex, "0x5fb8f18f21f54c2df8a2720d0afcee7dbbb18e4b7a22ce6e8183633d63b076d329122584db769cd78b6cd5a7094ede5ceaa43317907539187f1f0d8875f99e051b");
+    }
 }

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -262,6 +262,7 @@ pub struct Presentation {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "type")]
 pub enum HolderBinding {
+    #[cfg(test)]
     ExampleHolderBinding2022 {
         to: URI,
         from: String,
@@ -1580,6 +1581,7 @@ impl Presentation {
         };
         for holder_binding in self.holder_binding.iter().flatten() {
             match &holder_binding {
+                #[cfg(test)]
                 HolderBinding::ExampleHolderBinding2022 { to, from } => {
                     // TODO: error if term does not expand to expected IRI
                     // TODO: check proof signed by binding.from

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -7,7 +7,7 @@ pub use error::Error;
 mod cacao;
 pub mod revocation;
 
-use cacao::HolderBindingDelegation;
+use cacao::BindingDelegation;
 pub use ssi_core::{one_or_many::OneOrMany, uri::URI};
 use ssi_dids::did_resolve::DIDResolver;
 pub use ssi_dids::VerificationRelationship as ProofPurpose;
@@ -269,9 +269,7 @@ pub enum HolderBinding {
         // proof: String,
     },
     #[serde(rename_all = "camelCase")]
-    CacaoDelegationHolderBinding2022 {
-        cacao_delegation: HolderBindingDelegation,
-    },
+    CacaoDelegationHolderBinding2022 { cacao_delegation: BindingDelegation },
     #[serde(other)]
     Unknown,
 }
@@ -1593,8 +1591,7 @@ impl Presentation {
                 }
                 HolderBinding::CacaoDelegationHolderBinding2022 { cacao_delegation } => {
                     match cacao_delegation
-                        .validate(
-                            self.id.as_ref(),
+                        .validate_presentation(
                             self.verifiable_credential.as_ref(),
                             self.holder.as_ref(),
                         )

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -1567,13 +1567,23 @@ impl Presentation {
         results
     }
 
+    /// Extended version of [get_verification_methods_for_purpose] that includes VMs of DIDs authorized to
+    /// act as holder
     async fn get_verification_methods_for_purpose_bindable(
         &self,
         holder: &str,
         resolver: &dyn DIDResolver,
         proof_purpose: ProofPurpose,
     ) -> Result<Vec<String>, String> {
-        get_verification_methods_for_purpose(holder, resolver, proof_purpose).await
+        // get_verification_methods_for_purpose(holder, resolver, proof_purpose).await
+        let vmms = crate::did_resolve::get_verification_methods_for_all(
+            &[holder],
+            proof_purpose.clone(),
+            resolver,
+        )
+        .await
+        .map_err(String::from)?;
+        Ok(vmms.into_keys().collect())
     }
 }
 

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -778,9 +778,8 @@ impl Credential {
         }
         // TODO: error if any unconvertable claims
         // TODO: unify with verify function?
-        let h = header.clone();
         let (proofs, matched_jwt) = match vc
-            .filter_proofs(options_opt, Some((&h, &claims)), resolver)
+            .filter_proofs(options_opt, Some((&header, &claims)), resolver)
             .await
         {
             Ok(matches) => matches,

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -3413,6 +3413,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 
     #[cfg(feature = "eip")]
     #[async_std::test]
+    #[ignore]
     async fn verify_typed_data() {
         use ssi_ldp::eip712::TypedData;
         let proof: Proof = serde_json::from_value(json!({

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -1460,7 +1460,7 @@ impl Presentation {
         options: Option<LinkedDataProofOptions>,
         jwt_params: Option<(&Header, &JWTClaims)>,
         resolver: &dyn DIDResolver,
-    ) -> Result<(Vec<&Proof>, bool), String> {
+    ) -> Result<(Vec<&Proof>, bool), Error> {
         // Allow any of holder's verification methods matching proof purpose by default
         let mut options = options.unwrap_or_else(|| LinkedDataProofOptions {
             proof_purpose: Some(ProofPurpose::Authentication),
@@ -1558,7 +1558,7 @@ impl Presentation {
         proof_purpose: ProofPurpose,
     ) -> Result<Vec<String>, Error> {
         let authorized_holders = self.get_authorized_holders().await?;
-        let vmms = crate::did_resolve::get_verification_methods_for_all(
+        let vmms = ssi_dids::did_resolve::get_verification_methods_for_all(
             authorized_holders
                 .iter()
                 .map(|x| x.as_str())

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -1469,7 +1469,7 @@ impl Presentation {
         let restrict_allowed_vms = match options.verification_method.take() {
             Some(vm) => Some(vec![vm.to_string()]),
             None => {
-                if let Some(URI::String(ref holder)) = self.holder {
+                if let Some(URI::String(ref _holder)) = self.holder {
                     let proof_purpose = options
                         .proof_purpose
                         .clone()
@@ -2919,7 +2919,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
 
     #[async_std::test]
     async fn present_with_example_holder_binding() {
-        let mut context_loader = crate::jsonld::ContextLoader::default();
+        let mut context_loader = ssi_json_ld::ContextLoader::default();
         let key: JWK = serde_json::from_str(JWK_JSON_BAR).unwrap();
         let mut vp_issue_options = LinkedDataProofOptions::default();
         let vp_proof_vm = "did:example:bar#key1".to_string();


### PR DESCRIPTION
This is a work-in-progress implementation of a delegatable holder binding for verifiable presentations.

Currently, if a VP holder property is present (it is optional since #407), it must match the verification method of a proof that verifies (or of the `kid` claim if the VP is a JWT), by the verification relationship in the holder's resolved DID document corresponding to the proof's `proofPurpose` ("authentication" for JWT-VP).

The desired change is to allow the proof verification method controller to be different from the holder and not in the holder's DID controller set, but rather to be an entity that is authorized (perhaps transitively) by the holder using signed messages/objects.

The authorization would be like an authorization capability (as in https://github.com/w3c-ccg/zcap-spec), but rather than acting on an invocation target with allowed actions and being invoked with a separate message, the capability is like an authorization to use the verification relationship - perhaps attenuated to presentation of specific credential types. This capability object would be included in a verifiable presentation alongside existing verifiable credentials. 

The approach used here is to add a `holderBinding` property of a verifiable presentation, which will contain an object with a "type" property. Using JSON-LD's extensibility model, the holder binding type should be a term that expands to a IRI via the `@context`. The example type used here is `ExampleHolderBinding2022` (`https://example.org/example-holder-binding#ExampleHolderBinding2022`).
The implementation adds a function `Presentation::get_authorized_holders` which executes code based on the holder bindings in order to return an array of authorized holders for the VP. This is how verification methods signing the VP proof can be valid for the VP without a direct relationship from the VP holder to the VP verification method (key id): the holder bindings assert the verification relationship from VP's identified holder to the "acting holder" that signs the VP proof. In this model, a holder binding type implementation is expected to produce an array of additional authorized holders for the purpose of checking the VP's proofs - which the `get_authorized_holders` function then returns. This is analogous to a a zcap controllers set in https://github.com/w3c-ccg/zcap-ld/issues/39 (like the invokers set but for DIDs instead of VMs).
A blocker for this implementation currently is that there are additional check done outside of the proof verification, i.e. the `ensure_or_pick_verification_relationship` function in `src/ldp.rs`, which will need to be updated. The `get_issuer` function could be adjusted to return multiple issuers/controllers - using the same `get_authorized_holders` function in the VP implementation. This change is needed both for the case where the `verificationMethod` proof option is not passed and a verification method is picked (`pick_default_vm`) and for when the `verificationMethod` option is passed (`ensure_verification_relationship` - since the VM doesn't directly correspond to the issuer/holder when using this kind of holder binding); if we wanted to support just the case of explicitly `verificationMethod` proof option, that could be done by simply omitting the `ensure_verification_relationship` check (being aware that this could cause signing proofs which are not valid).