### PR TITLE
Update RustCrypto/signature crates

### DIFF
--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -19,13 +19,15 @@ secp384r1 = ["ssi-jwk/secp384r1"]
 
 [dependencies]
 ssi-dids = { path = "../ssi-dids", version = "0.1" }
-ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, features = ["ripemd-160"] }
-ssi-crypto = { path = "../ssi-crypto", default-features = false, version = "0.1"}
+ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, features = [
+  "ripemd-160",
+] }
+ssi-crypto = { path = "../ssi-crypto", default-features = false, version = "0.1" }
 async-trait = "0.1"
 thiserror = "1.0"
 multibase = "0.8"
-k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
+k256 = { version = "0.13.1", optional = true, features = ["ecdsa"] }
+p256 = { version = "0.13.2", optional = true, features = ["ecdsa"] }
 serde_json = "1.0"
 simple_asn1 = "^0.5.2"
 

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-method-key"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/ssi-crypto/Cargo.toml
+++ b/ssi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-crypto"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/ssi-crypto/Cargo.toml
+++ b/ssi-crypto/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/ssi-crypto/"
 
 [features]
 default = ["secp256k1", "ripemd-160"]
-secp256k1 = ["k256", "k256/keccak256", "keccak"]
+secp256k1 = ["k256", "keccak"]
 bbs = ["dep:bbs", "pairing-plus", "rand_old", "sha2_old", "hkdf", "serde"]
 ripemd-160 = ["ripemd160", "secp256k1", "bs58"]
 keccak = ["keccak-hash"]
@@ -20,13 +20,13 @@ ring = ["dep:ring"]
 thiserror = "1.0"
 sha2 = { version = "0.10" }
 ring = { version = "0.16", optional = true }
-k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
+k256 = { version = "0.13.1", optional = true, features = ["ecdsa"] }
+p256 = { version = "0.13.2", optional = true, features = ["ecdsa"] }
 hkdf = { version = "0.8", optional = true }
 rand_old = { package = "rand", version = "0.7", optional = true }
 sha2_old = { package = "sha2", version = "0.8", optional = true }
 keccak-hash = { version = "0.7", optional = true }
-ed25519-dalek = { version = "1", optional = true }
+ed25519-dalek = { version = "2.0.0", optional = true }
 ripemd160 = { version = "0.9", optional = true }
 bbs = { version = "=0.4.1", optional = true }
 pairing-plus = { version = "=0.19.0", optional = true }

--- a/ssi-jwk/Cargo.toml
+++ b/ssi-jwk/Cargo.toml
@@ -11,22 +11,31 @@ documentation = "https://docs.rs/ssi-jwk/"
 [features]
 default = ["secp256k1", "secp256r1", "ed25519", "rsa", "eip", "ripemd-160"]
 ## enable secp256k1 keys
-secp256k1 = ["k256", "rand", "k256/keccak256", "ssi-crypto/secp256k1"]
+secp256k1 = ["k256", "rand", "ssi-crypto/secp256k1"]
 ## enable secp256r1 (p256) keys
 secp256r1 = ["p256", "rand"]
 ## enable secp384r1 (p384) keys
 secp384r1 = ["p384", "rand"]
 ## enable ed25519 (EdDSA) keys
-ed25519 = ["ed25519-dalek", "rand_old", "getrandom"]
+ed25519 = ["ed25519-dalek", "rand", "getrandom"]
 ## enable RSA keys
 rsa = ["dep:rsa"]
 
 ## enable aleo ecosystem keys
-aleo = ["rand", "blake2", "snarkvm-dpc",  "snarkvm-algorithms", "snarkvm-curves", "snarkvm-utilities", "snarkvm-parameters", "bs58"]
+aleo = [
+  "rand",
+  "blake2",
+  "snarkvm-dpc",
+  "snarkvm-algorithms",
+  "snarkvm-curves",
+  "snarkvm-utilities",
+  "snarkvm-parameters",
+  "bs58",
+]
 ## enable ripemd-160 hashing for keys, e.g. for bitcoin
 ripemd-160 = ["ssi-crypto/ripemd-160", "secp256k1"]
 ## enable ethereum style key hashing
-eip = ["ssi-crypto/keccak", "k256/keccak256", "secp256k1"]
+eip = ["ssi-crypto/keccak", "secp256k1"]
 ## enable tezos style key hashing
 tezos = ["blake2b_simd", "secp256k1", "secp256r1", "bs58"]
 
@@ -39,21 +48,20 @@ zeroize = { version = "1.5", features = ["zeroize_derive"] }
 serde = { version = "1.0", features = ["derive"] }
 base64 = "0.12"
 thiserror = "1.0"
-ssi-crypto = { path = "../ssi-crypto", version = "0.1"}
-k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-p384 = { version = "0.11", optional = true, features = ["ecdsa"] }
+ssi-crypto = { path = "../ssi-crypto", version = "0.1" }
+k256 = { version = "0.13.1", optional = true, features = ["ecdsa"] }
+p256 = { version = "0.13.2", optional = true, features = ["ecdsa"] }
+p384 = { version = "0.13.0", optional = true, features = ["ecdsa"] }
 ring = { version = "0.16", optional = true }
 rsa = { version = "0.6", optional = true }
 rand = { version = "0.8", optional = true }
-rand_old = { package = "rand", version = "0.7", optional = true }
-ed25519-dalek = { version = "1", optional = true }
+ed25519-dalek = { version = "2.0.0", optional = true, features = ["rand_core"] }
 lazy_static = "1.4"
 bs58 = { version = "0.4", features = ["check"], optional = true }
 blake2 = { version = "0.9", optional = true }
 snarkvm-dpc = { version = "0.7.9", optional = true }
-snarkvm-algorithms = { version= "0.7.9", optional = true }
-snarkvm-curves = { version= "0.7.9", optional = true }
+snarkvm-algorithms = { version = "0.7.9", optional = true }
+snarkvm-curves = { version = "0.7.9", optional = true }
 snarkvm-utilities = { version = "0.7.9", optional = true }
 snarkvm-parameters = { version = "0.7.9", optional = true }
 blake2b_simd = { version = "0.5", optional = true }

--- a/ssi-jwk/Cargo.toml
+++ b/ssi-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-jwk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/ssi-jws/Cargo.toml
+++ b/ssi-jws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-jws"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/ssi-jws/Cargo.toml
+++ b/ssi-jws/Cargo.toml
@@ -9,9 +9,23 @@ repository = "https://github.com/spruceid/ssi/"
 documentation = "https://docs.rs/ssi-jws/"
 
 [features]
-default = ["secp256k1", "secp256r1", "ed25519", "rsa", "eip", "ssi-jwk/ripemd-160"]
+default = [
+  "secp256k1",
+  "secp256r1",
+  "ed25519",
+  "rsa",
+  "eip",
+  "ssi-jwk/ripemd-160",
+]
 ## enable secp256k1 signatures
-secp256k1 = ["ssi-jwk/secp256k1", "k256/keccak256", "ssi-crypto/secp256k1", "blake2", "dep:sha2"]
+secp256k1 = [
+  "ssi-jwk/secp256k1",
+  "k256",
+  "ssi-crypto/secp256k1",
+  "blake2",
+  "dep:sha2",
+  "dep:sha3",
+]
 ## enable secp256r1 (p256) signatures
 secp256r1 = ["ssi-jwk/secp256r1", "p256", "blake2"]
 ## enable secp384r1 (p384) signatures
@@ -24,7 +38,7 @@ rsa = ["ssi-jwk/rsa", "dep:rsa", "dep:sha2", "rand"]
 ## enable aleo ecosystem signatures
 aleo = ["ssi-jwk/aleo"]
 ## enable ethereum style signatures
-eip = ["ssi-jwk/eip", "ssi-crypto/keccak", "k256/keccak256", "secp256k1"]
+eip = ["ssi-jwk/eip", "ssi-crypto/keccak", "secp256k1"]
 ## enable tezos style signatures
 tezos = ["ssi-jwk/tezos", "secp256k1", "secp256r1", "ed25519"]
 
@@ -36,18 +50,19 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.12"
-k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-p384 = { version = "0.11", optional = true, features = ["ecdsa"] }
+k256 = { version = "0.13.1", optional = true, features = ["ecdsa"] }
+p256 = { version = "0.13.2", optional = true, features = ["ecdsa"] }
+p384 = { version = "0.13.0", optional = true, features = ["ecdsa"] }
 # blake2b_simd = { version = "0.5", optional = true }
 blake2 = { version = "0.10", optional = true }
-ed25519-dalek = { version = "1", optional = true }
+ed25519-dalek = { version = "2.0.0", optional = true }
 sha2 = { version = "0.10", optional = true }
+sha3 = { version = "0.10.8", optional = true }
 rsa = { version = "0.6", optional = true }
 rand = { version = "0.8", optional = true }
 ring = { version = "0.16", optional = true }
-ssi-crypto = { path = "../ssi-crypto", version = "0.1"}
-ssi-jwk = { path = "../ssi-jwk", version = "0.1"}
+ssi-crypto = { path = "../ssi-crypto", version = "0.1" }
+ssi-jwk = { path = "../ssi-jwk", version = "0.1" }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/ssi-ldp/Cargo.toml
+++ b/ssi-ldp/Cargo.toml
@@ -18,9 +18,15 @@ secp384r1 = ["ssi-jws/secp384r1"]
 ed25519 = ["ssi-jws/ed25519"]
 rsa = ["ssi-jws/rsa"]
 ## enable the EIP-defined LDPs: EIP712
-eip = ["keccak-hash", "ssi-caips/eip", "secp256k1", "ssi-jws/eip"]
+eip = ["keccak-hash", "ssi-caips/eip", "secp256k1", "ssi-jws/eip", "sha3"]
 ## enable LDPs from the Tezos Ecosystem
-tezos = ["ssi-tzkey", "ssi-jws/tezos", "ssi-caips/tezos", "secp256k1", "secp256r1"]
+tezos = [
+  "ssi-tzkey",
+  "ssi-jws/tezos",
+  "ssi-caips/tezos",
+  "secp256k1",
+  "secp256r1",
+]
 ## enable LDPs from the Aleo Ecosystem
 aleo = ["ssi-jws/aleo", "ssi-caips/aleo"]
 ## enable LDPs from the Solana Ecosystem
@@ -46,16 +52,17 @@ serde_jcs = "0.1"
 hex = "0.4"
 multibase = "0.8"
 sha2 = "0.10.7"
-k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
+sha3 = { version = "0.10.8", optional = true }
+k256 = { version = "0.13.1", optional = true, features = ["ecdsa"] }
+p256 = { version = "0.13.2", optional = true, features = ["ecdsa"] }
 keccak-hash = { version = "0.7", optional = true }
-ssi-jwk = { path = "../ssi-jwk", version = "0.1.1"}
-ssi-json-ld = { path = "../ssi-json-ld", version = "0.2"}
-ssi-core = { path = "../ssi-core", version = "0.1"}
-ssi-dids = { path = "../ssi-dids", version = "0.1"}
-ssi-crypto = { path = "../ssi-crypto", version = "0.1"}
-ssi-jws = { path = "../ssi-jws", version = "0.1"}
-ssi-tzkey = { path = "../ssi-tzkey", version = "0.1", optional = true}
+ssi-jwk = { path = "../ssi-jwk", version = "0.1.1" }
+ssi-json-ld = { path = "../ssi-json-ld", version = "0.2" }
+ssi-core = { path = "../ssi-core", version = "0.1" }
+ssi-dids = { path = "../ssi-dids", version = "0.1" }
+ssi-crypto = { path = "../ssi-crypto", version = "0.1" }
+ssi-jws = { path = "../ssi-jws", version = "0.1" }
+ssi-tzkey = { path = "../ssi-tzkey", version = "0.1", optional = true }
 ssi-caips = { path = "../ssi-caips", version = "0.1" }
 ssi-contexts = { version = "0.1.5", path = "../contexts" }
 

--- a/ssi-ldp/Cargo.toml
+++ b/ssi-ldp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-ldp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/ssi-ldp/src/eip712.rs
+++ b/ssi-ldp/src/eip712.rs
@@ -1615,7 +1615,7 @@ mod tests {
         let sk_bytes = bytes_from_hex(sk_hex).unwrap();
         use ssi_jwk::{Base64urlUInt, ECParams, Params, JWK};
 
-        let sk = k256::SecretKey::from_be_bytes(&sk_bytes).unwrap();
+        let sk = k256::SecretKey::from_bytes(sk_bytes.as_slice().into()).unwrap();
         let pk = sk.public_key();
         let mut ec_params = ECParams::try_from(&pk).unwrap();
         ec_params.ecc_private_key = Some(Base64urlUInt(sk_bytes.to_vec()));

--- a/ssi-tzkey/Cargo.toml
+++ b/ssi-tzkey/Cargo.toml
@@ -9,9 +9,13 @@ repository = "https://github.com/spruceid/ssi/"
 documentation = "https://docs.rs/ssi-tzkey/"
 
 [dependencies]
-ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, features = ["tezos"]}
-ssi-jws = { path = "../ssi-jws", version = "0.1", default-features = false, features = ["tezos"] }
-ed25519-dalek = "1.0.1"
+ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, features = [
+  "tezos",
+] }
+ssi-jws = { path = "../ssi-jws", version = "0.1", default-features = false, features = [
+  "tezos",
+] }
+ed25519-dalek = "2.0.0"
 thiserror = "1.0"
 bs58 = { version = "0.4", features = ["check"] }
 

--- a/ssi-tzkey/Cargo.toml
+++ b/ssi-tzkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-tzkey"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/ssi-tzkey/src/lib.rs
+++ b/ssi-tzkey/src/lib.rs
@@ -77,13 +77,9 @@ pub fn jwk_from_tezos_key(tz_pk: &str) -> Result<JWK, DecodeTezosPkError> {
             let sk_bytes = bs58::decode(&tz_pk).with_check(None).into_vec()?[4..].to_owned();
             let pk_bytes;
             {
-                let sk = ed25519_dalek::SecretKey::from_bytes(if sk_bytes.len() == 64 {
-                    &sk_bytes[..32]
-                } else {
-                    &sk_bytes
-                })
-                .map_err(ssi_jwk::Error::from)?;
-                pk_bytes = ed25519_dalek::PublicKey::from(&sk).as_bytes().to_vec()
+                let sk = ed25519_dalek::SigningKey::try_from(sk_bytes.as_slice())
+                    .map_err(ssi_jwk::Error::from)?;
+                pk_bytes = ed25519_dalek::VerifyingKey::from(&sk).as_bytes().to_vec()
             }
             (
                 Algorithm::EdBlake2b,

--- a/ssi-vc/Cargo.toml
+++ b/ssi-vc/Cargo.toml
@@ -16,11 +16,19 @@ thiserror = "1.0"
 flate2 = "1.0"
 bitvec = "0.20"
 base64 = "0.12"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
 cacaos = { version = "0.5.1" }
 siwe-recap = { version = "0.1" }
-libipld = { version = "0.14", default-features = false, features = ["dag-cbor", "derive"]}
-multihash = { version = "0.16", default-features = false, features = ["blake3"] }
+libipld = { version = "0.14", default-features = false, features = [
+  "dag-cbor",
+  "derive",
+] }
+multihash = { version = "0.16", default-features = false, features = [
+  "blake3",
+] }
 iref = "2.2.2"
 ssi-jwt = { path = "../ssi-jwt", version = "0.1", default-features = false }
 ssi-jws = { path = "../ssi-jws", version = "0.1", default-features = false }
@@ -40,11 +48,16 @@ chrono = { version = "0.4", features = ["serde", "wasmbind"] }
 async-std = { version = "1.9", features = ["attributes"] }
 multibase = "0.8"
 hex = "0.4"
-k256 = { version = "0.11", features = ["ecdsa"] }
+sha3 = "0.10.8"
+k256 = { version = "0.13.1", features = ["ecdsa"] }
 keccak-hash = { version = "0.7" }
 serde_jcs = "0.1"
 ssi-crypto = { path = "../ssi-crypto" }
-ssi-ldp = { path = "../ssi-ldp", features = ["aleo", "example-http-issuer", "secp384r1"] }
+ssi-ldp = { path = "../ssi-ldp", features = [
+  "aleo",
+  "example-http-issuer",
+  "secp384r1",
+] }
 ssi-dids = { path = "../ssi-dids", version = "0.1", features = ["example"] }
 josekit = "0.8.2"
 time = "0.3.20"


### PR DESCRIPTION
Mostly to upgrade ed25519-dalek which has a vulnerability.

The impact should be minimal, but does include empty error messages when recovered addresses don't match. This was to avoid breaking changes, and it should be addressed after the upcoming major refactor.