### PR TITLE
fix json-ld-normalization remote, repo has moved

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/w3c/json-ld-api
 [submodule "json-ld-normalization"]
 	path = json-ld-normalization
-	url = https://github.com/json-ld/rdf-dataset-canonicalization/
+	url = https://github.com/w3c-ccg/rdf-dataset-canonicalization


### PR DESCRIPTION
the [json-ld rdf canonicalisation repo](https://github.com/json-ld/rdf-dataset-canonicalization) has moved, so the GitHub actions are broken, this should fix it