### PR TITLE
Fix for compile error in wasm.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ sshkeys = "0.3"
 reqwest = { version = "0.11", features = ["json"] }
 flate2 = "1.0"
 bitvec = "0.20"
-clear_on_drop = "0.2.4"
 url = { version = "2.2", features = ["serde"] }
 anyhow = "1.0"
 rand_xorshift = "0.3"
@@ -93,9 +92,11 @@ snarkvm-parameters = { version = "0.7.9", optional = true }
 serde_with = "1.14"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+clear_on_drop = "0.2.4"
 chrono = { version = "0.4", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+clear_on_drop = { version = "0.2.4", features = ["no_cc"] }
 chrono = { version = "0.4", features = ["serde", "wasmbind"] }
 # https://docs.rs/getrandom/0.2.2/getrandom/#indirect-dependencies
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
The "no_cc" feature must be enabled in clear_on_drop for wasm32 target.