### PR TITLE
Remove wildcard dev dependency version

### DIFF
--- a/did-webkey/Cargo.toml
+++ b/did-webkey/Cargo.toml
@@ -35,7 +35,7 @@ version = "0.11.9"
 features = ["json", "native-tls-vendored"]
 
 [dev-dependencies]
-env_logger = "*"
+env_logger = "0.10"
 test-log = "0.2.11"
 pretty_assertions = "1.3"
 tokio = { version = "1.15.0", features = ["macros"] }


### PR DESCRIPTION
Because it's not allowed by crates.io