### PR TITLE
Verify jwt without key id field

### DIFF
--- a/ssi-jws/src/lib.rs
+++ b/ssi-jws/src/lib.rs
@@ -317,6 +317,7 @@ pub fn verify_bytes_warnable(
             {
                 use ed25519_dalek::Verifier;
                 let public_key = ed25519_dalek::PublicKey::try_from(okp)?;
+                use k256::ecdsa::signature::Signature;
                 let signature = ed25519_dalek::Signature::from_bytes(signature)
                     .map_err(ssi_jwk::Error::from)?;
                 public_key


### PR DESCRIPTION
This change allows JWT-formatted VCs and VPs to be verified even when they don't have a "kid" field specified.

See https://github.com/spruceid/ssi/issues/478 for context.

I've been using this code in a forked version of ssi crate in my codebase for some time now, based on an earlier version of ssi crate.  I'm not able to run the cargo tests for ssi-vc crate (see https://github.com/spruceid/ssi/issues/521), but the vc-test-suite tests do pass.

Is there a full battery of tests that I can run, and if so, how?