### PR TITLE
Made StringOrURI::as_str public to avoid destructuring inconvenience.

### DIFF
--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -416,7 +416,7 @@ impl From<StringOrURI> for String {
 }
 
 impl StringOrURI {
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             StringOrURI::URI(URI::String(string)) => string.as_str(),
             StringOrURI::String(string) => string.as_str(),


### PR DESCRIPTION
Seems like leaving it private was a simple oversight.