### PR TITLE
Fix and deprecate now_ms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,13 +65,6 @@ jobs:
       with:
         submodules: true
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: "1.68.0"
-        profile: minimal
-        override: true
-
     - uses: taiki-e/install-action@cargo-hack
 
     - uses: Swatinem/rust-cache@v2

--- a/examples/issue-revocation-list.rs
+++ b/examples/issue-revocation-list.rs
@@ -21,7 +21,7 @@ async fn main() {
         more_properties: serde_json::Value::Null,
     };
     let mut vc = Credential::try_from(rl_vc).unwrap();
-    vc.issuance_date = Some(ssi::vc::VCDateTime::from(ssi::ldp::now_ms()));
+    vc.issuance_date = Some(ssi::vc::VCDateTime::from(ssi::ldp::now_ns()));
     let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
     let verification_method = "did:example:foo#key1".to_string();
     proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));

--- a/examples/issue-status-list.rs
+++ b/examples/issue-status-list.rs
@@ -18,7 +18,7 @@ async fn main() {
         more_properties: serde_json::Value::Null,
     };
     let mut vc = Credential::try_from(rl_vc).unwrap();
-    vc.issuance_date = Some(ssi::vc::VCDateTime::from(ssi::ldp::now_ms()));
+    vc.issuance_date = Some(ssi::vc::VCDateTime::from(ssi::ldp::now_ns()));
     let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
     let verification_method = "did:example:12345#key1".to_string();
     proof_options.verification_method = Some(ssi::vc::URI::String(verification_method));

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -11,7 +11,7 @@ async fn main() {
         "@context": ["https://www.w3.org/2018/credentials/v1"],
         "type": "VerifiableCredential",
         "issuer": "did:example:foo",
-        "issuanceDate": ssi::ldp::now_ms(),
+        "issuanceDate": ssi::ldp::now_ns(),
         "credentialSubject": {
             "id": "urn:uuid:".to_string() + &uuid::Uuid::new_v4().to_string()
         }

--- a/ssi-ldp/Cargo.toml
+++ b/ssi-ldp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-ldp"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/ssi-ldp/src/lib.rs
+++ b/ssi-ldp/src/lib.rs
@@ -122,10 +122,15 @@ impl From<Result<VerificationWarnings, Error>> for VerificationResult {
 }
 
 // Get current time to millisecond precision if possible
+#[deprecated = "Use now_ns instead"]
 pub fn now_ms() -> DateTime<Utc> {
+    now_ns()
+}
+
+// Get current time to nanosecond precision if possible
+pub fn now_ns() -> DateTime<Utc> {
     let datetime = Utc::now();
-    let ms = datetime.timestamp_subsec_millis();
-    let ns = ms * 1_000_000;
+    let ns = datetime.timestamp_subsec_nanos();
     datetime.with_nanosecond(ns).unwrap_or(datetime)
 }
 

--- a/ssi-ldp/src/proof.rs
+++ b/ssi-ldp/src/proof.rs
@@ -93,7 +93,7 @@ impl Proof {
                 .map(|uri| uri.to_string()),
             domain: options.domain.clone(),
             challenge: options.challenge.clone(),
-            created: Some(options.created.unwrap_or_else(now_ms)),
+            created: Some(options.created.unwrap_or_else(now_ns)),
             ..self
         }
     }
@@ -114,7 +114,7 @@ impl Proof {
             );
         }
         if let Some(created) = self.created {
-            assert_local!(options.created.unwrap_or_else(now_ms) >= created);
+            assert_local!(options.created.unwrap_or_else(now_ns) >= created);
         } else {
             return false;
         }
@@ -244,7 +244,7 @@ impl Default for LinkedDataProofOptions {
         Self {
             verification_method: None,
             proof_purpose: Some(ProofPurpose::default()),
-            created: Some(crate::now_ms()),
+            created: Some(crate::now_ns()),
             challenge: None,
             domain: None,
             checks: Some(vec![Check::Proof]),

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -3004,7 +3004,6 @@ _:c14n0 <https://w3id.org/security#verificationMethod> <https://example.org/foo/
             .await
             .unwrap();
         let vp_jwt_verify_options = LinkedDataProofOptions {
-            created: None,
             checks: None,
             proof_purpose: None,
             ..Default::default()


### PR DESCRIPTION
The simple conversion to nanoseconds was not compatible with the accurate use of nanoseconds in other parts of ssi.