### PR TITLE
Fix a compile error for certain feature combo.

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -7,20 +7,34 @@ use crate::error::Error;
 /// SHA-256 hash
 #[cfg(any(feature = "sha2", feature = "ring"))]
 pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
+    #[cfg(not(feature = "ring"))]
     #[cfg(feature = "sha2")]
     {
         use sha2::Digest;
         let mut hasher = sha2::Sha256::new();
         hasher.update(data);
         let hash = hasher.finalize().into();
-        Ok(hash)
+        return Ok(hash);
     }
     #[cfg(feature = "ring")]
+    #[cfg(not(feature = "sha2"))]
     {
         use ring::digest;
         use std::convert::TryInto;
         let hash = digest::digest(&digest::SHA256, data).as_ref().try_into()?;
-        Ok(hash)
+        return Ok(hash);
+    }
+    #[cfg(feature = "ring")]
+    #[cfg(feature = "sha2")]
+    {
+        let _ = data;
+        unimplemented!("The [`sha256`] function requires feature either `sha2` or `ring` (not both).");
+    }
+    #[cfg(not(feature = "ring"))]
+    #[cfg(not(feature = "sha2"))]
+    {
+        let _ = data;
+        unimplemented!("The [`sha256`] function requires feature either `sha2` or `ring` (not both).");
     }
 }
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -5,7 +5,6 @@
 use crate::error::Error;
 
 /// SHA-256 hash
-#[cfg(any(feature = "sha2", feature = "ring"))]
 pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
     #[cfg(not(feature = "ring"))]
     #[cfg(feature = "sha2")]
@@ -28,13 +27,13 @@ pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
     #[cfg(feature = "sha2")]
     {
         let _ = data;
-        unimplemented!("The [`sha256`] function requires feature either `sha2` or `ring` (not both).");
+        unimplemented!("The [`sha256`] function requires feature either `sha2` or `ring` but not both (and both are currently enabled).");
     }
     #[cfg(not(feature = "ring"))]
     #[cfg(not(feature = "sha2"))]
     {
         let _ = data;
-        unimplemented!("The [`sha256`] function requires feature either `sha2` or `ring` (not both).");
+        unimplemented!("The [`sha256`] function requires feature either `sha2` or `ring` but not both (and neither are currently enabled).");
     }
 }
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -27,7 +27,7 @@ pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
     {
         // If neither "ring" nor "sha2" are enabled, no sha256 impl is possible.
         let _ = data;
-        unimplemented!("The [`sha256`] function requires feature either `sha2` or `ring` but not both (and neither are currently enabled).");
+        compile_error!("The [`sha256`] function requires feature either `sha2` or `ring` but not both (and neither are currently enabled).");
     }
 }
 


### PR DESCRIPTION
`cargo build --features secp256k1,secp256r1,sha2` was failing with
a compile error in ssi::hash::sha256.  This fixes that.