### PR TITLE
fix aleo feature in genaleojwk example

### DIFF
--- a/examples/genaleojwk.rs
+++ b/examples/genaleojwk.rs
@@ -1,7 +1,7 @@
 #[async_std::main]
 #[ignore] // Skip expensive key generation
 async fn main() -> Result<(), ssi_jwk::Error> {
-    #[cfg(feature = "aleosig")]
+    #[cfg(feature = "aleo")]
     {
         let jwk = ssi::jwk::JWK::generate_aleo()?;
         let writer = std::io::BufWriter::new(std::io::stdout());


### PR DESCRIPTION
`examples/genaleojwk.rs` still used the out of date `aleosig` feature flag. updated it to `also`