### PR TITLE
Allow resolving did:webs with ports

### DIFF
--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-web"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -47,7 +47,7 @@ fn did_web_url(did: &str) -> Result<String, ResolutionMetadata> {
     let mut url = format!(
         "{}://{}/{}/did.json",
         proto,
-        domain_name.replace("%3A", ":"),
+        domain_name.replacen("%3A", ":", 1),
         path
     );
     #[cfg(test)]
@@ -210,6 +210,11 @@ mod tests {
         assert_eq!(
             did_web_url("did:web:example.com:u:bob").unwrap(),
             "https://example.com/u/bob/did.json"
+        );
+        // https://w3c-ccg.github.io/did-method-web/#example-creating-the-did-with-optional-path-and-port
+        assert_eq!(
+            did_web_url("did:web:example.com%3A443:u:bob").unwrap(),
+            "https://example.com:443/u/bob/did.json"
         );
     }
 

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -38,13 +38,18 @@ fn did_web_url(did: &str) -> Result<String, ResolutionMetadata> {
         None => ".well-known".to_string(),
     };
     // Use http for localhost, for testing purposes.
-    let proto = if domain_name == "localhost" {
+    let proto = if domain_name.starts_with("localhost") {
         "http"
     } else {
         "https"
     };
     #[allow(unused_mut)]
-    let mut url = format!("{}://{}/{}/did.json", proto, domain_name, path);
+    let mut url = format!(
+        "{}://{}/{}/did.json",
+        proto,
+        domain_name.replace("%3A", ":"),
+        path
+    );
     #[cfg(test)]
     PROXY.with(|proxy| {
         if let Some(ref proxy) = *proxy.borrow() {
@@ -128,8 +133,8 @@ impl DIDResolver for DIDWeb {
             Err(err) => {
                 return (
                     ResolutionMetadata::from_error(&format!(
-                        "Error sending HTTP request : {}",
-                        err
+                        "Error sending HTTP request ({}): {}",
+                        url, err
                     )),
                     Vec::new(),
                     None,


### PR DESCRIPTION
A few months ago, while maintaining the fork for LEF, I noticed that did:web's with ports currently aren't being resolved! [The spec states to percent encode the colon as %3A for ports](https://w3c-ccg.github.io/did-method-web/#example-creating-the-did-with-optional-path-and-port), so I added that in! 

This is particularly useful when hosting dids locally and trying to resolve a `did:web:localhost%3A3000` did during development. I also accounted for this by adjusting the http check from `domain_name == "localhost"` to `domain_name.starts_with("localhost")`, thereby allowing the domain `localhost%3A3000` to still use http rather than https.