### PR TITLE
ucan 0.10

### DIFF
--- a/ssi-ucan/Cargo.toml
+++ b/ssi-ucan/Cargo.toml
@@ -17,11 +17,11 @@ base64 = "0.12"
 ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false }
 ssi-jws = { path = "../ssi-jws", version = "0.1", default-features = false }
 ssi-jwt = { path = "../ssi-jwt", version = "0.1", default-features = false }
-ssi-dids = { path = "../ssi-dids", version = "0.1.1" }
+ssi-dids = { path = "../ssi-dids", version = "0.1" }
 ssi-core = { path = "../ssi-core", version = "0.1" }
 ssi-caips = { path = "../ssi-caips", version = "0.1", default-features = false  }
-libipld = { version = "0.14", default-features = false, features = ["dag-cbor", "dag-json", "derive", "serde-codec"]}
-
+libipld = { version = "0.16", default-features = false, features = ["dag-json", "derive", "serde-codec"]}
+ucan-capabilities-object = { "version" = "0.1", path = "../../ucan-capabilities" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/ssi-ucan/src/lib.rs
+++ b/ssi-ucan/src/lib.rs
@@ -27,7 +27,7 @@ pub use ucan_capabilities_object;
 use ucan_capabilities_object::Capabilities;
 
 #[derive(Clone, PartialEq, Debug)]
-pub struct Ucan<F = JsonValue, A = JsonValue> {
+pub struct Ucan<F = BTreeMap<String, JsonValue>, A = JsonValue> {
     pub header: Header,
     pub payload: Payload<F, A>,
     pub signature: Vec<u8>,
@@ -244,12 +244,19 @@ pub struct Payload<F, A> {
     #[serde(rename = "nnc", skip_serializing_if = "Option::is_none")]
     pub nonce: Option<String>,
     #[serde(rename = "fct", skip_serializing_if = "Option::is_none")]
-    pub facts: Option<Vec<F>>,
+    pub facts: Option<Facts<F>>,
     #[serde_as(as = "Option<Vec<DisplayFromStr>>")]
     #[serde(rename = "prf", skip_serializing_if = "Option::is_none")]
     pub proof: Option<Vec<Cid>>,
     #[serde(rename = "cap")]
     pub capabilities: Capabilities<A>,
+}
+
+// F MUST de/serialize to a map type, so we are just wrapping and flattening it
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct Facts<F> {
+    #[serde(flatten)]
+    pub inner: F,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -422,7 +429,7 @@ mod ipld_encoding {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub nnc: &'a Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub fct: &'a Option<Vec<F>>,
+        pub fct: &'a Option<Facts<F>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub prf: &'a Option<Vec<Cid>>,
         pub cap: &'a Capabilities<A>,
@@ -438,7 +445,7 @@ mod ipld_encoding {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub nnc: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub fct: Option<Vec<F>>,
+        pub fct: Option<Facts<F>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub prf: Option<Vec<Cid>>,
         pub cap: Capabilities<A>,

--- a/ssi-ucan/src/lib.rs
+++ b/ssi-ucan/src/lib.rs
@@ -169,12 +169,11 @@ impl<F, A> Ucan<F, A> {
         })
     }
 
-    pub fn to_block<S, H>(&self, hash: H) -> Result<Block<S>, IpldError>
+    pub fn to_block<S>(&self, hash: impl Into<S::Hashes>) -> Result<Block<S>, IpldError>
     where
         F: Serialize,
         A: Serialize,
         S: libipld::store::StoreParams,
-        H: Into<S::Hashes>,
         S::Codecs: From<DagJsonCodec> + From<libipld::raw::RawCodec>,
     {
         match &self.codec {

--- a/ssi-ucan/src/lib.rs
+++ b/ssi-ucan/src/lib.rs
@@ -1,11 +1,12 @@
 pub mod error;
 pub use error::Error;
 use libipld::{
-    codec::{Codec, Decode, Encode},
+    codec::Codec,
     error::Error as IpldError,
     json::DagJsonCodec,
-    serde::{from_ipld, to_ipld},
-    Block, Cid, Ipld,
+    multihash::{Code, MultihashDigest},
+    serde::to_ipld,
+    Cid,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -21,39 +22,29 @@ use ssi_jwk::{Algorithm, JWK};
 use ssi_jws::{decode_jws_parts, sign_bytes, split_jws, verify_bytes, Header};
 use ssi_jwt::NumericDate;
 use std::collections::BTreeMap;
-use std::io::{Read, Seek, Write};
 
 use capabilities::Capabilities;
 pub use ucan_capabilities_object as capabilities;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct Ucan<F = BTreeMap<String, JsonValue>, A = JsonValue> {
-    pub header: Header,
-    pub payload: Payload<F, A>,
-    pub signature: Vec<u8>,
-    // unfortunately this matters for sig verification
-    // we have to keep track of how this ucan was created
-    // alternatively we could have 2 different types?
-    // e.g. DagJsonUcan and RawJwtUcan
-    codec: UcanCodec,
-}
-
-#[derive(Clone, PartialEq, Debug)]
-enum UcanCodec {
-    // maintain serialization
-    Raw(String),
-    DagJson,
-}
-
-impl Default for UcanCodec {
-    fn default() -> Self {
-        Self::DagJson
-    }
+    header: Header,
+    payload: Payload<F, A>,
+    signature: Vec<u8>,
 }
 
 const VERSION_STRING: &str = "0.2.0";
 
 impl<F, A> Ucan<F, A> {
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+    pub fn payload(&self) -> &Payload<F, A> {
+        &self.payload
+    }
+    pub fn signature(&self) -> &[u8] {
+        &self.signature
+    }
     pub async fn get_verification_key(&self, resolver: &dyn DIDResolver) -> Result<JWK, Error> {
         match (
             self.payload.issuer.get(..4),
@@ -126,14 +117,7 @@ impl<F, A> Ucan<F, A> {
         A: for<'a> Deserialize<'a>,
     {
         let parts = split_jws(jwt).and_then(|(h, p, s)| decode_jws_parts(h, p.as_bytes(), s))?;
-        let (payload, codec): (Payload<F, A>, UcanCodec) =
-            match serde_json::from_slice(&parts.payload) {
-                Ok(p) => Ok((p, UcanCodec::Raw(jwt.to_string()))),
-                Err(e) => match DagJsonCodec.decode(&parts.payload) {
-                    Ok(p) => Ok((p, UcanCodec::DagJson)),
-                    Err(_) => Err(e),
-                },
-            }?;
+        let payload: Payload<F, A> = serde_json::from_slice(&parts.payload)?;
 
         if parts.header.type_.as_deref() != Some("JWT") {
             return Err(Error::MissingUCANHeaderField("type: JWT"));
@@ -152,64 +136,31 @@ impl<F, A> Ucan<F, A> {
             header: parts.header,
             payload,
             signature: parts.signature,
-            codec,
         })
     }
 
-    pub fn encode(&self) -> Result<String, Error>
+    pub fn encode_as_canonicalized_jwt(&self) -> Result<String, Error>
     where
         F: Serialize,
         A: Serialize,
     {
-        Ok(match &self.codec {
-            UcanCodec::Raw(r) => r.clone(),
-            UcanCodec::DagJson => [
-                base64::encode_config(
-                    DagJsonCodec.encode(&to_ipld(&self.header).map_err(IpldError::new)?)?,
-                    base64::URL_SAFE_NO_PAD,
-                ),
-                base64::encode_config(DagJsonCodec.encode(&self.payload)?, base64::URL_SAFE_NO_PAD),
-                base64::encode_config(&self.signature, base64::URL_SAFE_NO_PAD),
-            ]
-            .join("."),
-        })
-    }
-
-    pub fn to_block<S>(&self, hash: impl Into<S::Hashes>) -> Result<Block<S>, IpldError>
-    where
-        F: Serialize,
-        A: Serialize,
-        S: libipld::store::StoreParams,
-        S::Codecs: From<DagJsonCodec> + From<libipld::raw::RawCodec>,
-    {
-        match &self.codec {
-            UcanCodec::Raw(r) => Block::encode(libipld::raw::RawCodec, hash.into(), r.as_bytes()),
-            UcanCodec::DagJson => Block::encode(
-                DagJsonCodec,
-                hash.into(),
-                &to_ipld(ipld_encoding::DagJsonUcanRef::from(self))?,
+        Ok([
+            base64::encode_config(
+                DagJsonCodec.encode(&to_ipld(&self.header).map_err(IpldError::new)?)?,
+                base64::URL_SAFE_NO_PAD,
             ),
-        }
+            base64::encode_config(
+                DagJsonCodec.encode(&to_ipld(&self.payload).map_err(IpldError::new)?)?,
+                base64::URL_SAFE_NO_PAD,
+            ),
+            base64::encode_config(&self.signature, base64::URL_SAFE_NO_PAD),
+        ]
+        .join("."))
     }
+}
 
-    pub fn from_block<S>(block: &Block<S>) -> Result<Self, IpldError>
-    where
-        F: for<'a> Deserialize<'a>,
-        A: for<'a> Deserialize<'a>,
-        S: libipld::store::StoreParams,
-        S::Codecs: From<DagJsonCodec> + From<libipld::raw::RawCodec>,
-        Ipld: Decode<S::Codecs>,
-    {
-        if block.cid().codec() == S::Codecs::from(DagJsonCodec).into() {
-            let ipld: Ipld = S::Codecs::from(DagJsonCodec).decode(block.data())?;
-            let du: ipld_encoding::DagJsonUcan<F, A> = from_ipld(ipld)?;
-            Ok(du.into())
-        } else if block.cid().codec() == S::Codecs::from(libipld::raw::RawCodec).into() {
-            Ok(Self::decode(std::str::from_utf8(block.data())?)?)
-        } else {
-            Err(IpldError::msg("Invalid Codec, expected 'raw' or 'dagJson'"))
-        }
-    }
+pub fn canonical_cid(jwt: &str) -> Cid {
+    Cid::new_v1(0x55, Code::Sha2_256.digest(jwt.as_bytes()))
 }
 
 fn match_key_with_did_pkh(key: &JWK, doc: &Document) -> Result<(), Error> {
@@ -287,7 +238,12 @@ impl<F, A> Payload<F, A> {
         }
     }
 
-    pub fn sign(self, algorithm: Algorithm, key: &JWK) -> Result<Ucan<F, A>, Error>
+    pub fn sign_canonicalized(
+        self,
+        algorithm: Algorithm,
+        key: &JWK,
+        custom_header: Option<Header>,
+    ) -> Result<Ucan<F, A>, Error>
     where
         F: Serialize,
         A: Serialize,
@@ -301,7 +257,7 @@ impl<F, A> Payload<F, A> {
             )]
             .into_iter()
             .collect(),
-            ..Default::default()
+            ..custom_header.unwrap_or_default()
         };
 
         let signature = sign_bytes(
@@ -311,7 +267,10 @@ impl<F, A> Payload<F, A> {
                     DagJsonCodec.encode(&to_ipld(&header).map_err(IpldError::new)?)?,
                     base64::URL_SAFE_NO_PAD,
                 ),
-                base64::encode_config(DagJsonCodec.encode(&self)?, base64::URL_SAFE_NO_PAD),
+                base64::encode_config(
+                    DagJsonCodec.encode(&to_ipld(&self).map_err(IpldError::new)?)?,
+                    base64::URL_SAFE_NO_PAD,
+                ),
             ]
             .join(".")
             .as_bytes(),
@@ -322,7 +281,6 @@ impl<F, A> Payload<F, A> {
             header,
             payload: self,
             signature,
-            codec: UcanCodec::DagJson,
         })
     }
 }
@@ -409,149 +367,6 @@ impl UcanRevocation {
             &key,
             &self.challenge,
         )?)
-    }
-}
-
-mod ipld_encoding {
-    use super::*;
-
-    #[derive(Serialize, Clone, PartialEq, Debug)]
-    pub struct DagJsonUcanRef<'a, F, A> {
-        header: &'a Header,
-        payload: DagJsonPayloadRef<'a, F, A>,
-        signature: &'a [u8],
-    }
-
-    #[derive(Deserialize, Clone, PartialEq, Debug)]
-    pub struct DagJsonUcan<F, A> {
-        header: Header,
-        payload: DagJsonPayload<F, A>,
-        signature: Vec<u8>,
-    }
-
-    #[derive(Serialize, Clone, PartialEq, Debug)]
-    pub struct DagJsonPayloadRef<'a, F, A> {
-        pub iss: &'a str,
-        pub aud: &'a str,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub nbf: &'a Option<NumericDate>,
-        pub exp: &'a Option<NumericDate>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub nnc: &'a Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub fct: &'a Option<Facts<F>>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub prf: &'a Option<Vec<Cid>>,
-        pub cap: &'a Capabilities<A>,
-    }
-
-    #[derive(Deserialize, Clone, PartialEq, Debug)]
-    pub struct DagJsonPayload<F, A> {
-        pub iss: String,
-        pub aud: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub nbf: Option<NumericDate>,
-        pub exp: Option<NumericDate>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub nnc: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub fct: Option<Facts<F>>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub prf: Option<Vec<Cid>>,
-        pub cap: Capabilities<A>,
-    }
-
-    impl<F, A> Encode<DagJsonCodec> for Ucan<F, A>
-    where
-        F: Serialize,
-        A: Serialize,
-    {
-        fn encode<W: Write>(&self, c: DagJsonCodec, w: &mut W) -> Result<(), IpldError> {
-            to_ipld(ipld_encoding::DagJsonUcanRef::from(self))?.encode(c, w)
-        }
-    }
-
-    impl<F, A> Decode<DagJsonCodec> for Ucan<F, A>
-    where
-        F: for<'a> Deserialize<'a>,
-        A: for<'a> Deserialize<'a>,
-    {
-        fn decode<R: Read + Seek>(c: DagJsonCodec, r: &mut R) -> Result<Self, IpldError> {
-            let u: ipld_encoding::DagJsonUcan<F, A> = from_ipld(Ipld::decode(c, r)?)?;
-            Ok(u.into())
-        }
-    }
-
-    impl<F, A> Encode<DagJsonCodec> for Payload<F, A>
-    where
-        F: Serialize,
-        A: Serialize,
-    {
-        fn encode<W: Write>(&self, c: DagJsonCodec, w: &mut W) -> Result<(), IpldError> {
-            to_ipld(ipld_encoding::DagJsonPayloadRef::from(self))?.encode(c, w)
-        }
-    }
-
-    impl<F, A> Decode<DagJsonCodec> for Payload<F, A>
-    where
-        F: for<'a> Deserialize<'a>,
-        A: for<'a> Deserialize<'a>,
-    {
-        fn decode<R: Read + Seek>(c: DagJsonCodec, r: &mut R) -> Result<Self, IpldError> {
-            let p: ipld_encoding::DagJsonPayload<F, A> = from_ipld(Ipld::decode(c, r)?)?;
-            Ok(p.into())
-        }
-    }
-
-    impl<'a, F, A> From<&'a Ucan<F, A>> for DagJsonUcanRef<'a, F, A> {
-        fn from(u: &'a Ucan<F, A>) -> Self {
-            Self {
-                header: &u.header,
-                payload: DagJsonPayloadRef::from(&u.payload),
-                signature: &u.signature,
-            }
-        }
-    }
-
-    impl<F, A> From<DagJsonUcan<F, A>> for Ucan<F, A> {
-        fn from(u: DagJsonUcan<F, A>) -> Self {
-            Self {
-                header: u.header,
-                payload: u.payload.into(),
-                signature: u.signature,
-                codec: UcanCodec::DagJson,
-            }
-        }
-    }
-
-    impl<'a, F, A> From<&'a Payload<F, A>> for DagJsonPayloadRef<'a, F, A> {
-        fn from(p: &'a Payload<F, A>) -> Self {
-            Self {
-                iss: &p.issuer,
-                aud: &p.audience,
-                nbf: &p.not_before,
-                exp: &p.expiration,
-                nnc: &p.nonce,
-                fct: &p.facts,
-                prf: &p.proof,
-                cap: &p.capabilities,
-            }
-        }
-    }
-
-    impl<F, A> From<DagJsonPayload<F, A>> for Payload<F, A> {
-        fn from(p: DagJsonPayload<F, A>) -> Self {
-            Self {
-                issuer: p.iss,
-                audience: p.aud,
-                not_before: p.nbf,
-                expiration: p.exp,
-                nonce: p.nnc,
-                facts: p.fct,
-                proof: p.prf,
-                capabilities: p.cap,
-            }
-        }
     }
 }
 

--- a/ssi-ucan/src/lib.rs
+++ b/ssi-ucan/src/lib.rs
@@ -7,13 +7,12 @@ use libipld::{
     serde::{from_ipld, to_ipld},
     Block, Cid, Ipld,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use serde_with::{
     base64::{Base64, UrlSafe},
     serde_as, DisplayFromStr,
 };
-use ssi_core::uri::URI;
 use ssi_dids::{
     did_resolve::{dereference, Content, DIDResolver},
     Document, Resource, VerificationMethod, VerificationMethodMap,
@@ -21,10 +20,11 @@ use ssi_dids::{
 use ssi_jwk::{Algorithm, JWK};
 use ssi_jws::{decode_jws_parts, sign_bytes, split_jws, verify_bytes, Header};
 use ssi_jwt::NumericDate;
-use std::{
-    fmt::Display,
-    io::{Read, Seek, Write},
-};
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+
+pub use ucan_capabilities_object;
+use ucan_capabilities_object::Capabilities;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct Ucan<F = JsonValue, A = JsonValue> {
@@ -50,6 +50,8 @@ impl Default for UcanCodec {
         Self::DagJson
     }
 }
+
+const VERSION_STRING: &str = "0.2.0";
 
 impl<F, A> Ucan<F, A> {
     pub async fn verify_signature(&self, resolver: &dyn DIDResolver) -> Result<(), Error>
@@ -114,8 +116,8 @@ impl<F, A> Ucan<F, A> {
 
     pub fn decode(jwt: &str) -> Result<Self, Error>
     where
-        F: DeserializeOwned,
-        A: DeserializeOwned,
+        F: for<'a> Deserialize<'a>,
+        A: for<'a> Deserialize<'a>,
     {
         let parts = split_jws(jwt).and_then(|(h, p, s)| decode_jws_parts(h, p.as_bytes(), s))?;
         let (payload, codec): (Payload<F, A>, UcanCodec) =
@@ -132,7 +134,7 @@ impl<F, A> Ucan<F, A> {
         }
 
         match parts.header.additional_parameters.get("ucv") {
-            Some(JsonValue::String(v)) if v == "0.9.0" => (),
+            Some(JsonValue::String(v)) if v == VERSION_STRING => (),
             _ => return Err(Error::MissingUCANHeaderField("ucv: 0.9.0")),
         }
 
@@ -187,8 +189,8 @@ impl<F, A> Ucan<F, A> {
 
     pub fn from_block<S>(block: &Block<S>) -> Result<Self, IpldError>
     where
-        F: DeserializeOwned,
-        A: DeserializeOwned,
+        F: for<'a> Deserialize<'a>,
+        A: for<'a> Deserialize<'a>,
         S: libipld::store::StoreParams,
         S::Codecs: From<DagJsonCodec> + From<libipld::raw::RawCodec>,
         Ipld: Decode<S::Codecs>,
@@ -230,24 +232,25 @@ fn match_key_with_vm(key: &JWK, vm: &VerificationMethodMap) -> Result<(), Error>
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
-pub struct Payload<F = JsonValue, A = JsonValue> {
+pub struct Payload<F, A> {
     #[serde(rename = "iss")]
     pub issuer: String,
     #[serde(rename = "aud")]
     pub audience: String,
     #[serde(rename = "nbf", skip_serializing_if = "Option::is_none")]
     pub not_before: Option<NumericDate>,
+    // no expiration should serialize to null in JSON
     #[serde(rename = "exp")]
-    pub expiration: NumericDate,
+    pub expiration: Option<NumericDate>,
     #[serde(rename = "nnc", skip_serializing_if = "Option::is_none")]
     pub nonce: Option<String>,
     #[serde(rename = "fct", skip_serializing_if = "Option::is_none")]
     pub facts: Option<Vec<F>>,
-    #[serde_as(as = "Vec<DisplayFromStr>")]
-    #[serde(rename = "prf")]
-    pub proof: Vec<Cid>,
-    #[serde(rename = "att")]
-    pub attenuation: Vec<Capability<A>>,
+    #[serde_as(as = "Option<Vec<DisplayFromStr>>")]
+    #[serde(rename = "prf", skip_serializing_if = "Option::is_none")]
+    pub proof: Option<Vec<Cid>>,
+    #[serde(rename = "cap")]
+    pub capabilities: Capabilities<A>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -261,15 +264,13 @@ pub enum TimeInvalid {
 impl<F, A> Payload<F, A> {
     pub fn validate_time(&self, time: Option<f64>) -> Result<(), TimeInvalid> {
         let t = time.unwrap_or_else(now);
-        match (self.not_before, t > self.expiration.as_seconds()) {
-            (_, true) => Err(TimeInvalid::TooLate),
+        match (self.not_before, self.expiration) {
+            (_, Some(exp)) if t >= exp.as_seconds() => Err(TimeInvalid::TooLate),
             (Some(nbf), _) if t < nbf.as_seconds() => Err(TimeInvalid::TooEarly),
             _ => Ok(()),
         }
     }
 
-    // NOTE IntoIter::new is deprecated, but into_iter() returns references until we move to 2021 edition
-    #[allow(deprecated)]
     pub fn sign(self, algorithm: Algorithm, key: &JWK) -> Result<Ucan<F, A>, Error>
     where
         F: Serialize,
@@ -278,10 +279,11 @@ impl<F, A> Payload<F, A> {
         let header = Header {
             algorithm,
             type_: Some("JWT".to_string()),
-            additional_parameters: std::array::IntoIter::new([(
+            additional_parameters: [(
                 "ucv".to_string(),
-                serde_json::Value::String("0.9.0".to_string()),
-            )])
+                serde_json::Value::String(VERSION_STRING.to_string()),
+            )]
+            .into_iter()
             .collect(),
             ..Default::default()
         };
@@ -307,94 +309,6 @@ impl<F, A> Payload<F, A> {
             codec: UcanCodec::DagJson,
         })
     }
-}
-
-#[serde_as]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-#[serde(untagged)]
-pub enum UcanResource {
-    Proof(#[serde_as(as = "DisplayFromStr")] UcanProofRef),
-    URI(URI),
-}
-
-impl Display for UcanResource {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match &self {
-            Self::Proof(p) => write!(f, "{}", p),
-            Self::URI(u) => write!(f, "{}", u),
-        }
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct UcanProofRef(pub Cid);
-
-impl Display for UcanProofRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "ucan:{}", self.0)
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum ProofRefParseErr {
-    #[error("Missing ucan prefix")]
-    Format,
-    #[error("Invalid Cid reference")]
-    ParseCid(#[from] libipld::cid::Error),
-}
-
-impl std::str::FromStr for UcanProofRef {
-    type Err = ProofRefParseErr;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(UcanProofRef(
-            s.strip_prefix("ucan:")
-                .map(Cid::from_str)
-                .ok_or(ProofRefParseErr::Format)??,
-        ))
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct UcanScope {
-    pub namespace: String,
-    pub capability: String,
-}
-
-impl std::fmt::Display for UcanScope {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}/{}", self.namespace, self.capability)
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum UcanScopeParseErr {
-    #[error("Missing namespace")]
-    Namespace,
-}
-
-impl std::str::FromStr for UcanScope {
-    type Err = UcanScopeParseErr;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (ns, cap) = s.split_once('/').ok_or(UcanScopeParseErr::Namespace)?;
-        Ok(UcanScope {
-            namespace: ns.to_string(),
-            capability: cap.to_string(),
-        })
-    }
-}
-
-/// 3.2.5 A JSON capability MUST include the with and can fields and
-/// MAY have additional fields needed to describe the capability
-#[serde_as]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-pub struct Capability<A = JsonValue> {
-    pub with: UcanResource,
-    #[serde_as(as = "DisplayFromStr")]
-    pub can: UcanScope,
-    #[serde(rename = "nb", skip_serializing_if = "Option::is_none")]
-    pub additional_fields: Option<A>,
 }
 
 fn now() -> f64 {
@@ -486,47 +400,49 @@ mod ipld_encoding {
     use super::*;
 
     #[derive(Serialize, Clone, PartialEq, Debug)]
-    pub struct DagJsonUcanRef<'a, F = JsonValue, A = JsonValue> {
+    pub struct DagJsonUcanRef<'a, F, A> {
         header: &'a Header,
         payload: DagJsonPayloadRef<'a, F, A>,
         signature: &'a [u8],
     }
 
     #[derive(Deserialize, Clone, PartialEq, Debug)]
-    pub struct DagJsonUcan<F = JsonValue, A = JsonValue> {
+    pub struct DagJsonUcan<F, A> {
         header: Header,
         payload: DagJsonPayload<F, A>,
         signature: Vec<u8>,
     }
 
     #[derive(Serialize, Clone, PartialEq, Debug)]
-    pub struct DagJsonPayloadRef<'a, F = JsonValue, A = JsonValue> {
+    pub struct DagJsonPayloadRef<'a, F, A> {
         pub iss: &'a str,
         pub aud: &'a str,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub nbf: &'a Option<NumericDate>,
-        pub exp: &'a NumericDate,
+        pub exp: &'a Option<NumericDate>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub nnc: &'a Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub fct: &'a Option<Vec<F>>,
-        pub prf: &'a Vec<Cid>,
-        pub att: &'a Vec<Capability<A>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub prf: &'a Option<Vec<Cid>>,
+        pub cap: &'a Capabilities<A>,
     }
 
     #[derive(Deserialize, Clone, PartialEq, Debug)]
-    pub struct DagJsonPayload<F = JsonValue, A = JsonValue> {
+    pub struct DagJsonPayload<F, A> {
         pub iss: String,
         pub aud: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub nbf: Option<NumericDate>,
-        pub exp: NumericDate,
+        pub exp: Option<NumericDate>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub nnc: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub fct: Option<Vec<F>>,
-        pub prf: Vec<Cid>,
-        pub att: Vec<Capability<A>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub prf: Option<Vec<Cid>>,
+        pub cap: Capabilities<A>,
     }
 
     impl<F, A> Encode<DagJsonCodec> for Ucan<F, A>
@@ -541,8 +457,8 @@ mod ipld_encoding {
 
     impl<F, A> Decode<DagJsonCodec> for Ucan<F, A>
     where
-        F: DeserializeOwned,
-        A: DeserializeOwned,
+        F: for<'a> Deserialize<'a>,
+        A: for<'a> Deserialize<'a>,
     {
         fn decode<R: Read + Seek>(c: DagJsonCodec, r: &mut R) -> Result<Self, IpldError> {
             let u: ipld_encoding::DagJsonUcan<F, A> = from_ipld(Ipld::decode(c, r)?)?;
@@ -562,8 +478,8 @@ mod ipld_encoding {
 
     impl<F, A> Decode<DagJsonCodec> for Payload<F, A>
     where
-        F: DeserializeOwned,
-        A: DeserializeOwned,
+        F: for<'a> Deserialize<'a>,
+        A: for<'a> Deserialize<'a>,
     {
         fn decode<R: Read + Seek>(c: DagJsonCodec, r: &mut R) -> Result<Self, IpldError> {
             let p: ipld_encoding::DagJsonPayload<F, A> = from_ipld(Ipld::decode(c, r)?)?;
@@ -602,7 +518,7 @@ mod ipld_encoding {
                 nnc: &p.nonce,
                 fct: &p.facts,
                 prf: &p.proof,
-                att: &p.attenuation,
+                cap: &p.capabilities,
             }
         }
     }
@@ -617,7 +533,7 @@ mod ipld_encoding {
                 nonce: p.nnc,
                 facts: p.fct,
                 proof: p.prf,
-                attenuation: p.att,
+                capabilities: p.cap,
             }
         }
     }


### PR DESCRIPTION
Updates the ucan impl to match the upcoming 0.10 version of the spec. This pr also removes a lot of the IPLD stuff as that will be covered by the cacao crate. Because of this, it removes tracking of the codec and implements verification in tandem with deserialisation so that it can have the original serialisation to verify. It also depends on the as-yet unreleased ucan-capabilities-object crate.

probable TODOs:
- [ ] tests, there are currently no independent 0.10 ucan test vectors that I'm aware of