### PR TITLE
fix default proof type selection

### DIFF
--- a/ssi-ldp/src/lib.rs
+++ b/ssi-ldp/src/lib.rs
@@ -469,6 +469,8 @@ impl LinkedDataProofs {
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
+        let mut options = options.clone();
+        ensure_or_pick_verification_relationship(&mut options, document, key, resolver).await?;
         // Use type property if present
         let suite = if let Some(ref type_) = options.type_ {
             get_proof_suite(type_)?
@@ -477,8 +479,6 @@ impl LinkedDataProofs {
         else {
             pick_proof_suite(key, options.verification_method.as_ref())?
         };
-        let mut options = options.clone();
-        ensure_or_pick_verification_relationship(&mut options, document, key, resolver).await?;
         suite
             .sign(
                 document,

--- a/ssi-ldp/src/lib.rs
+++ b/ssi-ldp/src/lib.rs
@@ -501,6 +501,9 @@ impl LinkedDataProofs {
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
+        let mut options = options.clone();
+        ensure_or_pick_verification_relationship(&mut options, document, public_key, resolver)
+            .await?;
         // Use type property if present
         let suite = if let Some(ref type_) = options.type_ {
             get_proof_suite(type_)?
@@ -509,9 +512,6 @@ impl LinkedDataProofs {
         else {
             pick_proof_suite(public_key, options.verification_method.as_ref())?
         };
-        let mut options = options.clone();
-        ensure_or_pick_verification_relationship(&mut options, document, public_key, resolver)
-            .await?;
         suite
             .prepare(
                 document,


### PR DESCRIPTION
Since #253 we have had good automatic defaults for `verificationMethod` and `verificationRelationship`, however auto-defaults didn't work for `type` as long as the signature suite was chosen prior to `ensure_or_pick_verification_relationship`, as that fn modifies `options.type_` to be appropriate. 