### PR TITLE
Bump PGP version

### DIFF
--- a/did-webkey/Cargo.toml
+++ b/did-webkey/Cargo.toml
@@ -27,7 +27,7 @@ http = "0.2.6"
 serde_json = "1.0.75"
 serde = { version = "1.0.134", features = ["derive"] }
 sshkeys = "0.3.1"
-pgp = "0.8.0"
+pgp = "0.10.0"
 
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]


### PR DESCRIPTION
pgp version 0.8.0 had dependencies which caused "future incompatible" warnings when building didkit.   I've bumped it to version 0.10.0 to remediate those warnings.