### PR TITLE
Did web http client

### DIFF
--- a/did-test/src/main.rs
+++ b/did-test/src/main.rs
@@ -231,7 +231,8 @@ async fn report_method_web() {
     let supported_content_types = vec![TYPE_DID_LD_JSON.to_string()];
 
     let did = "did:web:demo.spruceid.com:2021:07:08";
-    let did_vector = did_method_vector(&did_web::DIDWeb, did).await;
+    let did_web_resolver = did_web::DIDWeb::new_with_default_http_client().unwrap();
+    let did_vector = did_method_vector(&did_web_resolver, did).await;
     did_vectors.insert(did.to_string(), did_vector);
 
     let dids = did_vectors.keys().cloned().collect();
@@ -537,19 +538,21 @@ async fn report_resolver_web() {
         executions: Vec::new(),
     };
 
+    let did_web_resolver = did_web::DIDWeb::new_with_default_http_client().unwrap();
+
     for did in &[
         "did:web:identity.foundation",
         "did:web:did.actor:nonexistent",
     ] {
         report
-            .resolve(&did_web::DIDWeb, did, &ResolutionInputMetadata::default())
+            .resolve(&did_web_resolver, did, &ResolutionInputMetadata::default())
             .await;
     }
 
     {
         let did = &"did:web:identity.foundation";
         report
-            .resolve_representation(&did_web::DIDWeb, did, &ResolutionInputMetadata::default())
+            .resolve_representation(&did_web_resolver, did, &ResolutionInputMetadata::default())
             .await;
     }
 
@@ -709,6 +712,8 @@ async fn report_dereferencer_web() {
         executions: Vec::new(),
     };
 
+    let did_web_resolver = did_web::DIDWeb::new_with_default_http_client().unwrap();
+
     for did_url in &[
         "did:web:did.actor:nonexistent",
         "did:web:demo.spruceid.com:2021:07:14:service-example",
@@ -716,7 +721,7 @@ async fn report_dereferencer_web() {
     ] {
         report
             .dereference(
-                &did_web::DIDWeb,
+                &did_web_resolver,
                 did_url,
                 &DereferencingInputMetadata::default(),
             )

--- a/ssi-jws/src/lib.rs
+++ b/ssi-jws/src/lib.rs
@@ -317,6 +317,7 @@ pub fn verify_bytes_warnable(
             {
                 use ed25519_dalek::Verifier;
                 let public_key = ed25519_dalek::PublicKey::try_from(okp)?;
+                use k256::ecdsa::signature::Signature;
                 let signature = ed25519_dalek::Signature::from_bytes(signature)
                     .map_err(ssi_jwk::Error::from)?;
                 public_key


### PR DESCRIPTION
This adds the HTTP client as discussed in https://github.com/spruceid/ssi/issues/516

Note that this is a breaking change because of the semantics of the DIDWeb struct:
- Currently, DIDWeb is an empty struct and can be instantiated as `DIDWeb` by itself (no `{}` needed), and appears in various places as `&DIDWeb`.
- This change requires DIDWeb to be instantiated via methods `DIDWeb::new_with_default_http_client` (this is the drop-in replacement for existing functionality) or `DIDWeb::new_with_http_client` (if you want to specify your own HTTP client).

I altered the various call sites that were using `&DIDWeb`, and changed them to use an instance created with `DIDWeb::new_with_default_http_client`.  However, codebases downstream of ssi that use DIDWeb will need to update their uses of DIDWeb (e.g. when constructing a DIDMethods) in order to integrate this change.