### PR TITLE
Remove openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,13 @@ exclude = ["json-ld-api/*", "json-ld-normalization/*", "vc-test-suite/*"]
 [features]
 default = ["w3c", "ed25519", "rsa", "ripemd-160", "eip", "tezos"]
 
-w3c = ["ssi-ldp/w3c", "secp256k1", "ed25519", "secp256r1", "rsa"]
+w3c = ["ssi-ldp/w3c", "secp256k1", "ed25519", "secp256r1", "rsa", "secp384r1"]
 ## enable secp256k1 signatures
 secp256k1 = ["ssi-ldp/secp256k1"]
 ## enable secp256r1 (p256) signatures
 secp256r1 = ["ssi-ldp/secp256r1"]
+## enable secp384r1 (p384) signatures
+secp384r1 = ["ssi-ldp/secp384r1"]
 ## enable ed25519 (EdDSA) signatures
 ed25519 = ["ssi-ldp/ed25519", "ssi-jwk/ed25519", "ssi-jws/ed25519"]
 ## enable RSA signatures
@@ -36,8 +38,6 @@ tezos = ["ssi-caips/tezos", "ssi-jwk/tezos", "ssi-jws/tezos", "ssi-ldp/tezos"]
 ## enable LDPs from the Solana Ecosystem
 solana = ["ssi-ldp/solana"]
 
-## Use the OpenSSL crate for crypto operations
-openssl = ["ssi-jwk/openssl", "ssi-jws/openssl", "ssi-ldp/openssl"]
 ## Use the Ring crate for crypto operations
 ring = ["ssi-jwk/ring", "ssi-jws/ring", "ssi-crypto/ring"]
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,6 @@ We are setting up a process to accept contributions. Please feel free to open
 issues or PRs in the interim, but we cannot merge external changes until this
 process is in place.
 
-## Dependencies
-
-```
-clang
-openssl-devel
-```
-
 ## Install
 
 ### Crates.io

--- a/did-ion/Cargo.toml
+++ b/did-ion/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0"
 base64 = "0.12"
 sha2 = "0.10"
 json-patch = "0.2.6"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
 version = "0.11"

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/did-key/"
 default = ["secp256k1", "secp256r1"]
 secp256k1 = ["k256", "ssi-jwk/secp256k1"]
 secp256r1 = ["p256", "ssi-jwk/secp256r1"]
-ssi_p384 = ["ssi-jwk/openssl"]
+secp384r1 = ["ssi-jwk/secp384r1"]
 
 [dependencies]
 ssi-dids = { path = "../ssi-dids", version = "0.1" }

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -169,7 +169,7 @@ impl DIDResolver for DIDKey {
                 None,
             );
         } else if data[0] == DID_KEY_P384_PREFIX[0] && data[1] == DID_KEY_P384_PREFIX[1] {
-            #[cfg(feature = "ssi_p384")]
+            #[cfg(feature = "secp384r1")]
             match ssi_jwk::p384_parse(&data[2..]) {
                 Ok(jwk) => {
                     vm_type = "JsonWebKey2020".to_string();
@@ -178,7 +178,7 @@ impl DIDResolver for DIDKey {
                 }
                 Err(err) => return (ResolutionMetadata::from_error(&err.to_string()), None, None),
             }
-            #[cfg(not(feature = "ssi_p384"))]
+            #[cfg(not(feature = "secp384r1"))]
             return (
                 ResolutionMetadata::from_error("did:key type P-384 not supported"),
                 None,
@@ -338,9 +338,9 @@ impl DIDMethod for DIDKey {
                                 .concat(),
                             )
                     }
-                    #[cfg(feature = "ssi_p384")]
+                    #[cfg(feature = "secp384r1")]
                     "P-384" => {
-                        let pk_bytes = match ssi_jwk::p384_serialize(params) {
+                        let pk_bytes = match ssi_jwk::serialize_p384(params) {
                             Ok(pk) => pk,
                             Err(_err) => return None,
                         };

--- a/did-onion/Cargo.toml
+++ b/did-onion/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/did-onion/"
 ssi-dids = { path = "../ssi-dids", version = "0.1", default-features = false }
 ssi-jwk = { path = "../ssi-jwk", version = "0.1" }
 async-trait = "0.1"
-reqwest = { version = "0.11", features = ["json", "socks"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "socks"] }
 http = "0.2"
 serde_json = "1.0"
 

--- a/did-tezos/Cargo.toml
+++ b/did-tezos/Cargo.toml
@@ -18,7 +18,7 @@ ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, feat
 ssi-jws = { path = "../ssi-jws", version = "0.1", default-features = false }
 ssi-core = { path = "../ssi-core", version = "0.1" }
 chrono = { version = "0.4" }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/did-web/"
 [dependencies]
 ssi-dids = { path = "../ssi-dids", version = "0.1" }
 async-trait = "0.1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 http = "0.2"
 serde_json = "1.0"
 

--- a/did-webkey/Cargo.toml
+++ b/did-webkey/Cargo.toml
@@ -21,7 +21,7 @@ ssi-jwk = { version = "0.1", path = "../ssi-jwk" , default-features = false }
 ssi-ssh = { version = "0.1", path = "../ssi-ssh" }
 anyhow = "1.0.52"
 async-trait = "0.1.52"
-reqwest = { version = "0.11.9", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 hex = "0.4.3"
 http = "0.2.6"
 serde_json = "1.0.75"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,10 @@
 //! `eip`                 |    ✅   | Enable Ethereum related signature suites and cryptographic dependencies.
 //! `tezos`               |    ✅   | Enable Tezos related signature suites and cryptographic dependencies.
 //! `solana`              |         | Enable Solana related signature suites and cryptographic dependencies.
-//! `openssl`             |         | Use OpenSSL (bindings) for P384 functionality.
 //! `ring`                |         | Use the [ring](https://crates.io/crates/ring) crate for RSA, Ed25519, and SHA-256 functionality.
 //! `http-did`            |         | Enable DID resolution tests using [hyper](https://crates.io/crates/hyper) and [tokio](https://crates.io/crates/tokio).
 //! `example-http-issuer` |         | Enable resolving example HTTPS Verifiable credential Issuer URL, for [VC Test Suite](https://github.com/w3c/vc-test-suite/).
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg), feature(doc_cfg))]
 
 // maintain old structure here
 pub use ssi_caips::caip10;

--- a/ssi-dids/Cargo.toml
+++ b/ssi-dids/Cargo.toml
@@ -18,7 +18,7 @@ derive_builder = "0.9"
 bs58 = { version = "0.4", features = ["check"] }
 hex = "0.4"
 multibase = "0.8"
-reqwest = { version = "0.11", features = ["json"], optional = true }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"], optional = true }
 percent-encoding = { version = "2.1", optional = true }
 ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false }
 ssi-json-ld = { path = "../ssi-json-ld", version = "0.1" }

--- a/ssi-jwk/Cargo.toml
+++ b/ssi-jwk/Cargo.toml
@@ -9,6 +9,8 @@ default = ["secp256k1", "secp256r1", "ed25519", "rsa", "eip", "ripemd-160"]
 secp256k1 = ["k256", "rand", "k256/keccak256", "ssi-crypto/secp256k1"]
 ## enable secp256r1 (p256) keys
 secp256r1 = ["p256", "rand"]
+## enable secp384r1 (p384) keys
+secp384r1 = ["p384", "rand"]
 ## enable ed25519 (EdDSA) keys
 ed25519 = ["ed25519-dalek", "rand_old", "getrandom"]
 ## enable RSA keys
@@ -23,7 +25,6 @@ eip = ["ssi-crypto/keccak", "k256/keccak256", "secp256k1"]
 ## enable tezos style key hashing
 tezos = ["blake2b_simd", "secp256k1", "secp256r1", "bs58"]
 
-openssl = ["dep:openssl"]
 ring = ["dep:ring"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -38,7 +39,7 @@ thiserror = "1.0"
 ssi-crypto = { path = "../ssi-crypto", version = "0.1"}
 k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
 p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-openssl = { version = "0.10", optional = true }
+p384 = { version = "0.11", optional = true, features = ["ecdsa"] }
 ring = { version = "0.16", optional = true }
 rsa = { version = "0.6", optional = true }
 rand = { version = "0.8", optional = true }

--- a/ssi-jwk/src/error.rs
+++ b/ssi-jwk/src/error.rs
@@ -2,8 +2,6 @@
 #[cfg(feature = "aleo")]
 use crate::aleo::AleoGeneratePrivateKeyError;
 use base64::DecodeError as Base64Error;
-#[cfg(feature = "openssl")]
-use openssl::error::ErrorStack as OpenSSLErrors;
 #[cfg(feature = "ring")]
 use ring::error::{KeyRejected as KeyRejectedError, Unspecified as RingUnspecified};
 #[cfg(feature = "rsa")]
@@ -67,9 +65,6 @@ pub enum Error {
     #[cfg(feature = "rsa")]
     #[error(transparent)]
     Rsa(#[from] RsaError),
-    #[cfg(feature = "openssl")]
-    #[error(transparent)]
-    OpenSSL(#[from] OpenSSLErrors),
     /// Error encoding ASN.1 data structure.
     #[error(transparent)]
     ASN1Encode(#[from] ASN1EncodeError),
@@ -118,6 +113,9 @@ pub enum Error {
     #[cfg(all(feature = "p256", not(feature = "k256")))]
     #[error(transparent)]
     EC(#[from] p256::elliptic_curve::Error),
+    #[cfg(all(feature = "p384", not(any(feature = "p256", feature = "k256"))))]
+    #[error(transparent)]
+    EC(#[from] p384::elliptic_curve::Error),
     /// Unexpected length for publicKeyMultibase
     #[error("Unexpected length for publicKeyMultibase")]
     MultibaseKeyLength(usize, usize),

--- a/ssi-jwk/src/lib.rs
+++ b/ssi-jwk/src/lib.rs
@@ -319,28 +319,15 @@ impl JWK {
         Ok(JWK::from(Params::EC(ec_params)))
     }
 
-    #[cfg(feature = "openssl")]
+    #[cfg(feature = "secp384r1")]
     pub fn generate_p384() -> Result<JWK, Error> {
-        let group = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP384R1)?;
-        let keypair = openssl::ec::EcKey::generate(&group)?;
-        let form = openssl::ec::PointConversionForm::UNCOMPRESSED;
-        let mut ctx = openssl::bn::BigNumContext::new()?;
-        let sk_bytes = keypair.private_key().to_vec();
-        if sk_bytes.len() != 48 {
-            return Err(Error::InvalidKeyLength(sk_bytes.len()));
-        }
-        let pk_bytes = keypair.public_key().to_bytes(&group, form, &mut ctx)?;
-        if pk_bytes.len() != 97 {
-            return Err(Error::InvalidKeyLength(pk_bytes.len()));
-        }
-        let x = pk_bytes[1..49].to_vec();
-        let y = pk_bytes[49..97].to_vec();
-        Ok(JWK::from(Params::EC(ECParams {
-            curve: Some("P-384".to_string()),
-            x_coordinate: Some(Base64urlUInt(x)),
-            y_coordinate: Some(Base64urlUInt(y)),
-            ecc_private_key: Some(Base64urlUInt(sk_bytes)),
-        })))
+        let mut rng = rand::rngs::OsRng {};
+        let secret_key = p384::SecretKey::random(&mut rng);
+        let sk_bytes = zeroize::Zeroizing::new(secret_key.to_be_bytes().to_vec());
+        let public_key: p384::PublicKey = secret_key.public_key();
+        let mut ec_params = ECParams::try_from(&public_key)?;
+        ec_params.ecc_private_key = Some(Base64urlUInt(sk_bytes.to_vec()));
+        Ok(JWK::from(Params::EC(ec_params)))
     }
 
     #[cfg(feature = "aleo")]
@@ -699,66 +686,6 @@ impl ToASN1 for OctetParams {
     }
 }
 
-#[cfg(feature = "openssl")]
-impl TryFrom<&Base64urlUInt> for openssl::bn::BigNum {
-    type Error = Error;
-    fn try_from(uint: &Base64urlUInt) -> Result<Self, Self::Error> {
-        Ok(Self::from_slice(&uint.0)?)
-    }
-}
-
-#[cfg(feature = "openssl")]
-fn openssl_curve_to_nid(crv: &str) -> Result<openssl::nid::Nid, Error> {
-    use openssl::nid::Nid;
-    let nid = match &crv[..] {
-        "secp256k1" => Nid::SECP256K1,
-        "P-256" => Nid::X9_62_PRIME256V1,
-        "P-384" => Nid::SECP384R1,
-        crv => return Err(Error::CurveNotImplemented(crv.to_string())),
-    };
-    Ok(nid)
-}
-
-#[cfg(feature = "openssl")]
-impl TryFrom<&ECParams> for openssl::ec::EcKey<openssl::pkey::Private> {
-    type Error = Error;
-    fn try_from(params: &ECParams) -> Result<Self, Self::Error> {
-        let curve = params.curve.as_ref().ok_or(Error::MissingCurve)?;
-        let curve_nid = openssl_curve_to_nid(&curve)?;
-        let private_key = params
-            .ecc_private_key
-            .as_ref()
-            .ok_or(Error::MissingPrivateKey)?;
-        let group = openssl::ec::EcGroup::from_curve_name(curve_nid)?;
-        let private_number = openssl::bn::BigNum::try_from(private_key)?;
-        let public_key = openssl::ec::EcKey::<openssl::pkey::Public>::try_from(params)?;
-        let pkey = Self::from_private_components(
-            group.as_ref(),
-            &private_number,
-            public_key.public_key(),
-        )?;
-        Ok(pkey)
-    }
-}
-
-#[cfg(feature = "openssl")]
-impl TryFrom<&ECParams> for openssl::ec::EcKey<openssl::pkey::Public> {
-    type Error = Error;
-    fn try_from(params: &ECParams) -> Result<Self, Self::Error> {
-        let curve = params.curve.as_ref().ok_or(Error::MissingCurve)?;
-        let curve_nid = openssl_curve_to_nid(&curve)?;
-        let group = openssl::ec::EcGroup::from_curve_name(curve_nid)?;
-        let x = openssl::bn::BigNum::try_from(
-            params.x_coordinate.as_ref().ok_or(Error::MissingPoint)?,
-        )?;
-        let y = openssl::bn::BigNum::try_from(
-            params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?,
-        )?;
-        let pk = openssl::ec::EcKey::from_public_key_affine_coordinates(group.as_ref(), &x, &y)?;
-        Ok(pk)
-    }
-}
-
 #[cfg(feature = "rsa")]
 impl From<&Base64urlUInt> for rsa::BigUint {
     fn from(uint: &Base64urlUInt) -> Self {
@@ -949,6 +876,42 @@ pub fn p256_parse(pk_bytes: &[u8]) -> Result<JWK, Error> {
     };
     Ok(jwk)
 }
+
+#[cfg(feature = "secp384r1")]
+pub fn p384_parse(pk_bytes: &[u8]) -> Result<JWK, Error> {
+    let (x, y) = match pk_bytes.len() {
+        33 | 64 | 65 => {
+            use p384::elliptic_curve::{sec1::ToEncodedPoint, PublicKey};
+            let encoded_point =
+                PublicKey::<p384::NistP384>::from_sec1_bytes(pk_bytes)?.to_encoded_point(false);
+            (
+                encoded_point.x().ok_or(Error::MissingPoint)?.to_vec(),
+                encoded_point.y().ok_or(Error::MissingPoint)?.to_vec(),
+            )
+        }
+        _ => {
+            return Err(Error::P384KeyLength(pk_bytes.len()));
+        }
+    };
+    let jwk = JWK {
+        params: Params::EC(ECParams {
+            curve: Some("P-384".to_string()),
+            x_coordinate: Some(Base64urlUInt(x)),
+            y_coordinate: Some(Base64urlUInt(y)),
+            ecc_private_key: None,
+        }),
+        public_key_use: None,
+        key_operations: None,
+        algorithm: None,
+        key_id: None,
+        x509_url: None,
+        x509_certificate_chain: None,
+        x509_thumbprint_sha1: None,
+        x509_thumbprint_sha256: None,
+    };
+    Ok(jwk)
+}
+
 /// Serialize a secp256k1 public key as a 33-byte string with point compression.
 #[cfg(feature = "secp256k1")]
 pub fn serialize_secp256k1(params: &ECParams) -> Result<Vec<u8>, Error> {
@@ -970,6 +933,22 @@ pub fn serialize_p256(params: &ECParams) -> Result<Vec<u8>, Error> {
         &params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?.0,
     );
     let encoded_point = EncodedPoint::<p256::NistP256>::from_affine_coordinates(x, y, true);
+    let pk_compressed_bytes = encoded_point.to_bytes();
+    Ok(pk_compressed_bytes.to_vec())
+}
+
+/// Serialize a P-384 public key as a 33-byte string with point compression.
+#[cfg(feature = "secp384r1")]
+pub fn serialize_p384(params: &ECParams) -> Result<Vec<u8>, Error> {
+    // TODO: check that curve is P-384
+    use p384::elliptic_curve::{sec1::EncodedPoint, FieldBytes};
+    let x = FieldBytes::<p384::NistP384>::from_slice(
+        &params.x_coordinate.as_ref().ok_or(Error::MissingPoint)?.0,
+    );
+    let y = FieldBytes::<p384::NistP384>::from_slice(
+        &params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?.0,
+    );
+    let encoded_point = EncodedPoint::<p384::NistP384>::from_affine_coordinates(x, y, true);
     let pk_compressed_bytes = encoded_point.to_bytes();
     Ok(pk_compressed_bytes.to_vec())
 }
@@ -1022,47 +1001,6 @@ pub fn rsa_x509_pub_parse(pk_bytes: &[u8]) -> Result<JWK, RsaX509PubParseError> 
     Ok(JWK::from(Params::RSA(rsa_params)))
 }
 
-#[cfg(feature = "openssl")]
-/// Parse a P-384 public key
-pub fn p384_parse(pk_bytes: &[u8]) -> Result<JWK, Error> {
-    let (x, y) = match pk_bytes.len() {
-        96 => (pk_bytes[0..48].to_vec(), pk_bytes[48..96].to_vec()),
-        49 | 97 => {
-            let group = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP384R1)?;
-            let mut ctx = openssl::bn::BigNumContext::new()?;
-            let point = openssl::ec::EcPoint::from_bytes(&group, pk_bytes, &mut ctx)?;
-            let form = openssl::ec::PointConversionForm::UNCOMPRESSED;
-            let uncompressed_bytes = point.to_bytes(&group, form, &mut ctx)?;
-            if uncompressed_bytes.len() != 97 {
-                return Err(Error::P384KeyLength(uncompressed_bytes.len()));
-            }
-            (
-                uncompressed_bytes[1..49].to_vec(),
-                uncompressed_bytes[49..97].to_vec(),
-            )
-        }
-        _ => return Err(Error::P384KeyLength(pk_bytes.len())),
-    };
-    let jwk = JWK::from(Params::EC(ECParams {
-        curve: Some("P-384".to_string()),
-        x_coordinate: Some(Base64urlUInt(x)),
-        y_coordinate: Some(Base64urlUInt(y)),
-        ecc_private_key: None,
-    }));
-    Ok(jwk)
-}
-
-/// Serialize a P-384 public key
-#[cfg(feature = "openssl")]
-pub fn p384_serialize(params: &ECParams) -> Result<Vec<u8>, Error> {
-    let public_key = openssl::ec::EcKey::<openssl::pkey::Public>::try_from(params)?;
-    let group = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP384R1)?;
-    let form = openssl::ec::PointConversionForm::COMPRESSED;
-    let mut ctx = openssl::bn::BigNumContext::new()?;
-    let bytes = public_key.public_key().to_bytes(&group, form, &mut ctx)?;
-    Ok(bytes.to_vec())
-}
-
 #[cfg(feature = "secp256k1")]
 impl TryFrom<&ECParams> for k256::SecretKey {
     type Error = Error;
@@ -1093,6 +1031,23 @@ impl TryFrom<&ECParams> for p256::SecretKey {
             .as_ref()
             .ok_or(Error::MissingPrivateKey)?;
         let secret_key = p256::SecretKey::from_be_bytes(&private_key.0)?;
+        Ok(secret_key)
+    }
+}
+
+#[cfg(feature = "secp384r1")]
+impl TryFrom<&ECParams> for p384::SecretKey {
+    type Error = Error;
+    fn try_from(params: &ECParams) -> Result<Self, Self::Error> {
+        let curve = params.curve.as_ref().ok_or(Error::MissingCurve)?;
+        if curve != "P-384" {
+            return Err(Error::CurveNotImplemented(curve.to_string()));
+        }
+        let private_key = params
+            .ecc_private_key
+            .as_ref()
+            .ok_or(Error::MissingPrivateKey)?;
+        let secret_key = p384::SecretKey::from_be_bytes(&private_key.0)?;
         Ok(secret_key)
     }
 }
@@ -1131,6 +1086,23 @@ impl TryFrom<&ECParams> for p256::PublicKey {
     }
 }
 
+#[cfg(feature = "secp384r1")]
+impl TryFrom<&ECParams> for p384::PublicKey {
+    type Error = Error;
+    fn try_from(params: &ECParams) -> Result<Self, Self::Error> {
+        let curve = params.curve.as_ref().ok_or(Error::MissingCurve)?;
+        if curve != "P-384" {
+            return Err(Error::CurveNotImplemented(curve.to_string()));
+        }
+        const EC_UNCOMPRESSED_POINT_TAG: &[u8] = &[0x04];
+        let x = &params.x_coordinate.as_ref().ok_or(Error::MissingPoint)?.0;
+        let y = &params.y_coordinate.as_ref().ok_or(Error::MissingPoint)?.0;
+        let pk_data = [EC_UNCOMPRESSED_POINT_TAG, x.as_slice(), y.as_slice()].concat();
+        let public_key = p384::PublicKey::from_sec1_bytes(&pk_data)?;
+        Ok(public_key)
+    }
+}
+
 #[cfg(feature = "secp256k1")]
 impl TryFrom<&k256::PublicKey> for ECParams {
     type Error = Error;
@@ -1159,6 +1131,23 @@ impl TryFrom<&p256::PublicKey> for ECParams {
         let y = encoded_point.y().ok_or(Error::MissingPoint)?;
         Ok(ECParams {
             curve: Some("P-256".to_string()),
+            x_coordinate: Some(Base64urlUInt(x.to_vec())),
+            y_coordinate: Some(Base64urlUInt(y.to_vec())),
+            ecc_private_key: None,
+        })
+    }
+}
+
+#[cfg(feature = "secp384r1")]
+impl TryFrom<&p384::PublicKey> for ECParams {
+    type Error = Error;
+    fn try_from(pk: &p384::PublicKey) -> Result<Self, Self::Error> {
+        use p384::elliptic_curve::sec1::ToEncodedPoint;
+        let encoded_point = pk.to_encoded_point(false);
+        let x = encoded_point.x().ok_or(Error::MissingPoint)?;
+        let y = encoded_point.y().ok_or(Error::MissingPoint)?;
+        Ok(ECParams {
+            curve: Some("P-384".to_string()),
             x_coordinate: Some(Base64urlUInt(x.to_vec())),
             y_coordinate: Some(Base64urlUInt(y.to_vec())),
             ecc_private_key: None,
@@ -1236,7 +1225,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "openssl")]
+    #[cfg(feature = "secp384r1")]
     fn p384_generate() {
         let _jwk = JWK::generate_p384().unwrap();
     }

--- a/ssi-jws/Cargo.toml
+++ b/ssi-jws/Cargo.toml
@@ -10,6 +10,8 @@ default = ["secp256k1", "secp256r1", "ed25519", "rsa", "eip", "ssi-jwk/ripemd-16
 secp256k1 = ["ssi-jwk/secp256k1", "k256/keccak256", "ssi-crypto/secp256k1", "blake2", "dep:sha2"]
 ## enable secp256r1 (p256) signatures
 secp256r1 = ["ssi-jwk/secp256r1", "p256", "blake2"]
+## enable secp384r1 (p384) signatures
+secp384r1 = ["ssi-jwk/secp384r1", "p384"]
 ## enable ed25519 (EdDSA) signatures
 ed25519 = ["ssi-jwk/ed25519", "ed25519-dalek", "rand", "blake2"]
 ## enable RSA signatures
@@ -23,8 +25,6 @@ eip = ["ssi-jwk/eip", "ssi-crypto/keccak", "k256/keccak256", "secp256k1"]
 tezos = ["ssi-jwk/tezos", "secp256k1", "secp256r1", "ed25519"]
 
 ## Use the Ring crate for crypto operations
-openssl = ["ssi-jwk/openssl", "dep:openssl"]
-## Use the OpenSSL crate for crypto operations
 ring = ["ssi-jwk/ring", "dep:ring", "rand", "blake2"]
 
 [dependencies]
@@ -34,13 +34,13 @@ serde_json = "1.0"
 base64 = "0.12"
 k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
 p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
+p384 = { version = "0.11", optional = true, features = ["ecdsa"] }
 # blake2b_simd = { version = "0.5", optional = true }
 blake2 = { version = "0.10", optional = true }
 ed25519-dalek = { version = "1", optional = true }
 sha2 = { version = "0.10", optional = true }
 rsa = { version = "0.6", optional = true }
 rand = { version = "0.8", optional = true }
-openssl = { version = "0.10", optional = true }
 ring = { version = "0.16", optional = true }
 ssi-crypto = { path = "../ssi-crypto", version = "0.1"}
 ssi-jwk = { path = "../ssi-jwk", version = "0.1"}

--- a/ssi-jws/src/error.rs
+++ b/ssi-jws/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     #[cfg(all(feature = "p256", not(feature = "k256")))]
     #[error(transparent)]
     CryptoErr(#[from] p256::ecdsa::Error),
+    #[cfg(all(feature = "p384", not(any(feature = "k256", feature = "p256"))))]
+    #[error(transparent)]
+    CryptoErr(#[from] p384::ecdsa::Error),
     #[error(transparent)]
     JWK(#[from] ssi_jwk::Error),
     #[error(transparent)]
@@ -43,9 +46,6 @@ pub enum Error {
     UnexpectedSignatureLength(usize, usize),
     #[error("Invalid signature")]
     InvalidSignature,
-    #[cfg(feature = "openssl")]
-    #[error(transparent)]
-    OpenSSL(#[from] openssl::error::ErrorStack),
 }
 
 #[cfg(feature = "ring")]

--- a/ssi-ldp/Cargo.toml
+++ b/ssi-ldp/Cargo.toml
@@ -11,6 +11,7 @@ default = ["eip", "tezos", "w3c", "solana"]
 w3c = ["secp256k1", "secp256r1", "rsa", "ed25519"]
 secp256k1 = ["ssi-jws/secp256k1", "k256"]
 secp256r1 = ["ssi-jws/secp256r1", "p256"]
+secp384r1 = ["ssi-jws/secp384r1"]
 ed25519 = ["ssi-jws/ed25519"]
 rsa = ["ssi-jws/rsa"]
 ## enable the EIP-defined LDPs: EIP712
@@ -21,9 +22,6 @@ tezos = ["ssi-tzkey", "ssi-jws/tezos", "ssi-caips/tezos", "secp256k1", "secp256r
 aleo = ["ssi-jws/aleo", "ssi-caips/aleo"]
 ## enable LDPs from the Solana Ecosystem
 solana = []
-
-## Use the OpenSSL crate for crypto operations and P384
-openssl = ["ssi-jws/openssl"]
 
 example-http-issuer = []
 

--- a/ssi-ldp/src/lib.rs
+++ b/ssi-ldp/src/lib.rs
@@ -176,7 +176,7 @@ fn pick_proof_suite<'a, 'b>(
     Ok(match algorithm {
         Algorithm::RS256 => feature_gate!("rsa", RsaSignature2018),
         Algorithm::PS256 => feature_gate!("rsa", JsonWebSignature2020),
-        Algorithm::ES384 => feature_gate!("openssl", JsonWebSignature2020),
+        Algorithm::ES384 => feature_gate!("secp384r1", JsonWebSignature2020),
         Algorithm::AleoTestnet1Signature => feature_gate!("aleo", AleoSignature2021),
         Algorithm::EdDSA | Algorithm::EdBlake2b => match verification_method {
             Some(URI::String(ref vm))

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "1.0"
 flate2 = "1.0"
 bitvec = "0.20"
 base64 = "0.12"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 cacaos = { version = "0.5.1" }
 siwe-recap = { version = "0.1" }
 libipld = { version = "0.14", default-features = false, features = ["dag-cbor", "derive"]}


### PR DESCRIPTION
It was only used for:
- `secp384r1`, which has been replaced with the new-ish crate by RustCrypto; and
- `reqwest`, which now used `rustls`.

Checks done:
- made sure no leftover compilation condition was left over with `cargo +nightly  check --workspace --tests --all-features -Z check-cfg=features,names,values`; and
- `cargo tree` to see if `openssl-sys` disapeared. 

---

The reasoning behind removing openssl is to continue to clear up our dependencies and put the crypto-backend goal on the back-burner. Ideally we would keep it and extend its use for other curves but for now it's simpler to focus on RustCrypto dependencies.