### PR TITLE
Address Clippy warnings and add to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       run: cargo fmt -- --check
 
     - name: Clippy
-      run: cargo clippy
+      run: cargo clippy --workspace
 
     - name: Test
       run: cargo test --verbose --workspace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,12 @@ jobs:
     - name: Build
       run: cargo build --verbose --workspace
 
+    - name: Fmt
+      run: cargo fmt -- --check
+
+    - name: Clippy
+      run: cargo clippy
+
     - name: Test
       run: cargo test --verbose --workspace
 

--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -462,12 +462,11 @@ mod tests {
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(
-            !vc_bad_issuer
-                .verify(None, &DIDEthr, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc_bad_issuer
+            .verify(None, &DIDEthr, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
@@ -486,12 +485,11 @@ mod tests {
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
-        assert!(
-            !vc_wrong_key
-                .verify(None, &DIDEthr, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc_wrong_key
+            .verify(None, &DIDEthr, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Make it into a VP
         use ssi::one_or_many::OneOrMany;
@@ -551,11 +549,11 @@ mod tests {
         // test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:example:bad".to_string()));
-        assert!(
-            !vp2.verify(None, &DIDEthr, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vp2
+            .verify(None, &DIDEthr, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
     }
 
     #[tokio::test]

--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -463,12 +463,10 @@ mod tests {
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
         assert!(
-            vc_bad_issuer
+            !vc_bad_issuer
                 .verify(None, &DIDEthr, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         // Check that proof JWK must match proof verificationMethod
@@ -489,12 +487,10 @@ mod tests {
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
         assert!(
-            vc_wrong_key
+            !vc_wrong_key
                 .verify(None, &DIDEthr, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         // Make it into a VP
@@ -550,17 +546,15 @@ mod tests {
             .verify(Some(vp_issue_options), &DIDEthr, &mut context_loader)
             .await;
         println!("{:#?}", vp_verification_result);
-        assert!(vp_verification_result.errors.len() >= 1);
+        assert!(!vp_verification_result.errors.is_empty());
 
         // test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:example:bad".to_string()));
         assert!(
-            vp2.verify(None, &DIDEthr, &mut context_loader)
+            !vp2.verify(None, &DIDEthr, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
     }
 

--- a/did-ion/src/lib.rs
+++ b/did-ion/src/lib.rs
@@ -17,7 +17,7 @@ impl Sidetree for ION {
     }
 
     fn validate_key(key: &JWK) -> Result<(), SidetreeError> {
-        if !is_secp256k1(&key) {
+        if !is_secp256k1(key) {
             return Err(anyhow!("Key must be Secp256k1").into());
         }
         Ok(())

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -553,11 +553,11 @@ mod tests {
 
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(
-            !vc.verify(None, &DIDKey, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc
+            .verify(None, &DIDKey, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
     }
 
     #[async_std::test]
@@ -596,11 +596,11 @@ mod tests {
 
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(
-            !vc.verify(None, &DIDKey, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc
+            .verify(None, &DIDKey, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
     }
 
     #[async_std::test]
@@ -639,10 +639,10 @@ mod tests {
 
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(
-            !vc.verify(None, &DIDKey, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc
+            .verify(None, &DIDKey, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
     }
 }

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -384,7 +384,7 @@ mod tests {
     async fn from_did_key() {
         let vm = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
         let (res_meta, object, _meta) =
-            dereference(&DIDKey, &vm, &DereferencingInputMetadata::default()).await;
+            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
         assert_eq!(res_meta.error, None);
         let vm = match object {
             Content::Object(Resource::VerificationMethod(vm)) => vm,
@@ -404,7 +404,7 @@ mod tests {
 
         let vm = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme#zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
         let (res_meta, object, _meta) =
-            dereference(&DIDKey, &vm, &DereferencingInputMetadata::default()).await;
+            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
         assert_eq!(res_meta.error, None);
         let vm = match object {
             Content::Object(Resource::VerificationMethod(vm)) => vm,
@@ -429,7 +429,7 @@ mod tests {
 
         let vm = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169#zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
         let (res_meta, object, _meta) =
-            dereference(&DIDKey, &vm, &DereferencingInputMetadata::default()).await;
+            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
         assert_eq!(res_meta.error, None);
         let vm = match object {
             Content::Object(Resource::VerificationMethod(vm)) => vm,
@@ -463,7 +463,7 @@ mod tests {
 
         let vm = "did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY#zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY";
         let (res_meta, object, _meta) =
-            dereference(&DIDKey, &vm, &DereferencingInputMetadata::default()).await;
+            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
         assert_eq!(res_meta.error, None);
         let vm = match object {
             Content::Object(Resource::VerificationMethod(vm)) => vm,
@@ -497,7 +497,7 @@ mod tests {
 
         let vm = "did:key:z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i#z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i";
         let (res_meta, object, _meta) =
-            dereference(&DIDKey, &vm, &DereferencingInputMetadata::default()).await;
+            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
         assert_eq!(res_meta.error, None);
         let vm = match object {
             Content::Object(Resource::VerificationMethod(vm)) => vm,
@@ -554,11 +554,9 @@ mod tests {
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
         assert!(
-            vc.verify(None, &DIDKey, &mut context_loader)
+            !vc.verify(None, &DIDKey, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
     }
 
@@ -599,11 +597,9 @@ mod tests {
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
         assert!(
-            vc.verify(None, &DIDKey, &mut context_loader)
+            !vc.verify(None, &DIDKey, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
     }
 
@@ -644,11 +640,9 @@ mod tests {
         // test that issuer is verified
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
         assert!(
-            vc.verify(None, &DIDKey, &mut context_loader)
+            !vc.verify(None, &DIDKey, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
     }
 }

--- a/did-onion/src/lib.rs
+++ b/did-onion/src/lib.rs
@@ -114,10 +114,7 @@ impl DIDResolver for DIDOnion {
             }
             Err(err) => {
                 return (
-                    ResolutionMetadata::from_error(&format!(
-                        "Error constructing proxy: {}",
-                        err
-                    )),
+                    ResolutionMetadata::from_error(&format!("Error constructing proxy: {}", err)),
                     Vec::new(),
                     None,
                 )
@@ -127,10 +124,7 @@ impl DIDResolver for DIDOnion {
             Ok(c) => c,
             Err(err) => {
                 return (
-                    ResolutionMetadata::from_error(&format!(
-                        "Error building HTTP client: {}",
-                        err
-                    )),
+                    ResolutionMetadata::from_error(&format!("Error building HTTP client: {}", err)),
                     Vec::new(),
                     None,
                 )

--- a/did-onion/src/lib.rs
+++ b/did-onion/src/lib.rs
@@ -116,7 +116,7 @@ impl DIDResolver for DIDOnion {
                 return (
                     ResolutionMetadata::from_error(&format!(
                         "Error constructing proxy: {}",
-                        err.to_string()
+                        err
                     )),
                     Vec::new(),
                     None,
@@ -129,7 +129,7 @@ impl DIDResolver for DIDOnion {
                 return (
                     ResolutionMetadata::from_error(&format!(
                         "Error building HTTP client: {}",
-                        err.to_string()
+                        err
                     )),
                     Vec::new(),
                     None,
@@ -146,7 +146,7 @@ impl DIDResolver for DIDOnion {
                 return (
                     ResolutionMetadata::from_error(&format!(
                         "Error sending HTTP request : {}",
-                        err.to_string()
+                        err
                     )),
                     Vec::new(),
                     None,

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -946,12 +946,11 @@ mod tests {
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:pkh:example:bad".to_string())));
-        assert!(
-            !vc_bad_issuer
-                .verify(None, &DIDPKH, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc_bad_issuer
+            .verify(None, &DIDPKH, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
@@ -968,12 +967,11 @@ mod tests {
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
-        assert!(
-            !vc_wrong_key
-                .verify(None, &DIDPKH, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc_wrong_key
+            .verify(None, &DIDPKH, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Mess with proof signature to make verify fail
         let mut vc_fuzzed = vc.clone();
@@ -1034,11 +1032,11 @@ mod tests {
         // Test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:pkh:example:bad".to_string()));
-        assert!(
-            !vp2.verify(None, &DIDPKH, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vp2
+            .verify(None, &DIDPKH, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
     }
 
     async fn credential_prepare_complete_verify_did_pkh_tz(
@@ -1099,12 +1097,11 @@ mod tests {
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:pkh:example:bad".to_string())));
-        assert!(
-            !vc_bad_issuer
-                .verify(None, &DIDPKH, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc_bad_issuer
+            .verify(None, &DIDPKH, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
@@ -1121,12 +1118,11 @@ mod tests {
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
-        assert!(
-            !vc_wrong_key
-                .verify(None, &DIDPKH, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc_wrong_key
+            .verify(None, &DIDPKH, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Mess with proof signature to make verify fail
         let mut vc_fuzzed = vc.clone();
@@ -1188,11 +1184,11 @@ mod tests {
         // Test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:pkh:example:bad".to_string()));
-        assert!(
-            !vp2.verify(None, &DIDPKH, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vp2
+            .verify(None, &DIDPKH, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
     }
 
     fn sign_tezos(prep: &ssi::ldp::ProofPreparation, algorithm: Algorithm, key: &JWK) -> String {

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -710,7 +710,7 @@ mod tests {
             "did:pkh:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x",
         );
         test_generate(
-            secp256k1_pk.clone(),
+            secp256k1_pk,
             "tz",
             "did:pkh:tz:tz2CA2f3SWWcqbWsjHsMZPZxCY5iafSN3nDz",
         );
@@ -947,12 +947,10 @@ mod tests {
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:pkh:example:bad".to_string())));
         assert!(
-            vc_bad_issuer
+            !vc_bad_issuer
                 .verify(None, &DIDPKH, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         // Check that proof JWK must match proof verificationMethod
@@ -971,12 +969,10 @@ mod tests {
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
         assert!(
-            vc_wrong_key
+            !vc_wrong_key
                 .verify(None, &DIDPKH, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         // Mess with proof signature to make verify fail
@@ -984,7 +980,7 @@ mod tests {
         fuzz_proof_value(&mut vc_fuzzed.proof);
         let vp_verification_result = vc_fuzzed.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
-        assert!(vp_verification_result.errors.len() >= 1);
+        assert!(!vp_verification_result.errors.is_empty());
 
         // Make it into a VP
         use ssi::vc::{CredentialOrJWT, Presentation, ProofPurpose, DEFAULT_CONTEXT};
@@ -1033,17 +1029,15 @@ mod tests {
             .verify(Some(vp_issue_options), &DIDPKH, &mut context_loader)
             .await;
         println!("{:#?}", vp_verification_result);
-        assert!(vp_verification_result.errors.len() >= 1);
+        assert!(!vp_verification_result.errors.is_empty());
 
         // Test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:pkh:example:bad".to_string()));
         assert!(
-            vp2.verify(None, &DIDPKH, &mut context_loader)
+            !vp2.verify(None, &DIDPKH, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
     }
 
@@ -1106,12 +1100,10 @@ mod tests {
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:pkh:example:bad".to_string())));
         assert!(
-            vc_bad_issuer
+            !vc_bad_issuer
                 .verify(None, &DIDPKH, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         // Check that proof JWK must match proof verificationMethod
@@ -1130,12 +1122,10 @@ mod tests {
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
         assert!(
-            vc_wrong_key
+            !vc_wrong_key
                 .verify(None, &DIDPKH, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         // Mess with proof signature to make verify fail
@@ -1143,7 +1133,7 @@ mod tests {
         fuzz_proof_value(&mut vc_fuzzed.proof);
         let vp_verification_result = vc_fuzzed.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", vp_verification_result);
-        assert!(vp_verification_result.errors.len() >= 1);
+        assert!(!vp_verification_result.errors.is_empty());
 
         // Make it into a VP
         use ssi::vc::{CredentialOrJWT, Presentation, ProofPurpose, DEFAULT_CONTEXT};
@@ -1193,17 +1183,15 @@ mod tests {
             .verify(Some(vp_issue_options), &DIDPKH, &mut context_loader)
             .await;
         println!("{:#?}", vp_verification_result);
-        assert!(vp_verification_result.errors.len() >= 1);
+        assert!(!vp_verification_result.errors.is_empty());
 
         // Test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:pkh:example:bad".to_string()));
         assert!(
-            vp2.verify(None, &DIDPKH, &mut context_loader)
+            !vp2.verify(None, &DIDPKH, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
     }
 
@@ -1536,7 +1524,7 @@ mod tests {
         vc.property_set = Some(map);
         let verification_result = vc.verify(None, &DIDPKH, &mut context_loader).await;
         println!("{:#?}", verification_result);
-        assert!(verification_result.errors.len() > 0);
+        assert!(!verification_result.errors.is_empty());
     }
 
     #[tokio::test]

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -291,12 +291,10 @@ mod tests {
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
         assert!(
-            vc_bad_issuer
+            !vc_bad_issuer
                 .verify(None, &DIDSol, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         // Check that proof JWK must match proof verificationMethod
@@ -317,12 +315,10 @@ mod tests {
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
         assert!(
-            vc_wrong_key
+            !vc_wrong_key
                 .verify(None, &DIDSol, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         // Make it into a VP
@@ -375,17 +371,15 @@ mod tests {
             .verify(Some(vp_issue_options), &DIDSol, &mut context_loader)
             .await;
         println!("{:#?}", vp_verification_result);
-        assert!(vp_verification_result.errors.len() >= 1);
+        assert!(!vp_verification_result.errors.is_empty());
 
         // test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:example:bad".to_string()));
         assert!(
-            vp2.verify(None, &DIDSol, &mut context_loader)
+            !vp2.verify(None, &DIDSol, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
     }
 

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -290,12 +290,11 @@ mod tests {
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(
-            !vc_bad_issuer
-                .verify(None, &DIDSol, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc_bad_issuer
+            .verify(None, &DIDSol, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
@@ -314,12 +313,11 @@ mod tests {
             .unwrap();
         vc_wrong_key.add_proof(proof_bad);
         vc_wrong_key.validate().unwrap();
-        assert!(
-            !vc_wrong_key
-                .verify(None, &DIDSol, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc_wrong_key
+            .verify(None, &DIDSol, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Make it into a VP
         use ssi::one_or_many::OneOrMany;
@@ -376,11 +374,11 @@ mod tests {
         // test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:example:bad".to_string()));
-        assert!(
-            !vp2.verify(None, &DIDSol, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vp2
+            .verify(None, &DIDSol, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
     }
 
     /*

--- a/did-test/src/main.rs
+++ b/did-test/src/main.rs
@@ -102,6 +102,7 @@ pub enum ExecutionInput {
     },
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum ExecutionOutput {
@@ -281,7 +282,8 @@ async fn report_method_onion() {
     let mut did_vectors = Map::new();
     let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
 
-    for did in &["did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid"] {
+    {
+        let did = &"did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid";
         let did_vector = did_method_vector(&resolver, did).await;
         did_vectors.insert(did.to_string(), did_vector);
     }
@@ -338,7 +340,8 @@ async fn report_method_webkey() {
     let mut did_vectors = Map::new();
     let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
 
-    for did in &["did:webkey:ssh:demo.spruceid.com:2021:07:14:keys"] {
+    {
+        let did = &"did:webkey:ssh:demo.spruceid.com:2021:07:14:keys";
         let did_vector = did_method_vector(&resolver, did).await;
         did_vectors.insert(did.to_string(), did_vector);
     }
@@ -508,7 +511,8 @@ async fn report_resolver_key() {
             .await;
     }
 
-    for did in &["did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"] {
+    {
+        let did = &"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
         report
             .resolve_representation(
                 &did_method_key::DIDKey,
@@ -540,7 +544,8 @@ async fn report_resolver_web() {
             .await;
     }
 
-    for did in &["did:web:identity.foundation"] {
+    {
+        let did = &"did:web:identity.foundation";
         report
             .resolve_representation(&did_web::DIDWeb, did, &ResolutionInputMetadata::default())
             .await;
@@ -571,7 +576,8 @@ async fn report_resolver_tz() {
             .await;
     }
 
-    for did in &["did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x"] {
+    {
+        let did = &"did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x";
         report
             .resolve_representation(&did_tz, did, &ResolutionInputMetadata::default())
             .await;
@@ -591,13 +597,15 @@ async fn report_resolver_onion() {
         executions: Vec::new(),
     };
 
-    for did in &["did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid"] {
+    {
+        let did = &"did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid";
         report
             .resolve(&resolver, did, &ResolutionInputMetadata::default())
             .await;
     }
 
-    for did in &["did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid"] {
+    {
+        let did = &"did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid";
         report
             .resolve_representation(&resolver, did, &ResolutionInputMetadata::default())
             .await;
@@ -617,13 +625,15 @@ async fn report_resolver_pkh() {
         executions: Vec::new(),
     };
 
-    for did in &["did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L"] {
+    {
+        let did = &"did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L";
         report
             .resolve(&resolver, did, &ResolutionInputMetadata::default())
             .await;
     }
 
-    for did in &["did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L"] {
+    {
+        let did = &"did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L";
         report
             .resolve_representation(&resolver, did, &ResolutionInputMetadata::default())
             .await;
@@ -643,13 +653,15 @@ async fn report_resolver_webkey() {
         executions: Vec::new(),
     };
 
-    for did in &["did:webkey:ssh:demo.spruceid.com:2021:07:14:keys"] {
+    {
+        let did = &"did:webkey:ssh:demo.spruceid.com:2021:07:14:keys";
         report
             .resolve(&resolver, did, &ResolutionInputMetadata::default())
             .await;
     }
 
-    for did in &["did:webkey:ssh:demo.spruceid.com:2021:07:14:keys"] {
+    {
+        let did = &"did:webkey:ssh:demo.spruceid.com:2021:07:14:keys";
         report
             .resolve_representation(&resolver, did, &ResolutionInputMetadata::default())
             .await;

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -115,7 +115,7 @@ impl DIDResolver for DIDWeb {
                 return (
                     ResolutionMetadata::from_error(&format!(
                         "Error building HTTP client: {}",
-                        err.to_string()
+                        err
                     )),
                     Vec::new(),
                     None,
@@ -132,7 +132,7 @@ impl DIDResolver for DIDWeb {
                 return (
                     ResolutionMetadata::from_error(&format!(
                         "Error sending HTTP request : {}",
-                        err.to_string()
+                        err
                     )),
                     Vec::new(),
                     None,
@@ -253,7 +253,7 @@ mod tests {
                 let (mut parts, body) = Response::<Body>::default().into_parts();
                 parts.status = hyper::StatusCode::NOT_FOUND;
                 let response = Response::from_parts(parts, body);
-                return Ok::<_, hyper::Error>(response);
+                Ok::<_, hyper::Error>(response)
             }))
         });
         let server = Server::try_bind(&addr)?.serve(make_svc);
@@ -324,11 +324,9 @@ mod tests {
         // test that issuer property is used for verification
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
         assert!(
-            vc.verify(None, &DIDWeb, &mut context_loader)
+            !vc.verify(None, &DIDWeb, &mut context_loader)
                 .await
-                .errors
-                .len()
-                > 0
+                .errors.is_empty()
         );
 
         PROXY.with(|proxy| {

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -113,10 +113,7 @@ impl DIDResolver for DIDWeb {
             Ok(c) => c,
             Err(err) => {
                 return (
-                    ResolutionMetadata::from_error(&format!(
-                        "Error building HTTP client: {}",
-                        err
-                    )),
+                    ResolutionMetadata::from_error(&format!("Error building HTTP client: {}", err)),
                     Vec::new(),
                     None,
                 )
@@ -323,11 +320,11 @@ mod tests {
 
         // test that issuer property is used for verification
         vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(
-            !vc.verify(None, &DIDWeb, &mut context_loader)
-                .await
-                .errors.is_empty()
-        );
+        assert!(!vc
+            .verify(None, &DIDWeb, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         PROXY.with(|proxy| {
             proxy.replace(None);

--- a/did-webkey/src/lib.rs
+++ b/did-webkey/src/lib.rs
@@ -237,10 +237,7 @@ impl DIDResolver for DIDWebKey {
             Ok(c) => c,
             Err(err) => {
                 return (
-                    ResolutionMetadata::from_error(&format!(
-                        "Error building HTTP client: {}",
-                        err
-                    )),
+                    ResolutionMetadata::from_error(&format!("Error building HTTP client: {}", err)),
                     None,
                     None,
                 )

--- a/did-webkey/src/lib.rs
+++ b/did-webkey/src/lib.rs
@@ -239,7 +239,7 @@ impl DIDResolver for DIDWebKey {
                 return (
                     ResolutionMetadata::from_error(&format!(
                         "Error building HTTP client: {}",
-                        err.to_string()
+                        err
                     )),
                     None,
                     None,
@@ -256,7 +256,7 @@ impl DIDResolver for DIDWebKey {
                 return (
                     ResolutionMetadata::from_error(&format!(
                         "Error sending HTTP request : {}",
-                        err.to_string()
+                        err
                     )),
                     None,
                     None,

--- a/examples/issue-revocation-list.rs
+++ b/examples/issue-revocation-list.rs
@@ -31,7 +31,7 @@ async fn main() {
         .unwrap();
     vc.add_proof(proof);
     let result = vc.verify(None, resolver, &mut context_loader).await;
-    if result.errors.len() > 0 {
+    if !result.errors.is_empty() {
         panic!("verify failed: {:#?}", result);
     }
     let stdout_writer = std::io::BufWriter::new(std::io::stdout());

--- a/examples/issue-status-list.rs
+++ b/examples/issue-status-list.rs
@@ -29,7 +29,7 @@ async fn main() {
         .unwrap();
     vc.add_proof(proof);
     let result = vc.verify(None, resolver, &mut context_loader).await;
-    if result.errors.len() > 0 {
+    if !result.errors.is_empty() {
         panic!("verify failed: {:#?}", result);
     }
     let stdout_writer = std::io::BufWriter::new(std::io::stdout());

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -20,7 +20,7 @@ async fn main() {
     let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
     let verification_method = "did:example:foo#key1".to_string();
     proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));
-    let proof_format = std::env::args().skip(1).next();
+    let proof_format = std::env::args().nth(1);
     let mut context_loader = ssi::jsonld::ContextLoader::default();
     match &proof_format.unwrap()[..] {
         "ldp" => {
@@ -30,7 +30,7 @@ async fn main() {
                 .unwrap();
             vc.add_proof(proof);
             let result = vc.verify(None, resolver, &mut context_loader).await;
-            if result.errors.len() > 0 {
+            if !result.errors.is_empty() {
                 panic!("verify failed: {:#?}", result);
             }
             let stdout_writer = std::io::BufWriter::new(std::io::stdout());
@@ -45,7 +45,7 @@ async fn main() {
                 .unwrap();
             let result =
                 ssi::vc::Credential::verify_jwt(&jwt, None, resolver, &mut context_loader).await;
-            if result.errors.len() > 0 {
+            if !result.errors.is_empty() {
                 panic!("verify failed: {:#?}", result);
             }
             print!("{}", jwt);

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -23,7 +23,7 @@ async fn main() {
             use std::io::Read;
             let mut vc_jwt = String::new();
             reader.read_to_string(&mut vc_jwt).unwrap();
-            if vc_jwt.starts_with("{") {
+            if vc_jwt.starts_with('{') {
                 panic!("Input must be a compact JWT");
             }
             ssi::vc::CredentialOrJWT::JWT(vc_jwt)
@@ -55,7 +55,7 @@ async fn main() {
             let result = vp
                 .verify(Some(proof_options), resolver, &mut context_loader)
                 .await;
-            if result.errors.len() > 0 {
+            if !result.errors.is_empty() {
                 panic!("verify failed: {:#?}", result);
             }
             let writer = std::io::BufWriter::new(std::io::stdout());
@@ -71,7 +71,7 @@ async fn main() {
             print!("{}", jwt);
             let result =
                 ssi::vc::Presentation::verify_jwt(&jwt, None, resolver, &mut context_loader).await;
-            if result.errors.len() > 0 {
+            if !result.errors.is_empty() {
                 panic!("verify failed: {:#?}", result);
             }
         }

--- a/src/caip10.rs
+++ b/src/caip10.rs
@@ -265,12 +265,12 @@ mod tests {
     async fn account_id() {
         // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md#test-cases
         let dummy_max_length = "chainstd:8c3444cf8970a9e41a706fab93e7a6c4:6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f7";
-        let account_id = BlockchainAccountId::from_str(&dummy_max_length).unwrap();
+        let account_id = BlockchainAccountId::from_str(dummy_max_length).unwrap();
         assert_eq!(account_id.to_string(), dummy_max_length);
 
         // Support old format, for backwards compatibility
         let old = "6d9b0b4b9994e8a6afbd3dc3ed983cd51c755afb27cd1dc7825ef59c134a39f7@chainstd:8c3444cf8970a9e41a706fab93e7a6c4";
-        let account_id_old = BlockchainAccountId::from_str(&old).unwrap();
+        let account_id_old = BlockchainAccountId::from_str(old).unwrap();
         assert_eq!(account_id_old.to_string(), dummy_max_length);
     }
 

--- a/src/caip2.rs
+++ b/src/caip2.rs
@@ -140,7 +140,7 @@ mod tests {
     async fn chain_id() {
         // See https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md#test-cases
         let dummy_max_length = "chainstd:8c3444cf8970a9e41a706fab93e7a6c4";
-        let chain_id = ChainId::from_str(&dummy_max_length).unwrap();
+        let chain_id = ChainId::from_str(dummy_max_length).unwrap();
         assert_eq!(chain_id.to_string(), dummy_max_length);
 
         let reference_too_long = format!("{}0", dummy_max_length);

--- a/src/did.rs
+++ b/src/did.rs
@@ -1471,7 +1471,7 @@ mod tests {
     #[test]
     fn vmm_to_jwk() {
         // Identity: publicKeyJWK -> JWK
-        const JWK: &'static str = include_str!("../tests/ed25519-2020-10-18.json");
+        const JWK: &str = include_str!("../tests/ed25519-2020-10-18.json");
         let jwk: JWK = serde_json::from_str(JWK).unwrap();
         let pk_jwk = jwk.to_public();
         let vmm_ed = VerificationMethodMap {
@@ -1488,7 +1488,7 @@ mod tests {
     #[test]
     fn vmm_bs58_to_jwk() {
         // publicKeyBase58 (deprecated) -> JWK
-        const JWK: &'static str = include_str!("../tests/ed25519-2020-10-18.json");
+        const JWK: &str = include_str!("../tests/ed25519-2020-10-18.json");
         let jwk: JWK = serde_json::from_str(JWK).unwrap();
         let pk_jwk = jwk.to_public();
         let vmm_ed = VerificationMethodMap {
@@ -1506,7 +1506,7 @@ mod tests {
     #[cfg(feature = "k256")]
     fn vmm_hex_to_jwk() {
         // publicKeyHex (deprecated) -> JWK
-        const JWK: &'static str = include_str!("../tests/secp256k1-2021-02-17.json");
+        const JWK: &str = include_str!("../tests/secp256k1-2021-02-17.json");
         let jwk: JWK = serde_json::from_str(JWK).unwrap();
         let pk_jwk = jwk.to_public();
         let vmm_ed = VerificationMethodMap {

--- a/src/did_resolve.rs
+++ b/src/did_resolve.rs
@@ -948,10 +948,7 @@ impl DIDResolver for HTTPDIDResolver {
             Ok(client) => client,
             Err(err) => {
                 return (
-                    ResolutionMetadata::from_error(&format!(
-                        "Error building HTTP client: {}",
-                        err
-                    )),
+                    ResolutionMetadata::from_error(&format!("Error building HTTP client: {}", err)),
                     None,
                     None,
                 );

--- a/src/did_resolve.rs
+++ b/src/did_resolve.rs
@@ -889,7 +889,7 @@ fn transform_resolution_result(
     } else {
         ResolutionMetadata::default()
     };
-    return (res_meta, result.did_document, result.did_document_metadata);
+    (res_meta, result.did_document, result.did_document_metadata)
 }
 
 #[cfg(feature = "http")]
@@ -924,7 +924,7 @@ impl DIDResolver for HTTPDIDResolver {
             }
         };
         let did_urlencoded =
-            percent_encoding::utf8_percent_encode(&did, percent_encoding::CONTROLS).to_string();
+            percent_encoding::utf8_percent_encode(did, percent_encoding::CONTROLS).to_string();
         let mut url = self.endpoint.clone() + &did_urlencoded;
         if !querystring.is_empty() {
             url.push('?');
@@ -950,7 +950,7 @@ impl DIDResolver for HTTPDIDResolver {
                 return (
                     ResolutionMetadata::from_error(&format!(
                         "Error building HTTP client: {}",
-                        err.to_string()
+                        err
                     )),
                     None,
                     None,
@@ -1099,7 +1099,7 @@ impl DIDResolver for HTTPDIDResolver {
                 return Some((
                     DereferencingMetadata::from_error(&format!(
                         "Error building HTTP client: {}",
-                        err.to_string()
+                        err
                     )),
                     Content::Null,
                     ContentMetadata::default(),
@@ -1451,9 +1451,9 @@ mod tests {
         ]
     }"#;
     #[cfg(feature = "http-did")]
-    const DID_KEY_ID: &'static str = "did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6";
+    const DID_KEY_ID: &str = "did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6";
     #[cfg(feature = "http-did")]
-    const DID_KEY_JSON: &'static str = include_str!("../tests/did-key-uniresolver-resp.json");
+    const DID_KEY_JSON: &str = include_str!("../tests/did-key-uniresolver-resp.json");
 
     #[async_trait]
     impl DIDResolver for ExampleResolver {
@@ -1627,7 +1627,7 @@ mod tests {
         assert_eq!(res_meta.error, None);
         assert!(doc_meta.is_some());
         let doc: Value = serde_json::from_slice(&doc_representation).unwrap();
-        let doc_expected: Value = serde_json::from_str(&EXAMPLE_123_JSON).unwrap();
+        let doc_expected: Value = serde_json::from_str(EXAMPLE_123_JSON).unwrap();
         assert_eq!(doc, doc_expected);
         shutdown().ok();
     }
@@ -1654,7 +1654,7 @@ mod tests {
         let (endpoint, shutdown) = did_resolver_server().unwrap();
         let resolver = HTTPDIDResolver { endpoint };
         let (res_meta, doc, doc_meta) = resolver
-            .resolve(&id, &ResolutionInputMetadata::default())
+            .resolve(id, &ResolutionInputMetadata::default())
             .await;
         eprintln!("res_meta = {:?}", &res_meta);
         eprintln!("doc_meta = {:?}", &doc_meta);
@@ -1758,7 +1758,7 @@ mod tests {
 	"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
 }
         "#;
-        let vm: VerificationMethodMap = serde_json::from_str(&expected_output_resource).unwrap();
+        let vm: VerificationMethodMap = serde_json::from_str(expected_output_resource).unwrap();
         let expected_content = Content::Object(Resource::VerificationMethod(vm));
         let (deref_meta, content, content_meta) = dereference(
             &DerefExampleResolver,

--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -237,13 +237,6 @@ impl EIP712Value {
             _ => None,
         }
     }
-
-    fn as_struct_mut(&mut self) -> Option<&mut HashMap<StructName, EIP712Value>> {
-        match self {
-            EIP712Value::Struct(map) => Some(map),
-            _ => None,
-        }
-    }
 }
 
 impl fmt::Display for EIP712Type {
@@ -1037,7 +1030,7 @@ pub fn generate_types(
             // 7
             EIP712Value::Array(array) => {
                 // Ensure values have same primitive type.
-                let mut values = array.into_iter();
+                let mut values = array.iter();
                 let first_value = values
                     .next()
                     .ok_or_else(|| TypesGenerationError::EmptyArray(property_name.clone()))?;
@@ -1615,7 +1608,7 @@ mod tests {
         ERROR_NOT_FOUND, TYPE_DID_LD_JSON,
     };
     use async_trait::async_trait;
-    const DOC_JSON: &'static str = r#"
+    const DOC_JSON: &str = r#"
 {
   "@context": "https://www.w3.org/ns/did/v1",
   "id": "did:example:aaaabbbb",
@@ -1644,7 +1637,7 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl DIDMethod for DIDExample {
         fn name(&self) -> &'static str {
-            return "example";
+            "example"
         }
         fn to_resolver(&self) -> &dyn DIDResolver {
             self
@@ -1894,7 +1887,7 @@ mod tests {
         let sig: k256::ecdsa::recoverable::Signature = signing_key.try_sign(&bytes).unwrap();
         let sig_bytes = &mut sig.as_ref().to_vec();
         // Recovery ID starts at 27 instead of 0.
-        sig_bytes[64] = sig_bytes[64] + 27;
+        sig_bytes[64] += 27;
         let sig_hex = crate::keccak_hash::bytes_to_lowerhex(sig_bytes);
         let mut proof = proof.clone();
         proof.proof_value = Some(sig_hex.clone());
@@ -2024,7 +2017,7 @@ mod tests {
           }
         }))
         .unwrap();
-        let ldp_options = LinkedDataProofOptions::from(input_options);
+        let _ldp_options = LinkedDataProofOptions::from(input_options);
 
         // https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/blob/28bd5edecde8395242aea8ba64e9be25f59585d0/index.html#L685-L691
         let proof: Proof = serde_json::from_value(json!({
@@ -2132,7 +2125,7 @@ mod tests {
           "embed": true
         }))
         .unwrap();
-        let ldp_options = LinkedDataProofOptions::from(input_options);
+        let _ldp_options = LinkedDataProofOptions::from(input_options);
 
         // https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/blob/28bd5edecde8395242aea8ba64e9be25f59585d0/index.html#L788-L872
         let proof: Proof = serde_json::from_value(json!({
@@ -2245,7 +2238,7 @@ mod tests {
           }
         }))
         .unwrap();
-        let ldp_options = LinkedDataProofOptions::from(input_options);
+        let _ldp_options = LinkedDataProofOptions::from(input_options);
 
         // https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/blob/28bd5edecde8395242aea8ba64e9be25f59585d0/index.html#L898-L911
         let proof: Proof = serde_json::from_value(json!({
@@ -2295,7 +2288,7 @@ mod tests {
           "embed": true
         }))
         .unwrap();
-        let ldp_options = LinkedDataProofOptions::from(input_options);
+        let _ldp_options = LinkedDataProofOptions::from(input_options);
 
         // https://github.com/w3c-ccg/ethereum-eip712-signature-2021-spec/blob/28bd5edecde8395242aea8ba64e9be25f59585d0/index.html#L996-L1080
         let proof: Proof = serde_json::from_value(json!({

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -12,7 +12,7 @@ pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
         use ring::digest;
         use std::convert::TryInto;
         let hash = digest::digest(&digest::SHA256, data).as_ref().try_into()?;
-        return Ok(hash);
+        Ok(hash)
     }
     #[cfg(all(not(feature = "ring"), feature = "sha2"))]
     {
@@ -21,7 +21,7 @@ pub fn sha256(data: &[u8]) -> Result<[u8; 32], Error> {
         let mut hasher = sha2::Sha256::new();
         hasher.update(data);
         let hash = hasher.finalize().into();
-        return Ok(hash);
+        Ok(hash)
     }
     #[cfg(all(not(feature = "ring"), not(feature = "sha2")))]
     {

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap as Map, HashMap};
 use std::convert::TryFrom;
+use std::fmt::Write;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -491,7 +492,7 @@ impl Loader for ContextLoader {
                     .read()
                     .await
                     .get(url_buf.as_str())
-                    .map(|rd| rd.clone())
+                    .cloned()
                     .ok_or_else(|| json_ld::ErrorCode::LoadingDocumentFailed.into())
             } else {
                 Err(json_ld::ErrorCode::LoadingDocumentFailed.into())
@@ -1627,7 +1628,7 @@ pub fn canonicalize_json_string(string: &str) -> String {
             '\\' => out.push_str("\\\\"),
             '\x00'..='\x1f' => {
                 let bytes: u32 = c.into();
-                out.push_str(&format!("\\u{:04x}", bytes))
+                let _ = write!(out, "\\u{:04x}", bytes);
             }
             c => out.push(c),
         }

--- a/src/jsonld.rs
+++ b/src/jsonld.rs
@@ -1910,7 +1910,7 @@ mod tests {
             _ => Err(Error::ExpectedObject),
         }
         .unwrap();
-        let case = std::env::args().skip(2).next();
+        let case = std::env::args().nth(2);
         let sequence = manifest_obj.get("sequence").unwrap();
         let mut passed = 0;
         let mut total = 0;
@@ -1964,7 +1964,7 @@ mod tests {
                 }
             }
             total += 1;
-            if let Err(err) = test_to_rdf(&obj).await {
+            if let Err(err) = test_to_rdf(obj).await {
                 if let Error::ExpectedOutput(expected, found) = err {
                     let changes = difference::Changeset::new(&found, &expected, "\n");
                     eprintln!("test {}: failed. diff:\n{}", id, changes);

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -1127,10 +1127,10 @@ impl From<Base64urlUInt> for Base64urlUIntString {
 mod tests {
     use super::*;
 
-    const RSA_JSON: &'static str = include_str!("../tests/rsa2048-2020-08-25.json");
-    const RSA_DER: &'static [u8] = include_bytes!("../tests/rsa2048-2020-08-25.der");
-    const RSA_PK_DER: &'static [u8] = include_bytes!("../tests/rsa2048-2020-08-25-pk.der");
-    const ED25519_JSON: &'static str = include_str!("../tests/ed25519-2020-10-18.json");
+    const RSA_JSON: &str = include_str!("../tests/rsa2048-2020-08-25.json");
+    const RSA_DER: &[u8] = include_bytes!("../tests/rsa2048-2020-08-25.der");
+    const RSA_PK_DER: &[u8] = include_bytes!("../tests/rsa2048-2020-08-25-pk.der");
+    const ED25519_JSON: &str = include_str!("../tests/ed25519-2020-10-18.json");
 
     #[test]
     fn jwk_to_from_der_rsa() {

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -190,7 +190,7 @@ pub fn sign_bytes(algorithm: Algorithm, data: &[u8], key: &JWK) -> Result<Vec<u8
                 }
                 let secret_key = k256::SecretKey::try_from(ec)?;
                 let signing_key = k256::ecdsa::SigningKey::from(secret_key);
-                let hash = crate::hash::sha256(&data)?;
+                let hash = crate::hash::sha256(data)?;
                 let digest = Digest::chain(<PassthroughDigest as Digest>::new(), &hash);
                 let sig: k256::ecdsa::recoverable::Signature =
                     signing_key.try_sign_digest(digest)?;

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -2703,7 +2703,7 @@ mod tests {
             let resolver = ExampleResolver;
             let mut context_loader = crate::jsonld::ContextLoader::default();
             let warnings = EcdsaSecp256k1RecoverySignature2020
-                .verify(&proof, &vc, &resolver, &mut context_loader)
+                .verify(proof, &vc, &resolver, &mut context_loader)
                 .await
                 .unwrap();
             assert!(warnings.is_empty());
@@ -2729,7 +2729,7 @@ mod tests {
         let sk_bytes = hex::decode(sk_hex).unwrap();
         let sk_bytes_mc = [vec![0x80, 0x26], sk_bytes.clone()].concat();
         let sk_mb = multibase::encode(multibase::Base::Base58Btc, &sk_bytes_mc);
-        let ref props = vmm.property_set.unwrap();
+        let props = &vmm.property_set.unwrap();
         let sk_mb_expected = props
             .get("privateKeyMultibase")
             .unwrap()
@@ -2906,7 +2906,7 @@ mod tests {
             SigningInput::Bytes(Base64urlUInt(ref bytes)) => bytes,
             _ => panic!("expected SigningInput::Bytes for Ed25519Signature2020 preparation"),
         };
-        let sig = crate::jws::sign_bytes(Algorithm::EdDSA, &signing_input_bytes, &sk_jwk).unwrap();
+        let sig = crate::jws::sign_bytes(Algorithm::EdDSA, signing_input_bytes, &sk_jwk).unwrap();
         let sig_mb = multibase::encode(multibase::Base::Base58Btc, sig);
         let completed_proof = Ed25519Signature2020.complete(prep, &sig_mb).await.unwrap();
         Ed25519Signature2020

--- a/src/ldp.rs
+++ b/src/ldp.rs
@@ -502,6 +502,7 @@ async fn to_jws_payload(
     Ok(data)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn sign(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
@@ -536,6 +537,7 @@ async fn sign_proof(
     Ok(proof)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn sign_nojws(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
@@ -564,6 +566,7 @@ async fn sign_nojws(
     Ok(proof)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn prepare(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
@@ -601,6 +604,7 @@ async fn prepare_proof(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn prepare_nojws(
     document: &(dyn LinkedDataDocument + Sync),
     options: &LinkedDataProofOptions,
@@ -2628,7 +2632,7 @@ mod tests {
         struct ExampleResolver;
 
         const EXAMPLE_123_ID: &str = "did:example:123";
-        const EXAMPLE_123_JSON: &'static str = include_str!("../tests/esrs2020-did.jsonld");
+        const EXAMPLE_123_JSON: &str = include_str!("../tests/esrs2020-did.jsonld");
 
         #[async_trait]
         impl DIDResolver for ExampleResolver {

--- a/src/rdf.rs
+++ b/src/rdf.rs
@@ -1,6 +1,7 @@
 use std::collections::hash_map::Iter as HashMapIter;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt::Write;
 use std::iter::Peekable;
 use std::str::Chars;
 use std::str::FromStr;
@@ -167,7 +168,7 @@ impl From<&IRIRef> for String {
             match c {
                 '\x00'..='\x20' | '<' | '>' | '"' | '{' | '}' | '|' | '^' | '`' | '\\' => {
                     let bytes: u32 = c.into();
-                    out.push_str(&format!("\\u{:#04x}", bytes))
+                    let _ = write!(out, "\\u{:#04x}", bytes);
                 }
                 _ => out.push(c),
             }

--- a/src/rdf.rs
+++ b/src/rdf.rs
@@ -919,7 +919,7 @@ mod tests {
         }
         let mut out = String::new();
         out.push_str("_:");
-        while let Some(c) = chars.next() {
+        for c in chars.by_ref() {
             match c {
                 ' ' => break,
                 '\t' => break,

--- a/src/tzkey.rs
+++ b/src/tzkey.rs
@@ -230,7 +230,7 @@ mod tests {
         // Attempt to decode tzsig that would involve subslicing
         // through a char boundary.
         let bad_tzk = "xx💣️";
-        jwk_from_tezos_key(&bad_tzk).unwrap_err();
+        jwk_from_tezos_key(bad_tzk).unwrap_err();
     }
 
     #[test]

--- a/src/ucan.rs
+++ b/src/ucan.rs
@@ -69,12 +69,12 @@ impl<F, A> DecodedUcanTree<F, A> {
         ) {
             // did:pkh without fragment
             (Some("did:pkh:"), Some(jwk), Content::DIDDocument(d)) => {
-                match_key_with_did_pkh(&jwk, &d)?;
+                match_key_with_did_pkh(jwk, &d)?;
                 jwk.clone()
             }
             // did:pkh with fragment
             (Some("did:pkh:"), Some(jwk), Content::Object(Resource::VerificationMethod(vm))) => {
-                match_key_with_vm(&jwk, &vm)?;
+                match_key_with_vm(jwk, &vm)?;
                 jwk.clone()
             }
             // did:key without fragment
@@ -87,7 +87,7 @@ impl<F, A> DecodedUcanTree<F, A> {
                     VerificationMethod::Map(vm) => Some(vm),
                     _ => None,
                 })
-                .ok_or_else(|| Error::VerificationMethodMismatch)?
+                .ok_or(Error::VerificationMethodMismatch)?
                 .get_jwk()?,
             // general case, did with fragment
             (Some(_), _, Content::Object(Resource::VerificationMethod(vm))) => vm.get_jwk()?,
@@ -172,7 +172,7 @@ fn match_key_with_did_pkh(key: &JWK, doc: &Document) -> Result<(), Error> {
 fn match_key_with_vm(key: &JWK, vm: &VerificationMethodMap) -> Result<(), Error> {
     use std::str::FromStr;
     Ok(crate::caip10::BlockchainAccountId::from_str(
-        &vm.blockchain_account_id
+        vm.blockchain_account_id
             .as_ref()
             .ok_or(Error::VerificationMethodMismatch)?,
     )?

--- a/src/ucan.rs
+++ b/src/ucan.rs
@@ -437,7 +437,7 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl DIDMethod for DIDExample {
         fn name(&self) -> &'static str {
-            return "key";
+            "key"
         }
         fn to_resolver(&self) -> &dyn DIDResolver {
             self

--- a/src/urdna2015.rs
+++ b/src/urdna2015.rs
@@ -421,7 +421,7 @@ mod tests {
         use std::fs::{self};
         use std::path::PathBuf;
         use std::str::FromStr;
-        let case = std::env::args().skip(2).next();
+        let case = std::env::args().nth(2);
         // Example usage to run a single test case:
         //   cargo test normalization_test_suite -- test022
         let mut passed = 0;

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -1254,11 +1254,11 @@ impl Credential {
         Ok(())
     }
 
-    async fn filter_proofs(
-        &self,
+    async fn filter_proofs<'a, 'b>(
+        &'a self,
         options: Option<LinkedDataProofOptions>,
         jwt_params: Option<(&Header, &JWTClaims)>,
-        resolver: &dyn DIDResolver,
+        resolver: &'b dyn DIDResolver,
     ) -> Result<(Vec<&Proof>, bool), String> {
         // Allow any of issuer's verification methods by default
         let mut options = options.unwrap_or_default();
@@ -1810,10 +1810,10 @@ impl Presentation {
         }
     }
 
-    async fn filter_proofs(
-        &self,
+    async fn filter_proofs<'a, 'b>(
+        &'a self,
         options: Option<LinkedDataProofOptions>,
-        jwt_params: Option<(&Header, &JWTClaims)>,
+        jwt_params: Option<(&'b Header, &JWTClaims)>,
         resolver: &dyn DIDResolver,
     ) -> Result<(Vec<&Proof>, bool), String> {
         // Allow any of holder's verification methods matching proof purpose by default
@@ -2463,16 +2463,13 @@ pub(crate) mod tests {
         let _ = NumericDate::MAX + Duration::microseconds(1);
     }
 
-    pub const EXAMPLE_REVOCATION_2020_LIST_URL: &'static str =
-        "https://example.test/revocationList.json";
-    pub const EXAMPLE_REVOCATION_2020_LIST: &'static [u8] =
-        include_bytes!("../tests/revocationList.json");
+    pub const EXAMPLE_REVOCATION_2020_LIST_URL: &str = "https://example.test/revocationList.json";
+    pub const EXAMPLE_REVOCATION_2020_LIST: &[u8] = include_bytes!("../tests/revocationList.json");
 
-    pub const EXAMPLE_STATUS_LIST_2021_URL: &'static str =
-        "https://example.com/credentials/status/3";
-    pub const EXAMPLE_STATUS_LIST_2021: &'static [u8] = include_bytes!("../tests/statusList.json");
+    pub const EXAMPLE_STATUS_LIST_2021_URL: &str = "https://example.com/credentials/status/3";
+    pub const EXAMPLE_STATUS_LIST_2021: &[u8] = include_bytes!("../tests/statusList.json");
 
-    const JWK_JSON: &'static str = include_str!("../tests/rsa2048-2020-08-25.json");
+    const JWK_JSON: &str = include_str!("../tests/rsa2048-2020-08-25.json");
 
     #[test]
     fn credential_from_json() {

--- a/src/vc.rs
+++ b/src/vc.rs
@@ -2510,7 +2510,7 @@ pub(crate) mod tests {
         if let Contexts::Many(contexts) = doc.context {
             assert_eq!(contexts.len(), 2);
         } else {
-            assert!(false);
+            panic!();
         }
     }
 
@@ -2652,7 +2652,7 @@ pub(crate) mod tests {
         )
         .await;
         println!("{:#?}", verification_result);
-        assert!(verification_result.errors.len() > 0);
+        assert!(!verification_result.errors.is_empty());
     }
 
     #[async_std::test]
@@ -2692,7 +2692,7 @@ pub(crate) mod tests {
         println!("{:?}", signed_jwt);
 
         let mut context_loader = crate::jsonld::ContextLoader::default();
-        let (vc1_opt, verification_result) = Credential::decode_verify_jwt(
+        let (_vc1_opt, verification_result) = Credential::decode_verify_jwt(
             &signed_jwt,
             Some(options.clone()),
             &DIDExample,
@@ -2719,8 +2719,10 @@ pub(crate) mod tests {
 
         let key: JWK = serde_json::from_str(JWK_JSON).unwrap();
 
-        let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
+        let issue_options = LinkedDataProofOptions {
+            verification_method: Some(URI::String("did:example:foo#key1".to_string())),
+            ..Default::default()
+        };
         let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = vc
             .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
@@ -2747,7 +2749,7 @@ pub(crate) mod tests {
         println!("{}", serde_json::to_string_pretty(&vc).unwrap());
         let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
-        assert!(verification_result.errors.len() >= 1);
+        assert!(!verification_result.errors.is_empty());
     }
 
     #[async_std::test]
@@ -2767,8 +2769,10 @@ pub(crate) mod tests {
         let key_str = include_str!("../tests/ed25519-2020-10-18.json");
         let key: JWK = serde_json::from_str(key_str).unwrap();
 
-        let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(URI::String("did:example:foo#key3".to_string()));
+        let issue_options = LinkedDataProofOptions {
+            verification_method: Some(URI::String("did:example:foo#key3".to_string())),
+            ..Default::default()
+        };
         let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = vc
             .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
@@ -2795,7 +2799,7 @@ pub(crate) mod tests {
         println!("{}", serde_json::to_string_pretty(&vc).unwrap());
         let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
-        assert!(verification_result.errors.len() >= 1);
+        assert!(!verification_result.errors.is_empty());
     }
 
     #[async_std::test]
@@ -2814,8 +2818,10 @@ pub(crate) mod tests {
 
         let key: JWK = serde_json::from_str(JWK_JSON).unwrap();
 
-        let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
+        let issue_options = LinkedDataProofOptions {
+            verification_method: Some(URI::String("did:example:foo#key1".to_string())),
+            ..Default::default()
+        };
         let mut context_loader = crate::jsonld::ContextLoader::default();
         let proof = vc
             .generate_proof(&key, &issue_options, &DIDExample, &mut context_loader)
@@ -2845,9 +2851,11 @@ pub(crate) mod tests {
 
         let key: JWK = serde_json::from_str(JWK_JSON).unwrap();
 
-        let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.proof_purpose = Some(ProofPurpose::AssertionMethod);
-        issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
+        let issue_options = LinkedDataProofOptions {
+            proof_purpose: Some(ProofPurpose::AssertionMethod),
+            verification_method: Some(URI::String("did:example:foo#key1".to_string())),
+            ..Default::default()
+        };
         let mut context_loader = crate::jsonld::ContextLoader::default();
         let algorithm = key.get_algorithm().unwrap();
         let public_key = key.to_public();
@@ -2866,7 +2874,7 @@ pub(crate) mod tests {
             #[allow(unreachable_patterns)]
             _ => panic!("Unexpected signing input type"),
         };
-        let sig = crate::jws::sign_bytes(algorithm, &signing_input, &key).unwrap();
+        let sig = crate::jws::sign_bytes(algorithm, signing_input, &key).unwrap();
         let sig_b64 = base64::encode_config(sig, base64::URL_SAFE_NO_PAD);
         let proof = preparation.complete(&sig_b64).await.unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
@@ -2890,7 +2898,7 @@ pub(crate) mod tests {
         println!("{}", serde_json::to_string_pretty(&vc).unwrap());
         let verification_result = vc.verify(None, &DIDExample, &mut context_loader).await;
         println!("{:#?}", verification_result);
-        assert!(verification_result.errors.len() >= 1);
+        assert!(!verification_result.errors.is_empty());
     }
 
     #[async_std::test]
@@ -3003,7 +3011,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         let vc = Credential::from_json(vc_str).unwrap();
         let result = vc.verify(None, &DIDExample, context_loader).await;
         println!("{:#?}", result);
-        assert!(result.errors.len() > 0);
+        assert!(!result.errors.is_empty());
     }
 
     #[async_std::test]
@@ -3068,8 +3076,10 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         // LDP VC in LDP VP
         let vp_str = include_str!("../examples/vp.jsonld");
         let vp = Presentation::from_json(vp_str).unwrap();
-        let mut verify_options = LinkedDataProofOptions::default();
-        verify_options.proof_purpose = Some(ProofPurpose::Authentication);
+        let verify_options = LinkedDataProofOptions {
+            proof_purpose: Some(ProofPurpose::Authentication),
+            ..Default::default()
+        };
         let mut context_loader = crate::jsonld::ContextLoader::default();
         let result = vp
             .verify(
@@ -3197,8 +3207,10 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
         .unwrap();
         let key: JWK = serde_json::from_str(JWK_JSON).unwrap();
 
-        let mut issue_options = LinkedDataProofOptions::default();
-        issue_options.verification_method = Some(URI::String("did:example:foo#key1".to_string()));
+        let issue_options = LinkedDataProofOptions {
+            verification_method: Some(URI::String("did:example:foo#key1".to_string())),
+            ..Default::default()
+        };
         let verify_options = LinkedDataProofOptions {
             checks: Some(vec![Check::Proof, Check::CredentialStatus]),
             ..Default::default()
@@ -3406,18 +3418,16 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             )
             .await;
         println!("{:#?}", vp_verification_result);
-        assert!(vp_verification_result.errors.len() >= 1);
+        assert!(!vp_verification_result.errors.is_empty());
 
         // test that holder is verified
         let mut vp2 = vp.clone();
         vp2.holder = Some(URI::String("did:example:bad".to_string()));
-        assert!(
-            vp2.verify(None, &DIDExample, &mut context_loader)
-                .await
-                .errors
-                .len()
-                > 0
-        );
+        assert!(!vp2
+            .verify(None, &DIDExample, &mut context_loader)
+            .await
+            .errors
+            .is_empty());
 
         // Test JWT VP
         let vp_jwt_issue_options = LinkedDataProofOptions {
@@ -3452,7 +3462,7 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             &mut context_loader,
         )
         .await;
-        assert!(verification_result.errors.len() > 0);
+        assert!(!verification_result.errors.is_empty());
 
         // Test VP with JWT VC
         let vp_jwtvc = Presentation {


### PR DESCRIPTION
Also adds `cargo fmt` to the CI. 

Most warnings were fixed automatically. I verified that no breaking change was introduced by compiling DIDKit.