### PR TITLE
Use enum for proof suites

### DIFF
--- a/did-ethr/src/lib.rs
+++ b/did-ethr/src/lib.rs
@@ -324,6 +324,7 @@ mod tests {
     use serde_json::json;
     use ssi_dids::did_resolve::ResolutionInputMetadata;
     use ssi_jwk::JWK;
+    use ssi_ldp::{ProofSuite, ProofSuiteType};
 
     #[test]
     fn jwk_to_did_ethr() {
@@ -471,8 +472,7 @@ mod tests {
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let other_key = JWK::generate_ed25519().unwrap();
-        use ssi_ldp::ProofSuite;
-        let proof_bad = ssi_ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
+        let proof_bad = ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
             .sign(
                 &vc_no_proof,
                 &issue_options,

--- a/did-ion/src/lib.rs
+++ b/did-ion/src/lib.rs
@@ -7,6 +7,7 @@ use sidetree::{is_secp256k1, Sidetree, SidetreeClient, SidetreeError};
 
 pub const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
+#[derive(Clone)]
 pub struct ION;
 
 /// did:ion Method

--- a/did-ion/src/sidetree.rs
+++ b/did-ion/src/sidetree.rs
@@ -1404,6 +1404,7 @@ impl<S: Sidetree> HTTPSidetreeDIDResolver<S> {
 }
 
 /// Sidetree DID Method client implementation
+#[derive(Clone)]
 pub struct SidetreeClient<S: Sidetree> {
     pub resolver: Option<HTTPSidetreeDIDResolver<S>>,
     pub endpoint: Option<String>,

--- a/did-onion/src/lib.rs
+++ b/did-onion/src/lib.rs
@@ -14,6 +14,7 @@ const TOR_SOCKS_PORT: usize = 9050;
 ///
 /// [Specification](https://blockchaincommons.github.io/did-method-onion/)
 #[non_exhaustive]
+#[derive(Clone)]
 pub struct DIDOnion {
     pub proxy_url: String,
 }

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -679,7 +679,7 @@ mod tests {
     use serde_json::{from_str, from_value, json};
     use ssi_core::one_or_many::OneOrMany;
     use ssi_jwk::Algorithm;
-    use ssi_ldp::{Proof, ProofSuite};
+    use ssi_ldp::{Proof, ProofSuite, ProofSuiteType};
 
     fn test_generate(jwk_value: Value, type_: &str, did_expected: &str) {
         let jwk: JWK = from_value(jwk_value).unwrap();
@@ -1101,7 +1101,7 @@ mod tests {
         eprintln!("sig: {}", sig);
 
         // Complete issuance
-        let proof = proof_suite.complete(prep, &sig).await.unwrap();
+        let proof = proof_suite.complete(&prep, &sig).await.unwrap();
         println!("{}", serde_json::to_string_pretty(&proof).unwrap());
         vc.add_proof(proof);
         vc.validate().unwrap();
@@ -1178,7 +1178,7 @@ mod tests {
             .await
             .unwrap();
         let sig = sign_tezos(&prep, algorithm, &key);
-        let vp_proof = proof_suite.complete(prep, &sig).await.unwrap();
+        let vp_proof = proof_suite.complete(&prep, &sig).await.unwrap();
         vp.add_proof(vp_proof);
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
         vp.validate().unwrap();
@@ -1250,7 +1250,7 @@ mod tests {
             other_key_secp256k1.clone(),
             "eip155",
             "#blockchainAccountId",
-            &ssi_ldp::EcdsaSecp256k1RecoverySignature2020,
+            &ProofSuiteType::EcdsaSecp256k1RecoverySignature2020,
             None,
             None,
         )
@@ -1262,7 +1262,7 @@ mod tests {
             other_key_secp256k1.clone(),
             "eip155",
             "#blockchainAccountId",
-            &ssi_ldp::Eip712Signature2021,
+            &ProofSuiteType::Eip712Signature2021,
             None,
             None,
         )
@@ -1274,7 +1274,7 @@ mod tests {
             other_key_secp256k1.clone(),
             "eip155",
             "#blockchainAccountId",
-            &ssi_ldp::EthereumPersonalSignature2021,
+            &ProofSuiteType::EthereumPersonalSignature2021,
             None,
             None,
         )
@@ -1370,7 +1370,7 @@ mod tests {
             other_key_secp256k1.clone(),
             "eip155",
             "#blockchainAccountId",
-            &ssi_ldp::EthereumEip712Signature2021,
+            &ProofSuiteType::EthereumEip712Signature2021,
             Some(eip712_domain),
             Some(vp_eip712_domain),
         )
@@ -1382,7 +1382,7 @@ mod tests {
             other_key_secp256k1.clone(),
             "eip155",
             "#blockchainAccountId",
-            &ssi_ldp::Eip712Signature2021,
+            &ProofSuiteType::Eip712Signature2021,
             None,
             None,
         )
@@ -1396,7 +1396,7 @@ mod tests {
             other_key_ed25519.clone(),
             "tz",
             "#blockchainAccountId",
-            &ssi_ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021,
+            &ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021,
             None,
             None,
         )
@@ -1423,7 +1423,7 @@ mod tests {
             other_key_p256.clone(),
             "tz",
             "#blockchainAccountId",
-            &ssi_ldp::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021,
+            &ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021,
             None,
             None,
         )
@@ -1437,7 +1437,7 @@ mod tests {
             other_key_ed25519.clone(),
             "sol",
             "#controller",
-            &ssi_ldp::Ed25519Signature2018,
+            &ProofSuiteType::Ed25519Signature2018,
             None,
             None,
         )
@@ -1461,7 +1461,7 @@ mod tests {
             other_key_secp256k1.clone(),
             "btc",
             "#blockchainAccountId",
-            &ssi_ldp::EcdsaSecp256k1RecoverySignature2020,
+            &ProofSuiteType::EcdsaSecp256k1RecoverySignature2020,
             None,
             None,
         )
@@ -1473,7 +1473,7 @@ mod tests {
             other_key_secp256k1.clone(),
             "doge",
             "#blockchainAccountId",
-            &ssi_ldp::EcdsaSecp256k1RecoverySignature2020,
+            &ProofSuiteType::EcdsaSecp256k1RecoverySignature2020,
             None,
             None,
         )
@@ -1488,7 +1488,7 @@ mod tests {
             other_key_ed25519.clone(),
             "tz",
             "#TezosMethod2021",
-            &ssi_ldp::TezosSignature2021,
+            &ProofSuiteType::TezosSignature2021,
         )
         .await;
         key_ed25519.algorithm = Some(Algorithm::EdDSA);
@@ -1516,7 +1516,7 @@ mod tests {
             other_key_p256.clone(),
             "tz",
             "#TezosMethod2021",
-            &ssi_ldp::TezosSignature2021,
+            &ProofSuiteType::TezosSignature2021,
         )
         .await;
         key_p256.algorithm = Some(Algorithm::ES256);

--- a/did-sol/src/lib.rs
+++ b/did-sol/src/lib.rs
@@ -203,6 +203,7 @@ mod tests {
     use serde_json::json;
     use ssi_dids::did_resolve::ResolutionInputMetadata;
     use ssi_jwk::JWK;
+    use ssi_ldp::{ProofSuite, ProofSuiteType};
 
     #[test]
     fn key_to_did_sol() {
@@ -299,8 +300,7 @@ mod tests {
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let other_key = JWK::generate_ed25519().unwrap();
-        use ssi_ldp::ProofSuite;
-        let proof_bad = ssi_ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
+        let proof_bad = ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
             .sign(
                 &vc_no_proof,
                 &issue_options,

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -25,7 +25,7 @@ mod explorer;
 /// did:tz DID Method
 ///
 /// [Specification](https://github.com/spruceid/did-tezos/)
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct DIDTz {
     tzkt_url: Option<String>,
 }

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -563,6 +563,7 @@ mod tests {
     use ssi_dids::did_resolve::ResolutionInputMetadata;
     use ssi_dids::ServiceEndpoint;
     use ssi_jws::encode_sign;
+    use ssi_ldp::{ProofSuite, ProofSuiteType};
     use std::collections::BTreeMap as Map;
 
     const TZ1: &str = "did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x";
@@ -856,8 +857,7 @@ mod tests {
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let other_key = JWK::generate_ed25519().unwrap();
-        use ssi_ldp::ProofSuite;
-        let proof_bad = ssi_ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
+        let proof_bad = ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
             .sign(
                 &vc_no_proof,
                 &issue_options,
@@ -1052,8 +1052,7 @@ mod tests {
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let other_key = JWK::generate_ed25519().unwrap();
-        use ssi_ldp::ProofSuite;
-        let proof_bad = ssi_ldp::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
+        let proof_bad = ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
             .sign(
                 &vc_no_proof,
                 &issue_options,
@@ -1520,8 +1519,7 @@ mod tests {
         // Check that proof JWK must match proof verificationMethod
         let mut vc_wrong_key = vc_no_proof.clone();
         let other_key = JWK::generate_p256().unwrap();
-        use ssi_ldp::ProofSuite;
-        let proof_bad = ssi_ldp::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021
+        let proof_bad = ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021
             .sign(
                 &vc_no_proof,
                 &issue_options,

--- a/examples/zcap_invocation.jsonld
+++ b/examples/zcap_invocation.jsonld
@@ -3,7 +3,7 @@
  "id": "urn:uuid:ad86cb2c-e9db-434a-beae-71b82120a8a4",
  "capabilityAction": "Drive",
  "proof": {
-    "type": "RsaSignature2016",
+    "type": "Ed25519Signature2018",
     "proofPurpose": "capabilityInvocation",
     "capability": "https://whatacar.example/a-fancy-car/proc/7a397d7b",
     "created": "2016-02-08T17:13:48Z",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,38 +20,56 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg), feature(doc_cfg))]
 
 // maintain old structure here
+pub use ssi_caips as caips;
+#[deprecated = "Use ssi::caips::caip10"]
 pub use ssi_caips::caip10;
+#[deprecated = "Use ssi::caips::caip2"]
 pub use ssi_caips::caip2;
+pub use ssi_core as core;
+#[deprecated = "Use ssi::core::one_or_many"]
 pub use ssi_core::one_or_many;
+pub use ssi_crypto as crypto;
+#[deprecated = "Use ssi::crypto::hashes"]
 pub use ssi_crypto::hashes as hash;
 #[cfg(feature = "eip")]
+#[deprecated = "Use ssi::crypto::hashes::keccak"]
 pub use ssi_crypto::hashes::keccak;
 #[cfg(feature = "bbs")]
+#[deprecated = "Use ssi::crypto::signatures::bbs"]
 pub use ssi_crypto::signatures::bbs;
 pub use ssi_dids as did;
+#[deprecated = "Use ssi::did::did_resolve"]
 pub use ssi_dids::did_resolve;
 pub use ssi_json_ld as jsonld;
+#[deprecated = "Use ssi::jsonld::rdf"]
 pub use ssi_json_ld::rdf;
+#[deprecated = "Use ssi::jsonld::urdna2015"]
 pub use ssi_json_ld::urdna2015;
 pub use ssi_jwk as jwk;
+#[cfg(feature = "aleo")]
+#[deprecated = "Use ssi::jwk::aleo"]
+pub use ssi_jwk::aleo;
+#[deprecated = "Use ssi::jwk::blakesig"]
 pub use ssi_jwk::blakesig;
+#[deprecated = "Use ssi::jwk::der"]
 pub use ssi_jwk::der;
 #[cfg(feature = "ripemd-160")]
+#[deprecated = "Use ssi::jwk::ripemd160"]
 pub use ssi_jwk::ripemd160 as ripemd;
 pub use ssi_jws as jws;
 pub use ssi_jwt as jwt;
 pub use ssi_ldp as ldp;
 #[cfg(feature = "eip")]
+#[deprecated = "Use ssi::ldp::eip712"]
 pub use ssi_ldp::eip712;
+#[deprecated = "Use ssi::ldp::soltx"]
 pub use ssi_ldp::soltx;
 pub use ssi_ssh as ssh;
 pub use ssi_tzkey as tzkey;
 pub use ssi_ucan as ucan;
 pub use ssi_vc as vc;
+#[deprecated = "Use ssi::vc::revocation"]
+pub use ssi_vc::revocation;
 pub use ssi_zcap_ld as zcap;
-pub use vc::revocation;
-
-#[cfg(feature = "aleo")]
-pub use ssi_jwk::aleo;
 
 pub const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));

--- a/ssi-dids/src/lib.rs
+++ b/ssi-dids/src/lib.rs
@@ -590,7 +590,7 @@ pub enum DIDMethodError {
 /// Registries](https://www.w3.org/TR/did-spec-registries/#did-methods).
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait DIDMethod: Sync {
+pub trait DIDMethod: Sync + Send {
     /// Get the DID method's name.
     ///
     /// `method-name` in [DID Syntax](https://w3c.github.io/did-core/#did-syntax).

--- a/ssi-jws/src/lib.rs
+++ b/ssi-jws/src/lib.rs
@@ -546,8 +546,8 @@ pub fn prepare_detached_unencoded_payload(
     Ok((header, signing_input))
 }
 
-pub fn complete_sign_unencoded_payload(header: Header, sig_b64: &str) -> Result<String, Error> {
-    let header_b64 = base64_encode_json(&header)?;
+pub fn complete_sign_unencoded_payload(header: &Header, sig_b64: &str) -> Result<String, Error> {
+    let header_b64 = base64_encode_json(header)?;
     let jws = header_b64 + ".." + sig_b64;
     Ok(jws)
 }

--- a/ssi-ldp/Cargo.toml
+++ b/ssi-ldp/Cargo.toml
@@ -24,6 +24,7 @@ aleo = ["ssi-jws/aleo", "ssi-caips/aleo"]
 solana = []
 
 example-http-issuer = []
+test = []
 
 [dependencies]
 thiserror = "1.0"

--- a/ssi-ldp/src/error.rs
+++ b/ssi-ldp/src/error.rs
@@ -26,8 +26,8 @@ pub enum Error {
     UnsupportedNonDIDIssuer(String),
     #[error("Missing proof purpose")]
     MissingProofPurpose,
-    #[error("Linked Data Proof type not implemented")]
-    ProofTypeNotImplemented,
+    #[error("Linked Data Proof type not implemented or not enabled by feature")]
+    ProofTypeNotSupported,
     #[error("Unsupported curve")]
     UnsupportedCurve,
     #[error("Missing type")]

--- a/ssi-ldp/src/suites/eip.rs
+++ b/ssi-ldp/src/suites/eip.rs
@@ -1,6 +1,5 @@
 use super::super::*;
 use crate::eip712::TypedData;
-use async_trait::async_trait;
 use serde_json::Value;
 use ssi_dids::did_resolve::{resolve_vm, DIDResolver};
 use ssi_json_ld::ContextLoader;
@@ -8,14 +7,10 @@ use ssi_jwk::{ECParams, Params as JWKParams, JWK};
 use std::collections::HashMap as Map;
 
 pub struct Eip712Signature2021;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for Eip712Signature2021 {
-    async fn sign(
-        &self,
+impl Eip712Signature2021 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -23,7 +18,7 @@ impl ProofSuite for Eip712Signature2021 {
         use k256::ecdsa::signature::Signer;
         let mut proof = Proof {
             context: serde_json::json!([EIP712VM_CONTEXT.clone()]),
-            ..Proof::new("Eip712Signature2021")
+            ..Proof::new(ProofSuiteType::Eip712Signature2021)
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
@@ -46,18 +41,15 @@ impl ProofSuite for Eip712Signature2021 {
         Ok(proof)
     }
 
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
-        _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         let proof = Proof {
             context: serde_json::json!([EIP712VM_CONTEXT.clone()]),
-            ..Proof::new("Eip712Signature2021")
+            ..Proof::new(ProofSuiteType::Eip712Signature2021)
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
@@ -70,18 +62,7 @@ impl ProofSuite for Eip712Signature2021 {
         })
     }
 
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        let mut proof = preparation.proof;
-        proof.proof_value = Some(signature.to_string());
-        Ok(proof)
-    }
-
-    async fn verify(
-        &self,
+    pub(crate) async fn verify(
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
@@ -138,15 +119,10 @@ impl ProofSuite for Eip712Signature2021 {
 }
 
 pub struct EthereumEip712Signature2021;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for EthereumEip712Signature2021 {
-    async fn sign(
-        &self,
+impl EthereumEip712Signature2021 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
-        _context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
@@ -161,7 +137,7 @@ impl ProofSuite for EthereumEip712Signature2021 {
         }
         let mut proof = Proof {
             context: serde_json::json!(ssi_json_ld::EIP712SIG_V1_CONTEXT),
-            ..Proof::new("EthereumEip712Signature2021")
+            ..Proof::new(ProofSuiteType::EthereumEip712Signature2021)
                 .with_options(options)
                 .with_properties(props)
         };
@@ -183,13 +159,9 @@ impl ProofSuite for EthereumEip712Signature2021 {
         Ok(proof)
     }
 
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
-        _context_loader: &mut ContextLoader,
-        _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         let mut props = extra_proof_properties.clone();
@@ -201,7 +173,7 @@ impl ProofSuite for EthereumEip712Signature2021 {
         }
         let proof = Proof {
             context: serde_json::json!(ssi_json_ld::EIP712SIG_V1_CONTEXT),
-            ..Proof::new("EthereumEip712Signature2021")
+            ..Proof::new(ProofSuiteType::EthereumEip712Signature2021)
                 .with_options(options)
                 .with_properties(props)
         };
@@ -213,22 +185,10 @@ impl ProofSuite for EthereumEip712Signature2021 {
         })
     }
 
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        let mut proof = preparation.proof;
-        proof.proof_value = Some(signature.to_string());
-        Ok(proof)
-    }
-
-    async fn verify(
-        &self,
+    pub(crate) async fn verify(
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
-        _context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let sig_hex = proof
             .proof_value
@@ -278,14 +238,10 @@ impl ProofSuite for EthereumEip712Signature2021 {
 }
 
 pub struct EthereumPersonalSignature2021;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for EthereumPersonalSignature2021 {
-    async fn sign(
-        &self,
+impl EthereumPersonalSignature2021 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -293,7 +249,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         use k256::ecdsa::signature::Signer;
         let mut proof = Proof {
             context: serde_json::json!([EPSIG_CONTEXT.clone()]),
-            ..Proof::new("EthereumPersonalSignature2021")
+            ..Proof::new(ProofSuiteType::EthereumPersonalSignature2021)
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
@@ -316,18 +272,15 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         Ok(proof)
     }
 
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
-        _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         let proof = Proof {
             context: serde_json::json!([EPSIG_CONTEXT.clone()]),
-            ..Proof::new("EthereumPersonalSignature2021")
+            ..Proof::new(ProofSuiteType::EthereumPersonalSignature2021)
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
@@ -342,18 +295,7 @@ impl ProofSuite for EthereumPersonalSignature2021 {
         })
     }
 
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        let mut proof = preparation.proof;
-        proof.proof_value = Some(signature.to_string());
-        Ok(proof)
-    }
-
-    async fn verify(
-        &self,
+    pub(crate) async fn verify(
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,

--- a/ssi-ldp/src/suites/mod.rs
+++ b/ssi-ldp/src/suites/mod.rs
@@ -18,7 +18,7 @@ use eip::*;
 #[cfg(feature = "secp256k1")]
 use secp256k1::*;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 #[cfg(feature = "solana")]
 use solana::*;
 use ssi_core::uri::URI;
@@ -28,6 +28,7 @@ use ssi_jwk::{Algorithm, JWK};
 use ssi_jws::VerificationWarnings;
 #[cfg(feature = "tezos")]
 use tezos::*;
+use thiserror::Error;
 #[cfg(feature = "w3c")]
 use w3c::*;
 
@@ -37,7 +38,7 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use std::collections::HashMap as Map;
+use std::{collections::HashMap as Map, str::FromStr};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum ProofSuiteType {
@@ -82,6 +83,17 @@ pub enum ProofSuiteType {
     #[cfg(feature = "test")]
     #[serde(rename = "ex:AnonCredDerivedCredentialv1")]
     AnonCredDerivedCredentialv1,
+}
+
+// #[derive(Debug, Error)]
+// #[error(transparent)]
+// pub struct ParseProofSuiteError(#[from] ErrorRepr);
+impl FromStr for ProofSuiteType {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_value(json!(format!("{s}")))
+    }
 }
 
 pub enum SignatureType {

--- a/ssi-ldp/src/suites/mod.rs
+++ b/ssi-ldp/src/suites/mod.rs
@@ -28,7 +28,6 @@ use ssi_jwk::{Algorithm, JWK};
 use ssi_jws::VerificationWarnings;
 #[cfg(feature = "tezos")]
 use tezos::*;
-use thiserror::Error;
 #[cfg(feature = "w3c")]
 use w3c::*;
 

--- a/ssi-ldp/src/suites/mod.rs
+++ b/ssi-ldp/src/suites/mod.rs
@@ -74,6 +74,13 @@ pub enum ProofSuiteType {
     #[cfg(feature = "secp256r1")]
     EcdsaSecp256r1Signature2019,
     CLSignature2019,
+    #[cfg(feature = "test")]
+    NonJwsProof,
+    #[cfg(feature = "test")]
+    #[serde(rename = "ex:AnonCredPresentationProofv1")]
+    AnonCredPresentationProofv1,
+    #[serde(rename = "ex:AnonCredDerivedCredentialv1")]
+    AnonCredDerivedCredentialv1,
 }
 
 pub enum SignatureType {
@@ -85,42 +92,42 @@ impl ProofSuiteType {
     pub fn signature_type(&self) -> SignatureType {
         match self {
             #[cfg(feature = "rsa")]
-            ProofSuiteType::RsaSignature2018 => SignatureType::JWS,
+            Self::RsaSignature2018 => SignatureType::JWS,
             #[cfg(feature = "ed25519")]
-            ProofSuiteType::Ed25519Signature2018 => SignatureType::JWS,
+            Self::Ed25519Signature2018 => SignatureType::JWS,
             #[cfg(feature = "ed25519")]
-            ProofSuiteType::Ed25519Signature2020 => SignatureType::LD,
+            Self::Ed25519Signature2020 => SignatureType::LD,
             #[cfg(feature = "tezos")]
-            ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
-                SignatureType::JWS
-            }
+            Self::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => SignatureType::JWS,
             #[cfg(feature = "tezos")]
-            ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
-                SignatureType::JWS
-            }
+            Self::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => SignatureType::JWS,
             #[cfg(feature = "secp256k1")]
-            ProofSuiteType::EcdsaSecp256k1Signature2019 => SignatureType::JWS,
+            Self::EcdsaSecp256k1Signature2019 => SignatureType::JWS,
             #[cfg(feature = "secp256k1")]
-            ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => SignatureType::JWS,
+            Self::EcdsaSecp256k1RecoverySignature2020 => SignatureType::JWS,
             #[cfg(feature = "eip")]
-            ProofSuiteType::Eip712Signature2021 => SignatureType::LD,
+            Self::Eip712Signature2021 => SignatureType::LD,
             #[cfg(feature = "eip")]
-            ProofSuiteType::EthereumPersonalSignature2021 => SignatureType::LD,
+            Self::EthereumPersonalSignature2021 => SignatureType::LD,
             #[cfg(feature = "eip")]
-            ProofSuiteType::EthereumEip712Signature2021 => SignatureType::LD,
+            Self::EthereumEip712Signature2021 => SignatureType::LD,
             #[cfg(feature = "tezos")]
-            ProofSuiteType::TezosSignature2021 => SignatureType::LD,
+            Self::TezosSignature2021 => SignatureType::LD,
             #[cfg(feature = "tezos")]
-            ProofSuiteType::TezosJcsSignature2021 => SignatureType::LD,
+            Self::TezosJcsSignature2021 => SignatureType::LD,
             #[cfg(feature = "solana")]
-            ProofSuiteType::SolanaSignature2021 => SignatureType::LD,
+            Self::SolanaSignature2021 => SignatureType::LD,
             #[cfg(feature = "aleo")]
-            ProofSuiteType::AleoSignature2021 => SignatureType::LD,
+            Self::AleoSignature2021 => SignatureType::LD,
             #[cfg(feature = "w3c")]
-            ProofSuiteType::JsonWebSignature2020 => SignatureType::JWS,
+            Self::JsonWebSignature2020 => SignatureType::JWS,
             #[cfg(feature = "secp256r1")]
-            ProofSuiteType::EcdsaSecp256r1Signature2019 => SignatureType::JWS,
-            ProofSuiteType::CLSignature2019 => todo!(),
+            Self::EcdsaSecp256r1Signature2019 => SignatureType::JWS,
+            Self::CLSignature2019 => todo!(),
+            #[cfg(feature = "test")]
+            Self::NonJwsProof
+            | Self::AnonCredPresentationProofv1
+            | Self::AnonCredDerivedCredentialv1 => todo!(),
         }
     }
 
@@ -128,44 +135,47 @@ impl ProofSuiteType {
     pub(crate) fn associated_contexts(&self) -> &[&str] {
         match self {
 #[cfg(feature = "rsa")]
-ProofSuiteType::RsaSignature2018 => &["https://w3id.org/security#RsaSignature2018"],
+Self::RsaSignature2018 => &["https://w3id.org/security#RsaSignature2018"],
 #[cfg(feature = "ed25519")]
-ProofSuiteType::Ed25519Signature2018 => &["https://w3id.org/security#Ed25519Signature2018"],
+Self::Ed25519Signature2018 => &["https://w3id.org/security#Ed25519Signature2018"],
 #[cfg(feature = "ed25519")]
-ProofSuiteType::Ed25519Signature2020 => &["https://w3id.org/security#Ed25519Signature2020"],
+Self::Ed25519Signature2020 => &["https://w3id.org/security#Ed25519Signature2020"],
 #[cfg(feature = "tezos")]
-ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+Self::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
     &["https://w3id.org/security#Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021"]
 }
 #[cfg(feature = "tezos")]
-ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+Self::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
     &["https://w3id.org/security#P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021"]
 }
 #[cfg(feature = "secp256k1")]
-ProofSuiteType::EcdsaSecp256k1Signature2019 => &["https://w3id.org/security#EcdsaSecp256k1Signature2019"],
+Self::EcdsaSecp256k1Signature2019 => &["https://w3id.org/security#EcdsaSecp256k1Signature2019"],
 #[cfg(feature = "secp256k1")]
-ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => {
+Self::EcdsaSecp256k1RecoverySignature2020 => {
     &["https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoverySignature2020"]
 }
 #[cfg(feature = "eip")]
-ProofSuiteType::Eip712Signature2021 => &["https://w3id.org/security#Eip712Signature2021"],
+Self::Eip712Signature2021 => &["https://w3id.org/security#Eip712Signature2021"],
 #[cfg(feature = "eip")]
-ProofSuiteType::EthereumPersonalSignature2021 => &["https://w3id.org/security#EthereumPersonalSignature2021", "https://demo.spruceid.com/ld/epsig/EthereumPersonalSignature2021"],
+Self::EthereumPersonalSignature2021 => &["https://w3id.org/security#EthereumPersonalSignature2021", "https://demo.spruceid.com/ld/epsig/EthereumPersonalSignature2021"],
 #[cfg(feature = "eip")]
-ProofSuiteType::EthereumEip712Signature2021 => &[],
+Self::EthereumEip712Signature2021 => &[],
 #[cfg(feature = "tezos")]
-ProofSuiteType::TezosSignature2021 => &["https://w3id.org/security#TezosSignature2021"],
+Self::TezosSignature2021 => &["https://w3id.org/security#TezosSignature2021"],
 #[cfg(feature = "tezos")]
-ProofSuiteType::TezosJcsSignature2021 => &["https://w3id.org/security#TezosJcsSignature2021"],
+Self::TezosJcsSignature2021 => &["https://w3id.org/security#TezosJcsSignature2021"],
 #[cfg(feature = "solana")]
-ProofSuiteType::SolanaSignature2021 => &["https://w3id.org/security#SolanaSignature2021"],
+Self::SolanaSignature2021 => &["https://w3id.org/security#SolanaSignature2021"],
 #[cfg(feature = "aleo")]
-ProofSuiteType::AleoSignature2021 => &["https://w3id.org/security#AleoSignature2021"],
+Self::AleoSignature2021 => &["https://w3id.org/security#AleoSignature2021"],
 #[cfg(feature = "w3c")]
-ProofSuiteType::JsonWebSignature2020 => &["https://w3id.org/security#JsonWebSignature2020"],
+Self::JsonWebSignature2020 => &["https://w3id.org/security#JsonWebSignature2020"],
 #[cfg(feature = "secp256r1")]
-ProofSuiteType::EcdsaSecp256r1Signature2019 => &["https://w3id.org/security#EcdsaSecp256r1Signature2019"],
-            ProofSuiteType::CLSignature2019 => todo!(),
+Self::EcdsaSecp256r1Signature2019 => &["https://w3id.org/security#EcdsaSecp256r1Signature2019"],
+            Self::CLSignature2019 => todo!(),
+            #[cfg(feature = "test")]
+            Self::NonJwsProof |
+            Self::AnonCredPresentationProofv1 | Self::AnonCredDerivedCredentialv1 => todo!(),
         }
     }
 
@@ -283,7 +293,7 @@ ProofSuiteType::EcdsaSecp256r1Signature2019 => &["https://w3id.org/security#Ecds
     }
 
     pub fn is_zkp(&self) -> bool {
-        matches!(self, ProofSuiteType::CLSignature2019)
+        matches!(self, Self::CLSignature2019)
     }
 }
 
@@ -301,7 +311,7 @@ impl ProofSuite for ProofSuiteType {
     ) -> Result<Proof, Error> {
         match self {
             #[cfg(feature = "rsa")]
-            ProofSuiteType::RsaSignature2018 => {
+            Self::RsaSignature2018 => {
                 sign(
                     document,
                     options,
@@ -314,7 +324,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "ed25519")]
-            ProofSuiteType::Ed25519Signature2018 => {
+            Self::Ed25519Signature2018 => {
                 sign(
                     document,
                     options,
@@ -327,7 +337,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "ed25519")]
-            ProofSuiteType::Ed25519Signature2020 => {
+            Self::Ed25519Signature2020 => {
                 sign_nojws(
                     document,
                     options,
@@ -341,7 +351,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+            Self::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
                 Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021::sign(
                     document,
                     options,
@@ -352,7 +362,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+            Self::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
                 P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021::sign(
                     document,
                     options,
@@ -363,7 +373,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "secp256k1")]
-            ProofSuiteType::EcdsaSecp256k1Signature2019 => {
+            Self::EcdsaSecp256k1Signature2019 => {
                 sign(
                     document,
                     options,
@@ -376,7 +386,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "secp256k1")]
-            ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => {
+            Self::EcdsaSecp256k1RecoverySignature2020 => {
                 EcdsaSecp256k1RecoverySignature2020
                     .sign(
                         document,
@@ -389,7 +399,7 @@ impl ProofSuite for ProofSuiteType {
                     .await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::Eip712Signature2021 => {
+            Self::Eip712Signature2021 => {
                 Eip712Signature2021::sign(
                     document,
                     options,
@@ -400,7 +410,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::EthereumPersonalSignature2021 => {
+            Self::EthereumPersonalSignature2021 => {
                 EthereumPersonalSignature2021::sign(
                     document,
                     options,
@@ -411,12 +421,12 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::EthereumEip712Signature2021 => {
+            Self::EthereumEip712Signature2021 => {
                 EthereumEip712Signature2021::sign(document, options, key, extra_proof_properties)
                     .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::TezosSignature2021 => {
+            Self::TezosSignature2021 => {
                 TezosSignature2021::sign(
                     document,
                     options,
@@ -427,7 +437,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::TezosJcsSignature2021 => {
+            Self::TezosJcsSignature2021 => {
                 TezosJcsSignature2021::sign(
                     document,
                     options,
@@ -438,7 +448,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "solana")]
-            ProofSuiteType::SolanaSignature2021 => {
+            Self::SolanaSignature2021 => {
                 SolanaSignature2021::sign(
                     document,
                     options,
@@ -449,7 +459,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "aleo")]
-            ProofSuiteType::AleoSignature2021 => {
+            Self::AleoSignature2021 => {
                 AleoSignature2021::sign(
                     document,
                     options,
@@ -460,7 +470,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "w3c")]
-            ProofSuiteType::JsonWebSignature2020 => {
+            Self::JsonWebSignature2020 => {
                 JsonWebSignature2020::sign(
                     document,
                     options,
@@ -471,7 +481,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "secp256r1")]
-            ProofSuiteType::EcdsaSecp256r1Signature2019 => {
+            Self::EcdsaSecp256r1Signature2019 => {
                 sign(
                     document,
                     options,
@@ -483,7 +493,11 @@ impl ProofSuite for ProofSuiteType {
                 )
                 .await
             }
-            ProofSuiteType::CLSignature2019 => todo!(),
+            Self::CLSignature2019 => todo!(),
+            #[cfg(feature = "test")]
+            Self::NonJwsProof
+            | Self::AnonCredPresentationProofv1
+            | Self::AnonCredDerivedCredentialv1 => todo!(),
         }
     }
 
@@ -498,7 +512,7 @@ impl ProofSuite for ProofSuiteType {
     ) -> Result<ProofPreparation, Error> {
         match self {
             #[cfg(feature = "rsa")]
-            ProofSuiteType::RsaSignature2018 => {
+            Self::RsaSignature2018 => {
                 prepare(
                     document,
                     options,
@@ -511,7 +525,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "ed25519")]
-            ProofSuiteType::Ed25519Signature2018 => {
+            Self::Ed25519Signature2018 => {
                 prepare(
                     document,
                     options,
@@ -524,7 +538,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "ed25519")]
-            ProofSuiteType::Ed25519Signature2020 => {
+            Self::Ed25519Signature2020 => {
                 prepare_nojws(
                     document,
                     options,
@@ -538,7 +552,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+            Self::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
                 Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021::prepare(
                     document,
                     options,
@@ -549,7 +563,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+            Self::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
                 P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021::prepare(
                     document,
                     options,
@@ -560,7 +574,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "secp256k1")]
-            ProofSuiteType::EcdsaSecp256k1Signature2019 => {
+            Self::EcdsaSecp256k1Signature2019 => {
                 prepare(
                     document,
                     options,
@@ -573,7 +587,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "secp256k1")]
-            ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => {
+            Self::EcdsaSecp256k1RecoverySignature2020 => {
                 EcdsaSecp256k1RecoverySignature2020
                     .prepare(
                         document,
@@ -586,7 +600,7 @@ impl ProofSuite for ProofSuiteType {
                     .await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::Eip712Signature2021 => {
+            Self::Eip712Signature2021 => {
                 Eip712Signature2021::prepare(
                     document,
                     options,
@@ -596,7 +610,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::EthereumPersonalSignature2021 => {
+            Self::EthereumPersonalSignature2021 => {
                 EthereumPersonalSignature2021::prepare(
                     document,
                     options,
@@ -606,12 +620,12 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::EthereumEip712Signature2021 => {
+            Self::EthereumEip712Signature2021 => {
                 EthereumEip712Signature2021::prepare(document, options, extra_proof_properties)
                     .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::TezosSignature2021 => {
+            Self::TezosSignature2021 => {
                 TezosSignature2021::prepare(
                     document,
                     options,
@@ -622,7 +636,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::TezosJcsSignature2021 => {
+            Self::TezosJcsSignature2021 => {
                 TezosJcsSignature2021::prepare(
                     document,
                     options,
@@ -632,7 +646,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "solana")]
-            ProofSuiteType::SolanaSignature2021 => {
+            Self::SolanaSignature2021 => {
                 SolanaSignature2021::prepare(
                     document,
                     options,
@@ -642,7 +656,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "aleo")]
-            ProofSuiteType::AleoSignature2021 => {
+            Self::AleoSignature2021 => {
                 AleoSignature2021::prepare(
                     document,
                     options,
@@ -652,7 +666,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "w3c")]
-            ProofSuiteType::JsonWebSignature2020 => {
+            Self::JsonWebSignature2020 => {
                 JsonWebSignature2020::prepare(
                     document,
                     options,
@@ -663,7 +677,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "secp256r1")]
-            ProofSuiteType::EcdsaSecp256r1Signature2019 => {
+            Self::EcdsaSecp256r1Signature2019 => {
                 prepare(
                     document,
                     options,
@@ -675,7 +689,11 @@ impl ProofSuite for ProofSuiteType {
                 )
                 .await
             }
-            ProofSuiteType::CLSignature2019 => todo!(),
+            Self::CLSignature2019 => todo!(),
+            #[cfg(feature = "test")]
+            Self::NonJwsProof
+            | Self::AnonCredPresentationProofv1
+            | Self::AnonCredDerivedCredentialv1 => todo!(),
         }
     }
 
@@ -688,19 +706,15 @@ impl ProofSuite for ProofSuiteType {
     ) -> Result<VerificationWarnings, Error> {
         match self {
             #[cfg(feature = "rsa")]
-            ProofSuiteType::RsaSignature2018 => {
-                verify(proof, document, resolver, context_loader).await
-            }
+            Self::RsaSignature2018 => verify(proof, document, resolver, context_loader).await,
             #[cfg(feature = "ed25519")]
-            ProofSuiteType::Ed25519Signature2018 => {
-                verify(proof, document, resolver, context_loader).await
-            }
+            Self::Ed25519Signature2018 => verify(proof, document, resolver, context_loader).await,
             #[cfg(feature = "ed25519")]
-            ProofSuiteType::Ed25519Signature2020 => {
+            Self::Ed25519Signature2020 => {
                 verify_nojws(proof, document, resolver, context_loader, Algorithm::EdDSA).await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+            Self::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
                 Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021::verify(
                     proof,
                     document,
@@ -710,7 +724,7 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+            Self::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
                 P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021::verify(
                     proof,
                     document,
@@ -720,55 +734,59 @@ impl ProofSuite for ProofSuiteType {
                 .await
             }
             #[cfg(feature = "secp256k1")]
-            ProofSuiteType::EcdsaSecp256k1Signature2019 => {
+            Self::EcdsaSecp256k1Signature2019 => {
                 verify(proof, document, resolver, context_loader).await
             }
             #[cfg(feature = "secp256k1")]
-            ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => {
+            Self::EcdsaSecp256k1RecoverySignature2020 => {
                 EcdsaSecp256k1RecoverySignature2020
                     .verify(proof, document, resolver, context_loader)
                     .await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::Eip712Signature2021 => {
+            Self::Eip712Signature2021 => {
                 Eip712Signature2021::verify(proof, document, resolver, context_loader).await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::EthereumPersonalSignature2021 => {
+            Self::EthereumPersonalSignature2021 => {
                 EthereumPersonalSignature2021::verify(proof, document, resolver, context_loader)
                     .await
             }
             #[cfg(feature = "eip")]
-            ProofSuiteType::EthereumEip712Signature2021 => {
+            Self::EthereumEip712Signature2021 => {
                 EthereumEip712Signature2021::verify(proof, document, resolver).await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::TezosSignature2021 => {
+            Self::TezosSignature2021 => {
                 TezosSignature2021::verify(proof, document, resolver, context_loader).await
             }
             #[cfg(feature = "tezos")]
-            ProofSuiteType::TezosJcsSignature2021 => {
+            Self::TezosJcsSignature2021 => {
                 TezosJcsSignature2021::verify(proof, document, resolver).await
             }
             #[cfg(feature = "solana")]
-            ProofSuiteType::SolanaSignature2021 => {
+            Self::SolanaSignature2021 => {
                 SolanaSignature2021
                     .verify(proof, document, resolver, context_loader)
                     .await
             }
             #[cfg(feature = "aleo")]
-            ProofSuiteType::AleoSignature2021 => {
+            Self::AleoSignature2021 => {
                 AleoSignature2021::verify(proof, document, resolver, context_loader).await
             }
             #[cfg(feature = "w3c")]
-            ProofSuiteType::JsonWebSignature2020 => {
+            Self::JsonWebSignature2020 => {
                 JsonWebSignature2020::verify(proof, document, resolver, context_loader).await
             }
             #[cfg(feature = "secp256r1")]
-            ProofSuiteType::EcdsaSecp256r1Signature2019 => {
+            Self::EcdsaSecp256r1Signature2019 => {
                 verify(proof, document, resolver, context_loader).await
             }
-            ProofSuiteType::CLSignature2019 => todo!(),
+            Self::CLSignature2019 => todo!(),
+            #[cfg(feature = "test")]
+            Self::NonJwsProof
+            | Self::AnonCredPresentationProofv1
+            | Self::AnonCredDerivedCredentialv1 => todo!(),
         }
     }
 

--- a/ssi-ldp/src/suites/mod.rs
+++ b/ssi-ldp/src/suites/mod.rs
@@ -2,18 +2,795 @@
 mod aleo;
 #[cfg(feature = "eip")]
 mod eip;
+#[cfg(feature = "secp256k1")]
+mod secp256k1;
 #[cfg(feature = "solana")]
 mod solana;
 #[cfg(feature = "tezos")]
 mod tezos;
+#[cfg(feature = "w3c")]
 mod w3c;
 
 #[cfg(feature = "aleo")]
-pub use aleo::*;
+use aleo::*;
 #[cfg(feature = "eip")]
-pub use eip::*;
+use eip::*;
+#[cfg(feature = "secp256k1")]
+use secp256k1::*;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 #[cfg(feature = "solana")]
-pub use solana::*;
+use solana::*;
+use ssi_core::uri::URI;
+use ssi_dids::did_resolve::DIDResolver;
+use ssi_json_ld::ContextLoader;
+use ssi_jwk::{Algorithm, JWK};
+use ssi_jws::VerificationWarnings;
 #[cfg(feature = "tezos")]
-pub use tezos::*;
-pub use w3c::*;
+use tezos::*;
+#[cfg(feature = "w3c")]
+use w3c::*;
+
+use crate::{
+    prepare, prepare_nojws, sign, sign_nojws, use_eip712sig, use_epsig, verify, verify_nojws,
+    Error, LinkedDataDocument, LinkedDataProofOptions, Proof, ProofPreparation, ProofSuite,
+};
+
+use async_trait::async_trait;
+use std::collections::HashMap as Map;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub enum ProofSuiteType {
+    #[cfg(feature = "rsa")]
+    RsaSignature2018,
+    #[cfg(feature = "ed25519")]
+    Ed25519Signature2018,
+    #[cfg(feature = "ed25519")]
+    Ed25519Signature2020,
+    #[cfg(feature = "tezos")]
+    Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021,
+    #[cfg(feature = "tezos")]
+    P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021,
+    #[cfg(feature = "secp256k1")]
+    EcdsaSecp256k1Signature2019,
+    #[cfg(feature = "secp256k1")]
+    EcdsaSecp256k1RecoverySignature2020,
+    #[cfg(feature = "eip")]
+    Eip712Signature2021,
+    #[cfg(feature = "eip")]
+    EthereumPersonalSignature2021,
+    #[cfg(feature = "eip")]
+    EthereumEip712Signature2021,
+    #[cfg(feature = "tezos")]
+    TezosSignature2021,
+    #[cfg(feature = "tezos")]
+    TezosJcsSignature2021,
+    #[cfg(feature = "solana")]
+    SolanaSignature2021,
+    #[cfg(feature = "aleo")]
+    AleoSignature2021,
+    #[cfg(feature = "w3c")]
+    JsonWebSignature2020,
+    #[cfg(feature = "secp256r1")]
+    EcdsaSecp256r1Signature2019,
+    CLSignature2019,
+}
+
+pub enum SignatureType {
+    JWS,
+    LD,
+}
+
+impl ProofSuiteType {
+    pub fn signature_type(&self) -> SignatureType {
+        match self {
+            #[cfg(feature = "rsa")]
+            ProofSuiteType::RsaSignature2018 => SignatureType::JWS,
+            #[cfg(feature = "ed25519")]
+            ProofSuiteType::Ed25519Signature2018 => SignatureType::JWS,
+            #[cfg(feature = "ed25519")]
+            ProofSuiteType::Ed25519Signature2020 => SignatureType::LD,
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+                SignatureType::JWS
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+                SignatureType::JWS
+            }
+            #[cfg(feature = "secp256k1")]
+            ProofSuiteType::EcdsaSecp256k1Signature2019 => SignatureType::JWS,
+            #[cfg(feature = "secp256k1")]
+            ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => SignatureType::JWS,
+            #[cfg(feature = "eip")]
+            ProofSuiteType::Eip712Signature2021 => SignatureType::LD,
+            #[cfg(feature = "eip")]
+            ProofSuiteType::EthereumPersonalSignature2021 => SignatureType::LD,
+            #[cfg(feature = "eip")]
+            ProofSuiteType::EthereumEip712Signature2021 => SignatureType::LD,
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::TezosSignature2021 => SignatureType::LD,
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::TezosJcsSignature2021 => SignatureType::LD,
+            #[cfg(feature = "solana")]
+            ProofSuiteType::SolanaSignature2021 => SignatureType::LD,
+            #[cfg(feature = "aleo")]
+            ProofSuiteType::AleoSignature2021 => SignatureType::LD,
+            #[cfg(feature = "w3c")]
+            ProofSuiteType::JsonWebSignature2020 => SignatureType::JWS,
+            #[cfg(feature = "secp256r1")]
+            ProofSuiteType::EcdsaSecp256r1Signature2019 => SignatureType::JWS,
+            ProofSuiteType::CLSignature2019 => todo!(),
+        }
+    }
+
+    // TODO not sure why this check isn't covered by JSON-LD
+    pub(crate) fn associated_contexts(&self) -> &[&str] {
+        match self {
+#[cfg(feature = "rsa")]
+ProofSuiteType::RsaSignature2018 => &["https://w3id.org/security#RsaSignature2018"],
+#[cfg(feature = "ed25519")]
+ProofSuiteType::Ed25519Signature2018 => &["https://w3id.org/security#Ed25519Signature2018"],
+#[cfg(feature = "ed25519")]
+ProofSuiteType::Ed25519Signature2020 => &["https://w3id.org/security#Ed25519Signature2020"],
+#[cfg(feature = "tezos")]
+ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+    &["https://w3id.org/security#Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021"]
+}
+#[cfg(feature = "tezos")]
+ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+    &["https://w3id.org/security#P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021"]
+}
+#[cfg(feature = "secp256k1")]
+ProofSuiteType::EcdsaSecp256k1Signature2019 => &["https://w3id.org/security#EcdsaSecp256k1Signature2019"],
+#[cfg(feature = "secp256k1")]
+ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => {
+    &["https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoverySignature2020"]
+}
+#[cfg(feature = "eip")]
+ProofSuiteType::Eip712Signature2021 => &["https://w3id.org/security#Eip712Signature2021"],
+#[cfg(feature = "eip")]
+ProofSuiteType::EthereumPersonalSignature2021 => &["https://w3id.org/security#EthereumPersonalSignature2021", "https://demo.spruceid.com/ld/epsig/EthereumPersonalSignature2021"],
+#[cfg(feature = "eip")]
+ProofSuiteType::EthereumEip712Signature2021 => &[],
+#[cfg(feature = "tezos")]
+ProofSuiteType::TezosSignature2021 => &["https://w3id.org/security#TezosSignature2021"],
+#[cfg(feature = "tezos")]
+ProofSuiteType::TezosJcsSignature2021 => &["https://w3id.org/security#TezosJcsSignature2021"],
+#[cfg(feature = "solana")]
+ProofSuiteType::SolanaSignature2021 => &["https://w3id.org/security#SolanaSignature2021"],
+#[cfg(feature = "aleo")]
+ProofSuiteType::AleoSignature2021 => &["https://w3id.org/security#AleoSignature2021"],
+#[cfg(feature = "w3c")]
+ProofSuiteType::JsonWebSignature2020 => &["https://w3id.org/security#JsonWebSignature2020"],
+#[cfg(feature = "secp256r1")]
+ProofSuiteType::EcdsaSecp256r1Signature2019 => &["https://w3id.org/security#EcdsaSecp256r1Signature2019"],
+            ProofSuiteType::CLSignature2019 => todo!(),
+        }
+    }
+
+    pub(crate) fn pick(jwk: &JWK, verification_method: Option<&URI>) -> Result<Self, Error> {
+        let algorithm = jwk.get_algorithm().ok_or(Error::MissingAlgorithm)?;
+        Ok(match algorithm {
+            #[cfg(feature = "rsa")]
+            Algorithm::RS256 => Self::RsaSignature2018,
+            #[cfg(feature = "w3c")]
+            Algorithm::PS256 => Self::JsonWebSignature2020,
+            #[cfg(feature = "w3c")]
+            Algorithm::ES384 => Self::JsonWebSignature2020,
+            #[cfg(feature = "aleo")]
+            Algorithm::AleoTestnet1Signature => Self::AleoSignature2021,
+            Algorithm::EdDSA | Algorithm::EdBlake2b => match verification_method {
+                #[cfg(feature = "solana")]
+                Some(URI::String(ref vm))
+                    if (vm.starts_with("did:sol:") || vm.starts_with("did:pkh:sol:"))
+                        && vm.ends_with("#SolanaMethod2021") =>
+                {
+                    Self::SolanaSignature2021
+                }
+                #[cfg(feature = "tezos")]
+                Some(URI::String(ref vm))
+                    if vm.starts_with("did:tz:") || vm.starts_with("did:pkh:tz:") =>
+                {
+                    if vm.ends_with("#TezosMethod2021") {
+                        Self::TezosSignature2021
+                    } else {
+                        Self::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021
+                    }
+                }
+                #[cfg(feature = "ed25519")]
+                _ => Self::Ed25519Signature2018,
+                #[cfg(not(feature = "ed25519"))]
+                _ => {
+                    return Err(Error::JWS(ssi_jws::Error::MissingFeatures(
+                        "ed25519 or tezos or solana",
+                    )))
+                }
+            },
+            Algorithm::ES256 | Algorithm::ESBlake2b => match verification_method {
+                #[cfg(feature = "tezos")]
+                Some(URI::String(ref vm))
+                    if vm.starts_with("did:tz:") || vm.starts_with("did:pkh:tz:") =>
+                {
+                    if vm.ends_with("#TezosMethod2021") {
+                        Self::TezosSignature2021
+                    } else {
+                        Self::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021
+                    }
+                }
+                #[cfg(feature = "secp256r1")]
+                _ => Self::EcdsaSecp256r1Signature2019,
+                #[cfg(not(feature = "secp256r1"))]
+                _ => {
+                    return Err(Error::JWS(ssi_jws::Error::MissingFeatures(
+                        "secp256r1 or tezos",
+                    )))
+                }
+            },
+            Algorithm::ES256K | Algorithm::ESBlake2bK => match verification_method {
+                #[cfg(any(feature = "tezos", feature = "w3c"))]
+                Some(URI::String(ref vm))
+                    if vm.starts_with("did:tz:") || vm.starts_with("did:pkh:tz:") =>
+                {
+                    #[cfg(feature = "tezos")]
+                    if vm.ends_with("#TezosMethod2021") {
+                        return Ok(Self::TezosSignature2021);
+                    }
+                    #[cfg(feature = "w3c")]
+                    return Ok(Self::EcdsaSecp256k1RecoverySignature2020);
+                    #[cfg(not(feature = "w3c"))]
+                    return Err(Error::JWS(ssi_jws::Error::MissingFeatures("w3c or tezos")));
+                }
+                #[cfg(feature = "secp256k1")]
+                _ => Self::EcdsaSecp256k1Signature2019,
+                #[cfg(not(feature = "secp256k1"))]
+                _ => {
+                    return Err(Error::JWS(ssi_jws::Error::MissingFeatures(
+                        "secp256k1 or tezos or w3c",
+                    )))
+                }
+            },
+            Algorithm::ES256KR => {
+                // #[allow(clippy::if_same_then_else)]
+                #[cfg(feature = "eip")]
+                if use_eip712sig(jwk) {
+                    return Ok(Self::EthereumEip712Signature2021);
+                }
+                #[cfg(feature = "eip")]
+                if use_epsig(jwk) {
+                    return Ok(Self::EthereumPersonalSignature2021);
+                }
+                match verification_method {
+                    #[cfg(feature = "eip")]
+                    Some(URI::String(ref vm))
+                        if (vm.starts_with("did:ethr:") || vm.starts_with("did:pkh:eth:"))
+                            && vm.ends_with("#Eip712Method2021") =>
+                    {
+                        Self::Eip712Signature2021
+                    }
+                    #[cfg(feature = "secp256k1")]
+                    _ => Self::EcdsaSecp256k1RecoverySignature2020,
+                    #[cfg(not(feature = "secp256k1"))]
+                    _ => {
+                        return Err(Error::JWS(ssi_jws::Error::MissingFeatures(
+                            "secp256k1 or eip",
+                        )))
+                    }
+                }
+            }
+            _ => return Err(Error::ProofTypeNotSupported),
+        })
+    }
+
+    pub fn is_zkp(&self) -> bool {
+        matches!(self, ProofSuiteType::CLSignature2019)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl ProofSuite for ProofSuiteType {
+    async fn sign(
+        &self,
+        document: &(dyn LinkedDataDocument + Sync),
+        options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
+        key: &JWK,
+        extra_proof_properties: Option<Map<String, Value>>,
+    ) -> Result<Proof, Error> {
+        match self {
+            #[cfg(feature = "rsa")]
+            ProofSuiteType::RsaSignature2018 => {
+                sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    self.clone(),
+                    Algorithm::RS256,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "ed25519")]
+            ProofSuiteType::Ed25519Signature2018 => {
+                sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    self.clone(),
+                    Algorithm::EdDSA,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "ed25519")]
+            ProofSuiteType::Ed25519Signature2020 => {
+                sign_nojws(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    self.clone(),
+                    Algorithm::EdDSA,
+                    ssi_json_ld::W3ID_ED2020_V1_CONTEXT,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+                Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+                P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "secp256k1")]
+            ProofSuiteType::EcdsaSecp256k1Signature2019 => {
+                sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    self.clone(),
+                    Algorithm::ES256K,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "secp256k1")]
+            ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => {
+                EcdsaSecp256k1RecoverySignature2020
+                    .sign(
+                        document,
+                        options,
+                        resolver,
+                        context_loader,
+                        key,
+                        extra_proof_properties,
+                    )
+                    .await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::Eip712Signature2021 => {
+                Eip712Signature2021::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::EthereumPersonalSignature2021 => {
+                EthereumPersonalSignature2021::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::EthereumEip712Signature2021 => {
+                EthereumEip712Signature2021::sign(document, options, key, extra_proof_properties)
+                    .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::TezosSignature2021 => {
+                TezosSignature2021::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::TezosJcsSignature2021 => {
+                TezosJcsSignature2021::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "solana")]
+            ProofSuiteType::SolanaSignature2021 => {
+                SolanaSignature2021::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "aleo")]
+            ProofSuiteType::AleoSignature2021 => {
+                AleoSignature2021::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "w3c")]
+            ProofSuiteType::JsonWebSignature2020 => {
+                JsonWebSignature2020::sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "secp256r1")]
+            ProofSuiteType::EcdsaSecp256r1Signature2019 => {
+                sign(
+                    document,
+                    options,
+                    context_loader,
+                    key,
+                    self.clone(),
+                    Algorithm::ES256,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            ProofSuiteType::CLSignature2019 => todo!(),
+        }
+    }
+
+    async fn prepare(
+        &self,
+        document: &(dyn LinkedDataDocument + Sync),
+        options: &LinkedDataProofOptions,
+        resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
+        public_key: &JWK,
+        extra_proof_properties: Option<Map<String, Value>>,
+    ) -> Result<ProofPreparation, Error> {
+        match self {
+            #[cfg(feature = "rsa")]
+            ProofSuiteType::RsaSignature2018 => {
+                prepare(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    self.clone(),
+                    Algorithm::RS256,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "ed25519")]
+            ProofSuiteType::Ed25519Signature2018 => {
+                prepare(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    self.clone(),
+                    Algorithm::EdDSA,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "ed25519")]
+            ProofSuiteType::Ed25519Signature2020 => {
+                prepare_nojws(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    self.clone(),
+                    Algorithm::EdDSA,
+                    ssi_json_ld::W3ID_ED2020_V1_CONTEXT,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+                Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021::prepare(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+                P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021::prepare(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "secp256k1")]
+            ProofSuiteType::EcdsaSecp256k1Signature2019 => {
+                prepare(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    self.clone(),
+                    Algorithm::ES256K,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "secp256k1")]
+            ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => {
+                EcdsaSecp256k1RecoverySignature2020
+                    .prepare(
+                        document,
+                        options,
+                        resolver,
+                        context_loader,
+                        public_key,
+                        extra_proof_properties,
+                    )
+                    .await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::Eip712Signature2021 => {
+                Eip712Signature2021::prepare(
+                    document,
+                    options,
+                    context_loader,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::EthereumPersonalSignature2021 => {
+                EthereumPersonalSignature2021::prepare(
+                    document,
+                    options,
+                    context_loader,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::EthereumEip712Signature2021 => {
+                EthereumEip712Signature2021::prepare(document, options, extra_proof_properties)
+                    .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::TezosSignature2021 => {
+                TezosSignature2021::prepare(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::TezosJcsSignature2021 => {
+                TezosJcsSignature2021::prepare(
+                    document,
+                    options,
+                    public_key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "solana")]
+            ProofSuiteType::SolanaSignature2021 => {
+                SolanaSignature2021::prepare(
+                    document,
+                    options,
+                    context_loader,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "aleo")]
+            ProofSuiteType::AleoSignature2021 => {
+                AleoSignature2021::prepare(
+                    document,
+                    options,
+                    context_loader,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "w3c")]
+            ProofSuiteType::JsonWebSignature2020 => {
+                JsonWebSignature2020::prepare(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            #[cfg(feature = "secp256r1")]
+            ProofSuiteType::EcdsaSecp256r1Signature2019 => {
+                prepare(
+                    document,
+                    options,
+                    context_loader,
+                    public_key,
+                    self.clone(),
+                    Algorithm::ES256,
+                    extra_proof_properties,
+                )
+                .await
+            }
+            ProofSuiteType::CLSignature2019 => todo!(),
+        }
+    }
+
+    async fn verify(
+        &self,
+        proof: &Proof,
+        document: &(dyn LinkedDataDocument + Sync),
+        resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
+    ) -> Result<VerificationWarnings, Error> {
+        match self {
+            #[cfg(feature = "rsa")]
+            ProofSuiteType::RsaSignature2018 => {
+                verify(proof, document, resolver, context_loader).await
+            }
+            #[cfg(feature = "ed25519")]
+            ProofSuiteType::Ed25519Signature2018 => {
+                verify(proof, document, resolver, context_loader).await
+            }
+            #[cfg(feature = "ed25519")]
+            ProofSuiteType::Ed25519Signature2020 => {
+                verify_nojws(proof, document, resolver, context_loader, Algorithm::EdDSA).await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+                Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021::verify(
+                    proof,
+                    document,
+                    resolver,
+                    context_loader,
+                )
+                .await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 => {
+                P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021::verify(
+                    proof,
+                    document,
+                    resolver,
+                    context_loader,
+                )
+                .await
+            }
+            #[cfg(feature = "secp256k1")]
+            ProofSuiteType::EcdsaSecp256k1Signature2019 => {
+                verify(proof, document, resolver, context_loader).await
+            }
+            #[cfg(feature = "secp256k1")]
+            ProofSuiteType::EcdsaSecp256k1RecoverySignature2020 => {
+                EcdsaSecp256k1RecoverySignature2020
+                    .verify(proof, document, resolver, context_loader)
+                    .await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::Eip712Signature2021 => {
+                Eip712Signature2021::verify(proof, document, resolver, context_loader).await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::EthereumPersonalSignature2021 => {
+                EthereumPersonalSignature2021::verify(proof, document, resolver, context_loader)
+                    .await
+            }
+            #[cfg(feature = "eip")]
+            ProofSuiteType::EthereumEip712Signature2021 => {
+                EthereumEip712Signature2021::verify(proof, document, resolver).await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::TezosSignature2021 => {
+                TezosSignature2021::verify(proof, document, resolver, context_loader).await
+            }
+            #[cfg(feature = "tezos")]
+            ProofSuiteType::TezosJcsSignature2021 => {
+                TezosJcsSignature2021::verify(proof, document, resolver).await
+            }
+            #[cfg(feature = "solana")]
+            ProofSuiteType::SolanaSignature2021 => {
+                SolanaSignature2021
+                    .verify(proof, document, resolver, context_loader)
+                    .await
+            }
+            #[cfg(feature = "aleo")]
+            ProofSuiteType::AleoSignature2021 => {
+                AleoSignature2021::verify(proof, document, resolver, context_loader).await
+            }
+            #[cfg(feature = "w3c")]
+            ProofSuiteType::JsonWebSignature2020 => {
+                JsonWebSignature2020::verify(proof, document, resolver, context_loader).await
+            }
+            #[cfg(feature = "secp256r1")]
+            ProofSuiteType::EcdsaSecp256r1Signature2019 => {
+                verify(proof, document, resolver, context_loader).await
+            }
+            ProofSuiteType::CLSignature2019 => todo!(),
+        }
+    }
+
+    async fn complete(
+        &self,
+        preparation: &ProofPreparation,
+        signature: &str,
+    ) -> Result<Proof, Error> {
+        let mut proof = preparation.proof.clone();
+        match self.signature_type() {
+            SignatureType::LD => {
+                proof.proof_value = Some(signature.to_string());
+            }
+            SignatureType::JWS => {
+                let jws_header = preparation
+                    .jws_header
+                    .as_ref()
+                    .ok_or(Error::MissingJWSHeader)?;
+                let jws = ssi_jws::complete_sign_unencoded_payload(jws_header, signature)?;
+                proof.jws = Some(jws);
+            }
+        }
+        Ok(proof)
+    }
+}

--- a/ssi-ldp/src/suites/mod.rs
+++ b/ssi-ldp/src/suites/mod.rs
@@ -79,6 +79,7 @@ pub enum ProofSuiteType {
     #[cfg(feature = "test")]
     #[serde(rename = "ex:AnonCredPresentationProofv1")]
     AnonCredPresentationProofv1,
+    #[cfg(feature = "test")]
     #[serde(rename = "ex:AnonCredDerivedCredentialv1")]
     AnonCredDerivedCredentialv1,
 }

--- a/ssi-ldp/src/suites/secp256k1.rs
+++ b/ssi-ldp/src/suites/secp256k1.rs
@@ -1,0 +1,96 @@
+use super::super::*;
+use serde_json::Value;
+use ssi_dids::did_resolve::{resolve_vm, DIDResolver};
+use ssi_json_ld::ContextLoader;
+use ssi_jwk::{Algorithm, JWK};
+use std::collections::HashMap as Map;
+
+#[cfg(feature = "secp256k1")]
+pub struct EcdsaSecp256k1RecoverySignature2020;
+#[cfg(feature = "secp256k1")]
+impl EcdsaSecp256k1RecoverySignature2020 {
+    pub(crate) async fn sign(
+        &self,
+        document: &(dyn LinkedDataDocument + Sync),
+        options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
+        key: &JWK,
+        extra_proof_properties: Option<Map<String, Value>>,
+    ) -> Result<Proof, Error> {
+        if let Some(key_algorithm) = key.algorithm {
+            if key_algorithm != Algorithm::ES256KR {
+                return Err(Error::JWS(ssi_jws::Error::AlgorithmMismatch));
+            }
+        }
+        let has_context = document_has_context(document, ssi_json_ld::W3ID_ESRS2020_V2_CONTEXT)?;
+        let proof = Proof {
+            context: if has_context {
+                Value::Null
+            } else {
+                serde_json::json!([ssi_json_ld::W3ID_ESRS2020_V2_CONTEXT])
+            },
+            ..Proof::new(ProofSuiteType::EcdsaSecp256k1RecoverySignature2020)
+                .with_options(options)
+                .with_properties(extra_proof_properties)
+        };
+        sign_proof(document, proof, key, Algorithm::ES256KR, context_loader).await
+    }
+
+    pub(crate) async fn prepare(
+        &self,
+        document: &(dyn LinkedDataDocument + Sync),
+        options: &LinkedDataProofOptions,
+        _resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
+        _public_key: &JWK,
+        extra_proof_properties: Option<Map<String, Value>>,
+    ) -> Result<ProofPreparation, Error> {
+        let has_context = document_has_context(document, ssi_json_ld::W3ID_ESRS2020_V2_CONTEXT)?;
+        let proof = Proof {
+            context: if has_context {
+                Value::Null
+            } else {
+                serde_json::json!([ssi_json_ld::W3ID_ESRS2020_V2_CONTEXT])
+            },
+            ..Proof::new(ProofSuiteType::EcdsaSecp256k1RecoverySignature2020)
+                .with_options(options)
+                .with_properties(extra_proof_properties)
+        };
+        prepare_proof(document, proof, Algorithm::ES256KR, context_loader).await
+    }
+
+    pub(crate) async fn verify(
+        &self,
+        proof: &Proof,
+        document: &(dyn LinkedDataDocument + Sync),
+        resolver: &dyn DIDResolver,
+        context_loader: &mut ContextLoader,
+    ) -> Result<VerificationWarnings, Error> {
+        let jws = proof.jws.as_ref().ok_or(Error::MissingProofSignature)?;
+        let verification_method = proof
+            .verification_method
+            .as_ref()
+            .ok_or(Error::MissingVerificationMethod)?;
+        let vm = resolve_vm(verification_method, resolver).await?;
+        if vm.type_ != "EcdsaSecp256k1RecoveryMethod2020"
+            && vm.type_ != "EcdsaSecp256k1VerificationKey2019"
+            && vm.type_ != "JsonWebKey2020"
+        {
+            return Err(Error::VerificationMethodMismatch);
+        }
+        let message = to_jws_payload(document, proof, context_loader).await?;
+        let (_header, jwk) = ssi_jws::detached_recover(jws, &message)?;
+        let mut warnings = VerificationWarnings::default();
+        if let Err(_e) = vm.match_jwk(&jwk) {
+            // Legacy mode: allow using Keccak-256 instead of SHA-256
+            let (_header, jwk) = ssi_jws::detached_recover_legacy_keccak_es256kr(jws, &message)?;
+            vm.match_jwk(&jwk)?;
+            warnings.push(
+                "Signature uses legacy mode EcdsaSecp256k1RecoveryMethod2020 with Keccak-256"
+                    .to_string(),
+            );
+        }
+        Ok(warnings)
+    }
+}

--- a/ssi-ldp/src/suites/solana.rs
+++ b/ssi-ldp/src/suites/solana.rs
@@ -1,5 +1,4 @@
 use super::super::*;
-use async_trait::async_trait;
 use serde_json::Value;
 use ssi_dids::did_resolve::{resolve_vm, DIDResolver};
 use ssi_json_ld::ContextLoader;
@@ -7,21 +6,17 @@ use ssi_jwk::{Algorithm, Base64urlUInt, JWK};
 use std::collections::HashMap as Map;
 
 pub struct SolanaSignature2021;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for SolanaSignature2021 {
-    async fn sign(
-        &self,
+impl SolanaSignature2021 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
         let mut proof = Proof {
             context: serde_json::json!([SOLVM_CONTEXT.clone()]),
-            ..Proof::new("SolanaSignature2021")
+            ..Proof::new(ProofSuiteType::SolanaSignature2021)
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
@@ -34,18 +29,15 @@ impl ProofSuite for SolanaSignature2021 {
         Ok(proof)
     }
 
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
-        _public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         let proof = Proof {
             context: serde_json::json!([SOLVM_CONTEXT.clone()]),
-            ..Proof::new("SolanaSignature2021")
+            ..Proof::new(ProofSuiteType::SolanaSignature2021)
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
@@ -59,17 +51,7 @@ impl ProofSuite for SolanaSignature2021 {
         })
     }
 
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        let mut proof = preparation.proof;
-        proof.proof_value = Some(signature.to_string());
-        Ok(proof)
-    }
-
-    async fn verify(
+    pub(crate) async fn verify(
         &self,
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),

--- a/ssi-ldp/src/suites/tezos.rs
+++ b/ssi-ldp/src/suites/tezos.rs
@@ -1,5 +1,4 @@
 use super::super::*;
-use async_trait::async_trait;
 use serde_json::Value;
 use ssi_caips::caip10::BlockchainAccountId;
 use ssi_dids::did_resolve::{resolve_vm, DIDResolver};
@@ -13,14 +12,10 @@ const P2SIG_PREFIX: [u8; 4] = [54, 240, 44, 52];
 
 /// Proof type used with [did:tz](https://github.com/spruceid/did-tezos/) `tz1` addresses.
 pub struct Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
-    async fn sign(
-        &self,
+impl Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -41,18 +36,16 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         // It needs custom JSON_LD context too.
         let proof = Proof {
             context: TZ_CONTEXT.clone(),
-            ..Proof::new("Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021")
+            ..Proof::new(ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021)
                 .with_options(options)
                 .with_properties(props)
         };
         sign_proof(document, proof, key, Algorithm::EdBlake2b, context_loader).await
     }
 
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -67,23 +60,14 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         // It needs custom JSON_LD context too.
         let proof = Proof {
             context: TZ_CONTEXT.clone(),
-            ..Proof::new("Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021")
+            ..Proof::new(ProofSuiteType::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021)
                 .with_options(options)
                 .with_properties(props)
         };
         prepare_proof(document, proof, Algorithm::EdBlake2b, context_loader).await
     }
 
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        complete(preparation, signature).await
-    }
-
-    async fn verify(
-        &self,
+    pub(crate) async fn verify(
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
@@ -112,14 +96,10 @@ impl ProofSuite for Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
 
 /// Proof type used with [did:tz](https://github.com/spruceid/did-tezos/) `tz3` addresses.
 pub struct P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
-    async fn sign(
-        &self,
+impl P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -139,18 +119,16 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         // It needs custom JSON_LD context too.
         let proof = Proof {
             context: TZ_CONTEXT.clone(),
-            ..Proof::new("P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021")
+            ..Proof::new(ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021)
                 .with_options(options)
                 .with_properties(props)
         };
         sign_proof(document, proof, key, Algorithm::ESBlake2b, context_loader).await
     }
 
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -165,23 +143,14 @@ impl ProofSuite for P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021 {
         // It needs custom JSON_LD context too.
         let proof = Proof {
             context: TZ_CONTEXT.clone(),
-            ..Proof::new("P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021")
+            ..Proof::new(ProofSuiteType::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021)
                 .with_options(options)
                 .with_properties(props)
         };
         prepare_proof(document, proof, Algorithm::ESBlake2b, context_loader).await
     }
 
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        complete(preparation, signature).await
-    }
-
-    async fn verify(
-        &self,
+    pub(crate) async fn verify(
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
@@ -248,14 +217,10 @@ async fn micheline_from_document_and_options_jcs(
 }
 
 pub struct TezosSignature2021;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for TezosSignature2021 {
-    async fn sign(
-        &self,
+impl TezosSignature2021 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -268,7 +233,7 @@ impl ProofSuite for TezosSignature2021 {
             .insert("publicKeyJwk".to_string(), jwk_value);
         let mut proof = Proof {
             context: TZVM_CONTEXT.clone(),
-            ..Proof::new("TezosSignature2021")
+            ..Proof::new(ProofSuiteType::TezosSignature2021)
                 .with_options(options)
                 .with_properties(props)
         };
@@ -289,11 +254,9 @@ impl ProofSuite for TezosSignature2021 {
         Ok(proof)
     }
 
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -307,7 +270,7 @@ impl ProofSuite for TezosSignature2021 {
 
         let proof = Proof {
             context: TZVM_CONTEXT.clone(),
-            ..Proof::new("TezosSignature2021")
+            ..Proof::new(ProofSuiteType::TezosSignature2021)
                 .with_options(options)
                 .with_properties(props)
         };
@@ -323,18 +286,7 @@ impl ProofSuite for TezosSignature2021 {
         })
     }
 
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        let mut proof = preparation.proof;
-        proof.proof_value = Some(signature.to_string());
-        Ok(proof)
-    }
-
-    async fn verify(
-        &self,
+    pub(crate) async fn verify(
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
@@ -392,14 +344,10 @@ impl ProofSuite for TezosSignature2021 {
 }
 
 pub struct TezosJcsSignature2021;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for TezosJcsSignature2021 {
-    async fn sign(
-        &self,
+impl TezosJcsSignature2021 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
@@ -413,7 +361,7 @@ impl ProofSuite for TezosJcsSignature2021 {
             .insert("publicKeyMultibase".to_string(), Value::String(pkmb));
         let mut proof = Proof {
             context: TZJCSVM_CONTEXT.clone(),
-            ..Proof::new("TezosJcsSignature2021")
+            ..Proof::new(ProofSuiteType::TezosJcsSignature2021)
                 .with_options(options)
                 .with_properties(props)
         };
@@ -434,12 +382,9 @@ impl ProofSuite for TezosJcsSignature2021 {
         Ok(proof)
     }
 
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
-        _context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
@@ -454,7 +399,7 @@ impl ProofSuite for TezosJcsSignature2021 {
 
         let proof = Proof {
             context: TZJCSVM_CONTEXT.clone(),
-            ..Proof::new("TezosJcsSignature2021")
+            ..Proof::new(ProofSuiteType::TezosJcsSignature2021)
                 .with_options(options)
                 .with_properties(props)
         };
@@ -469,22 +414,10 @@ impl ProofSuite for TezosJcsSignature2021 {
         })
     }
 
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        let mut proof = preparation.proof;
-        proof.proof_value = Some(signature.to_string());
-        Ok(proof)
-    }
-
-    async fn verify(
-        &self,
+    pub(crate) async fn verify(
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
-        _context_loader: &mut ContextLoader,
     ) -> Result<VerificationWarnings, Error> {
         let sig_bs58 = proof
             .proof_value

--- a/ssi-ldp/src/suites/w3c.rs
+++ b/ssi-ldp/src/suites/w3c.rs
@@ -1,458 +1,22 @@
 use super::super::*;
-use async_trait::async_trait;
 use serde_json::Value;
-use ssi_dids::did_resolve::{resolve_key, resolve_vm, DIDResolver};
+use ssi_dids::did_resolve::{resolve_key, DIDResolver};
 use ssi_json_ld::ContextLoader;
 use ssi_jwk::{Algorithm, Params as JWKParams, JWK};
 use std::collections::HashMap as Map;
 
-#[cfg(feature = "rsa")]
-pub struct RsaSignature2018;
-#[cfg(feature = "rsa")]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for RsaSignature2018 {
-    async fn sign(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<Proof, Error> {
-        sign(
-            document,
-            options,
-            resolver,
-            context_loader,
-            key,
-            "RsaSignature2018",
-            Algorithm::RS256,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn prepare(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        public_key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<ProofPreparation, Error> {
-        prepare(
-            document,
-            options,
-            resolver,
-            context_loader,
-            public_key,
-            "RsaSignature2018",
-            Algorithm::RS256,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn verify(
-        &self,
-        proof: &Proof,
-        document: &(dyn LinkedDataDocument + Sync),
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-    ) -> Result<VerificationWarnings, Error> {
-        verify(proof, document, resolver, context_loader).await
-    }
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        complete(preparation, signature).await
-    }
-}
-
-#[cfg(feature = "ed25519")]
-pub struct Ed25519Signature2018;
-#[cfg(feature = "ed25519")]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for Ed25519Signature2018 {
-    async fn sign(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<Proof, Error> {
-        sign(
-            document,
-            options,
-            resolver,
-            context_loader,
-            key,
-            "Ed25519Signature2018",
-            Algorithm::EdDSA,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn prepare(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        public_key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<ProofPreparation, Error> {
-        prepare(
-            document,
-            options,
-            resolver,
-            context_loader,
-            public_key,
-            "Ed25519Signature2018",
-            Algorithm::EdDSA,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn verify(
-        &self,
-        proof: &Proof,
-        document: &(dyn LinkedDataDocument + Sync),
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-    ) -> Result<VerificationWarnings, Error> {
-        verify(proof, document, resolver, context_loader).await
-    }
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        complete(preparation, signature).await
-    }
-}
-
-#[cfg(feature = "ed25519")]
-pub struct Ed25519Signature2020;
-#[cfg(feature = "ed25519")]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for Ed25519Signature2020 {
-    async fn sign(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<Proof, Error> {
-        sign_nojws(
-            document,
-            options,
-            context_loader,
-            key,
-            "Ed25519Signature2020",
-            Algorithm::EdDSA,
-            ssi_json_ld::W3ID_ED2020_V1_CONTEXT,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn verify(
-        &self,
-        proof: &Proof,
-        document: &(dyn LinkedDataDocument + Sync),
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-    ) -> Result<VerificationWarnings, Error> {
-        verify_nojws(proof, document, resolver, context_loader, Algorithm::EdDSA).await
-    }
-    async fn prepare(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        public_key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<ProofPreparation, Error> {
-        prepare_nojws(
-            document,
-            options,
-            context_loader,
-            public_key,
-            "Ed25519Signature2020",
-            Algorithm::EdDSA,
-            ssi_json_ld::W3ID_ED2020_V1_CONTEXT,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        let mut proof = preparation.proof;
-        proof.proof_value = Some(signature.to_string());
-        Ok(proof)
-    }
-}
-
-#[cfg(feature = "secp256k1")]
-pub struct EcdsaSecp256k1Signature2019;
-#[cfg(feature = "secp256k1")]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for EcdsaSecp256k1Signature2019 {
-    async fn sign(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<Proof, Error> {
-        sign(
-            document,
-            options,
-            resolver,
-            context_loader,
-            key,
-            "EcdsaSecp256k1Signature2019",
-            Algorithm::ES256K,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn prepare(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        public_key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<ProofPreparation, Error> {
-        prepare(
-            document,
-            options,
-            resolver,
-            context_loader,
-            public_key,
-            "EcdsaSecp256k1Signature2019",
-            Algorithm::ES256K,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn verify(
-        &self,
-        proof: &Proof,
-        document: &(dyn LinkedDataDocument + Sync),
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-    ) -> Result<VerificationWarnings, Error> {
-        verify(proof, document, resolver, context_loader).await
-    }
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        complete(preparation, signature).await
-    }
-}
-
-#[cfg(feature = "secp256k1")]
-pub struct EcdsaSecp256k1RecoverySignature2020;
-#[cfg(feature = "secp256k1")]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for EcdsaSecp256k1RecoverySignature2020 {
-    async fn sign(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<Proof, Error> {
-        if let Some(key_algorithm) = key.algorithm {
-            if key_algorithm != Algorithm::ES256KR {
-                return Err(Error::JWS(ssi_jws::Error::AlgorithmMismatch));
-            }
-        }
-        let has_context = document_has_context(document, ssi_json_ld::W3ID_ESRS2020_V2_CONTEXT)?;
-        let proof = Proof {
-            context: if has_context {
-                Value::Null
-            } else {
-                serde_json::json!([ssi_json_ld::W3ID_ESRS2020_V2_CONTEXT])
-            },
-            ..Proof::new("EcdsaSecp256k1RecoverySignature2020")
-                .with_options(options)
-                .with_properties(extra_proof_properties)
-        };
-        sign_proof(document, proof, key, Algorithm::ES256KR, context_loader).await
-    }
-
-    async fn prepare(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        _public_key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<ProofPreparation, Error> {
-        let has_context = document_has_context(document, ssi_json_ld::W3ID_ESRS2020_V2_CONTEXT)?;
-        let proof = Proof {
-            context: if has_context {
-                Value::Null
-            } else {
-                serde_json::json!([ssi_json_ld::W3ID_ESRS2020_V2_CONTEXT])
-            },
-            ..Proof::new("EcdsaSecp256k1RecoverySignature2020")
-                .with_options(options)
-                .with_properties(extra_proof_properties)
-        };
-        prepare_proof(document, proof, Algorithm::ES256KR, context_loader).await
-    }
-
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        complete(preparation, signature).await
-    }
-
-    async fn verify(
-        &self,
-        proof: &Proof,
-        document: &(dyn LinkedDataDocument + Sync),
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-    ) -> Result<VerificationWarnings, Error> {
-        let jws = proof.jws.as_ref().ok_or(Error::MissingProofSignature)?;
-        let verification_method = proof
-            .verification_method
-            .as_ref()
-            .ok_or(Error::MissingVerificationMethod)?;
-        let vm = resolve_vm(verification_method, resolver).await?;
-        if vm.type_ != "EcdsaSecp256k1RecoveryMethod2020"
-            && vm.type_ != "EcdsaSecp256k1VerificationKey2019"
-            && vm.type_ != "JsonWebKey2020"
-        {
-            return Err(Error::VerificationMethodMismatch);
-        }
-        let message = to_jws_payload(document, proof, context_loader).await?;
-        let (_header, jwk) = ssi_jws::detached_recover(jws, &message)?;
-        let mut warnings = VerificationWarnings::default();
-        if let Err(_e) = vm.match_jwk(&jwk) {
-            // Legacy mode: allow using Keccak-256 instead of SHA-256
-            let (_header, jwk) = ssi_jws::detached_recover_legacy_keccak_es256kr(jws, &message)?;
-            vm.match_jwk(&jwk)?;
-            warnings.push(
-                "Signature uses legacy mode EcdsaSecp256k1RecoveryMethod2020 with Keccak-256"
-                    .to_string(),
-            );
-        }
-        Ok(warnings)
-    }
-}
-#[cfg(feature = "secp256r1")]
-pub struct EcdsaSecp256r1Signature2019;
-#[cfg(feature = "secp256r1")]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for EcdsaSecp256r1Signature2019 {
-    async fn sign(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<Proof, Error> {
-        sign(
-            document,
-            options,
-            resolver,
-            context_loader,
-            key,
-            "EcdsaSecp256r1Signature2019",
-            Algorithm::ES256,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn prepare(
-        &self,
-        document: &(dyn LinkedDataDocument + Sync),
-        options: &LinkedDataProofOptions,
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-        public_key: &JWK,
-        extra_proof_properties: Option<Map<String, Value>>,
-    ) -> Result<ProofPreparation, Error> {
-        prepare(
-            document,
-            options,
-            resolver,
-            context_loader,
-            public_key,
-            "EcdsaSecp256r1Signature2019",
-            Algorithm::ES256,
-            extra_proof_properties,
-        )
-        .await
-    }
-    async fn verify(
-        &self,
-        proof: &Proof,
-        document: &(dyn LinkedDataDocument + Sync),
-        resolver: &dyn DIDResolver,
-        context_loader: &mut ContextLoader,
-    ) -> Result<VerificationWarnings, Error> {
-        verify(proof, document, resolver, context_loader).await
-    }
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        complete(preparation, signature).await
-    }
-}
-
 /// <https://w3c-ccg.github.io/lds-jws2020/>
 pub struct JsonWebSignature2020;
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl ProofSuite for JsonWebSignature2020 {
-    async fn sign(
-        &self,
+impl JsonWebSignature2020 {
+    pub(crate) async fn sign(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<Proof, Error> {
         let algorithm = key.get_algorithm().ok_or(Error::MissingAlgorithm)?;
-        self.validate_key_and_algorithm(key, algorithm)?;
+        Self::validate_key_and_algorithm(key, algorithm)?;
         let has_context = document_has_context(document, ssi_json_ld::W3ID_JWS2020_V1_CONTEXT)?;
         let proof = Proof {
             context: if has_context {
@@ -460,23 +24,21 @@ impl ProofSuite for JsonWebSignature2020 {
             } else {
                 serde_json::json!([ssi_json_ld::W3ID_JWS2020_V1_CONTEXT])
             },
-            ..Proof::new("JsonWebSignature2020")
+            ..Proof::new(ProofSuiteType::JsonWebSignature2020)
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
         sign_proof(document, proof, key, algorithm, context_loader).await
     }
-    async fn prepare(
-        &self,
+    pub(crate) async fn prepare(
         document: &(dyn LinkedDataDocument + Sync),
         options: &LinkedDataProofOptions,
-        _resolver: &dyn DIDResolver,
         context_loader: &mut ContextLoader,
         public_key: &JWK,
         extra_proof_properties: Option<Map<String, Value>>,
     ) -> Result<ProofPreparation, Error> {
         let algorithm = public_key.get_algorithm().ok_or(Error::MissingAlgorithm)?;
-        self.validate_key_and_algorithm(public_key, algorithm)?;
+        Self::validate_key_and_algorithm(public_key, algorithm)?;
         let has_context = document_has_context(document, ssi_json_ld::W3ID_JWS2020_V1_CONTEXT)?;
         let proof = Proof {
             context: if has_context {
@@ -484,14 +46,13 @@ impl ProofSuite for JsonWebSignature2020 {
             } else {
                 serde_json::json!([ssi_json_ld::W3ID_JWS2020_V1_CONTEXT])
             },
-            ..Proof::new("JsonWebSignature2020")
+            ..Proof::new(ProofSuiteType::JsonWebSignature2020)
                 .with_options(options)
                 .with_properties(extra_proof_properties)
         };
         prepare_proof(document, proof, algorithm, context_loader).await
     }
-    async fn verify(
-        &self,
+    pub(crate) async fn verify(
         proof: &Proof,
         document: &(dyn LinkedDataDocument + Sync),
         resolver: &dyn DIDResolver,
@@ -511,9 +72,9 @@ impl ProofSuite for JsonWebSignature2020 {
             signature,
         } = ssi_jws::decode_jws_parts(header_b64, &message, signature_b64)?;
         // Redundant early algorithm check before expensive key lookup and signature verification.
-        self.validate_algorithm(header.algorithm)?;
+        Self::validate_algorithm(header.algorithm)?;
         let key = resolve_key(verification_method, resolver).await?;
-        self.validate_key_and_algorithm(&key, header.algorithm)?;
+        Self::validate_key_and_algorithm(&key, header.algorithm)?;
         Ok(ssi_jws::verify_bytes_warnable(
             header.algorithm,
             &signing_input,
@@ -521,17 +82,8 @@ impl ProofSuite for JsonWebSignature2020 {
             &signature,
         )?)
     }
-    async fn complete(
-        &self,
-        preparation: ProofPreparation,
-        signature: &str,
-    ) -> Result<Proof, Error> {
-        complete(preparation, signature).await
-    }
-}
 
-impl JsonWebSignature2020 {
-    fn validate_algorithm(&self, algorithm: Algorithm) -> Result<(), Error> {
+    fn validate_algorithm(algorithm: Algorithm) -> Result<(), Error> {
         match algorithm {
             Algorithm::EdDSA => (),
             Algorithm::ES256K => (),
@@ -543,7 +95,7 @@ impl JsonWebSignature2020 {
         Ok(())
     }
     // https://w3c-ccg.github.io/lds-jws2020/#jose-conformance
-    fn validate_key_and_algorithm(&self, key: &JWK, algorithm: Algorithm) -> Result<(), Error> {
+    fn validate_key_and_algorithm(key: &JWK, algorithm: Algorithm) -> Result<(), Error> {
         if let Some(key_algorithm) = key.algorithm {
             if key_algorithm != algorithm {
                 return Err(Error::JWS(ssi_jws::Error::AlgorithmMismatch));

--- a/vc-test/Cargo.toml
+++ b/vc-test/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [dependencies]
 ssi = { version = "0.4", path = "../", features = ["example-http-issuer"] }
+ssi-ldp = { version = "0.1", path = "../ssi-ldp", default-features = false, features = ["test"] }
 async-std = { version = "1.9", features = ["attributes"] }
 serde_json = "1.0"
 base64 = "0.12"


### PR DESCRIPTION
Based on #488

This allows to fail early when processing a Credential/Presentation, have a list of types in the code to use when listing the supported types in issuers or verifiers, and is just generally more idiomatic.

In the future we should separate types such as Credential to have a `CredentialGenerics` that accepts anything that implements `ProofSuite` so users can extend ssi with their own proof suite. I don't think it's necessary for now as I'm not aware of anyone not using the default types.