### PR TITLE
Adds FromBytes trait to JWS, adds display requirements for error in UCan

### DIFF
--- a/ssi-jws/src/lib.rs
+++ b/ssi-jws/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub use error::Error;
+use k256::ecdsa::signature::Signature;
 use serde::{Deserialize, Serialize};
 #[cfg(any(feature = "secp256k1", feature = "p256"))]
 use ssi_crypto::hashes::passthrough_digest::PassthroughDigest;

--- a/ssi-ucan/src/lib.rs
+++ b/ssi-ucan/src/lib.rs
@@ -22,7 +22,7 @@ use ssi_jwk::{Algorithm, JWK};
 use ssi_jws::{decode_jws_parts, sign_bytes, split_jws, verify_bytes, Header};
 use ssi_jwt::NumericDate;
 use std::{
-    fmt::Display,
+    fmt::{Debug, Display},
     io::{Read, Seek, Write},
 };
 
@@ -232,7 +232,10 @@ fn match_key_with_vm(key: &JWK, vm: &VerificationMethodMap) -> Result<(), Error>
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum DecodeError<E> {
+pub enum DecodeError<E>
+where
+    E: Debug + Display + serde::ser::StdError,
+{
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     #[error(transparent)]


### PR DESCRIPTION
I had to add a couple of traits to allow the tzprofiles worker to compile. These were the `FromBytes` trait for ssi-jws and the Display / Debug / Error traits for the generic `E` in `DecodeError<E>` enum in ssi-ucan