### PR TITLE
Refactor the `key` DID method & Remove associated future types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ ssi-vc.workspace = true
 members = [
   "did-tezos",
   "did-jwk",
-  # "did-key",
+  "did-key",
   # "did-web",
   # "did-ethr",
   # "did-sol",

--- a/did-jwk/src/lib.rs
+++ b/did-jwk/src/lib.rs
@@ -224,10 +224,7 @@ mod tests {
     #[cfg(feature = "secp256r1")]
     async fn from_p256() {
         let did_url = DIDURL::new(b"did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9#0").unwrap();
-        let resolved = JWKMethod
-            .dereference(did_url)
-            .await
-            .unwrap();
+        let resolved = JWKMethod.dereference(did_url).await.unwrap();
 
         let vm: JsonWebKey2020Ref = resolved
             .content
@@ -284,10 +281,7 @@ mod tests {
     #[async_std::test]
     async fn from_x25519() {
         let did_url = DIDURL::new(b"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJYMjU1MTkiLCJ1c2UiOiJlbmMiLCJ4IjoiM3A3YmZYdDl3YlRUVzJIQzdPUTFOei1EUThoYmVHZE5yZngtRkctSUswOCJ9#0").unwrap();
-        let resolved = JWKMethod
-            .dereference(did_url)
-            .await
-            .unwrap();
+        let resolved = JWKMethod.dereference(did_url).await.unwrap();
 
         let vm: JsonWebKey2020Ref = resolved
             .content

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -13,26 +13,46 @@ documentation = "https://docs.rs/did-key/"
 
 [features]
 default = ["secp256k1", "secp256r1"]
-secp256k1 = ["k256", "ssi-jwk/secp256k1"]
-secp256r1 = ["p256", "ssi-jwk/secp256r1"]
+secp256k1 = [
+	"k256",
+	"ssi-jwk/secp256k1"
+]
+secp256r1 = [
+	"p256",
+	"ssi-jwk/secp256r1"
+]
 secp384r1 = ["ssi-jwk/secp384r1"]
 
 [dependencies]
-ssi-dids = { path = "../ssi-dids", version = "0.1" }
-ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, features = ["ripemd-160"] }
-ssi-crypto = { path = "../ssi-crypto", default-features = false, version = "0.1"}
-async-trait = "0.1"
-thiserror = "1.0"
-multibase = "0.8"
+ssi-dids.workspace = true
+ssi-jwk.workspace = true
+ssi-multicodec.workspace = true
+bs58 = { version = "0.4", features = ["check"] }
+multibase.workspace = true
+iref.workspace = true
+static-iref.workspace = true
+thiserror.workspace = true
+serde_json.workspace = true
+simple_asn1 = "^0.5.2"
+# ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, features = ["ripemd-160"] }
+# ssi-crypto = { path = "../ssi-crypto", default-features = false, version = "0.1"}
+# async-trait = "0.1"
+# thiserror = "1.0"
+# multibase = "0.8"
 k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
 p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-serde_json = "1.0"
-simple_asn1 = "^0.5.2"
+# serde_json = "1.0"
+# simple_asn1 = "^0.5.2"
 
 [dev-dependencies]
-ssi-vc = { path = "../ssi-vc" }
-ssi-ldp = { path = "../ssi-ldp" }
-ssi-json-ld = { path = "../ssi-json-ld" }
-serde = { version = "1.0", features = ["derive"] }
+ssi-top.workspace = true
+# ssi-vc = { path = "../ssi-vc" }
+ssi-vc-ldp.workspace = true
+# ssi-json-ld = { path = "../ssi-json-ld" }
+xsd-types.workspace = true
+linked-data.workspace = true
+serde = { workspace = true, features = ["derive"] }
 async-std = { version = "1.9", features = ["attributes"] }
-serde_json = "1.0"
+# serde_json = "1.0"
+rand_chacha.workspace = true
+rand_chacha_old = { package = "rand_chacha", version = "0.2" }

--- a/did-key/src/json_ld_context.rs
+++ b/did-key/src/json_ld_context.rs
@@ -1,0 +1,144 @@
+use ssi_dids::{
+    document::representation,
+    json_ld::{
+        syntax::context::{
+            term_definition::{Expanded, Id, Type, TypeKeyword},
+            Definition, TermDefinition,
+        },
+        Entry, Nullable,
+    },
+};
+use static_iref::iri;
+
+use crate::VerificationMethodType;
+
+#[derive(Debug, Default)]
+pub struct JsonLdContext {
+    ed25519_verification_key_2018: bool,
+    ecdsa_secp256k1_verification_key_2019: bool,
+    ecdsa_secp256r1_verification_key_2019: bool,
+    json_web_key_2020: bool,
+    bls12381g2_key_2020: bool,
+}
+
+impl JsonLdContext {
+    pub fn add_verification_method_type(&mut self, vm_type: VerificationMethodType) {
+        match vm_type {
+            VerificationMethodType::Ed25519VerificationKey2018 => {
+                self.ed25519_verification_key_2018 = true
+            }
+            VerificationMethodType::EcdsaSecp256k1VerificationKey2019 => {
+                self.ecdsa_secp256k1_verification_key_2019 = true
+            }
+            VerificationMethodType::EcdsaSecp256r1VerificationKey2019 => {
+                self.ecdsa_secp256r1_verification_key_2019 = true
+            }
+            VerificationMethodType::JsonWebKey2020 => self.json_web_key_2020 = true,
+            VerificationMethodType::Bls12381G2Key2020 => self.bls12381g2_key_2020 = true,
+        }
+    }
+
+    pub fn into_entries(self) -> Vec<representation::json_ld::ContextEntry> {
+        let mut def = Definition::new();
+
+        let mut public_key_jwk = false;
+        let mut public_key_base_58 = false;
+        let mut public_key_multibase = false;
+
+        if self.ed25519_verification_key_2018 {
+            let ty = VerificationMethodType::Ed25519VerificationKey2018;
+            def.bindings.insert(
+                ty.name().into(),
+                TermDefinition::Simple(ty.iri().to_owned().into()).into(),
+            );
+
+            public_key_base_58 = true;
+        }
+
+        if self.ecdsa_secp256k1_verification_key_2019 {
+            let ty = VerificationMethodType::EcdsaSecp256k1VerificationKey2019;
+            def.bindings.insert(
+                ty.name().into(),
+                TermDefinition::Simple(ty.iri().to_owned().into()).into(),
+            );
+
+            public_key_jwk = true;
+        }
+
+        if self.ecdsa_secp256r1_verification_key_2019 {
+            let ty = VerificationMethodType::EcdsaSecp256r1VerificationKey2019;
+            def.bindings.insert(
+                ty.name().into(),
+                TermDefinition::Simple(ty.iri().to_owned().into()).into(),
+            );
+
+            public_key_multibase = true;
+        }
+
+        if self.json_web_key_2020 {
+            let ty = VerificationMethodType::JsonWebKey2020;
+            def.bindings.insert(
+                ty.name().into(),
+                TermDefinition::Simple(ty.iri().to_owned().into()).into(),
+            );
+
+            public_key_jwk = true;
+        }
+
+        if self.bls12381g2_key_2020 {
+            let ty = VerificationMethodType::Bls12381G2Key2020;
+            def.bindings.insert(
+                ty.name().into(),
+                TermDefinition::Simple(ty.iri().to_owned().into()).into(),
+            );
+
+            public_key_jwk = true;
+        }
+
+        if public_key_jwk {
+            def.bindings.insert(
+                "publicKeyJwk".into(),
+                TermDefinition::Expanded(Box::new(Expanded {
+                    id: Some(Entry::new(Nullable::Some(Id::Term(
+                        iri!("https://w3id.org/security#publicKeyJwk")
+                            .to_owned()
+                            .into_string(),
+                    )))),
+                    type_: Some(Entry::new(Nullable::Some(Type::Keyword(TypeKeyword::Json)))),
+                    ..Default::default()
+                }))
+                .into(),
+            );
+        }
+
+        if public_key_base_58 {
+            def.bindings.insert(
+                "publicKeyBase58".into(),
+                TermDefinition::Simple(
+                    iri!("https://w3id.org/security#publicKeyBase58")
+                        .to_owned()
+                        .into(),
+                )
+                .into(),
+            );
+        }
+
+        if public_key_multibase {
+            def.bindings.insert(
+                "publicKeyMultibase".into(),
+                TermDefinition::Simple(
+                    iri!("https://w3id.org/security#publicKeyMultibase")
+                        .to_owned()
+                        .into(),
+                )
+                .into(),
+            );
+        }
+
+        let mut entries = Vec::new();
+
+        entries.push(representation::json_ld::ContextEntry::Definition(def));
+
+        entries
+    }
+}

--- a/did-key/src/lib.rs
+++ b/did-key/src/lib.rs
@@ -1,22 +1,21 @@
-use async_trait::async_trait;
-use serde_json::Value;
 use std::collections::BTreeMap;
-use thiserror::Error;
 
-use ssi_dids::did_resolve::{
-    DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
-    ERROR_NOT_FOUND,
-};
+use iref::Iri;
 use ssi_dids::{
-    Context, Contexts, DIDMethod, Document, Source, VerificationMethod, VerificationMethodMap,
-    DEFAULT_CONTEXT, DIDURL,
+    document::{
+        self,
+        representation::{self, MediaType},
+        verification_method::ValueOrReference,
+        DIDVerificationMethod,
+    },
+    resolution::{self, DIDMethodResolver, Error},
+    DIDBuf, DIDURLBuf, Document,
 };
-#[cfg(feature = "secp256r1")]
-use ssi_jwk::p256_parse;
-use ssi_jwk::rsa_x509_pub_parse;
-#[cfg(feature = "secp256k1")]
-use ssi_jwk::secp256k1_parse;
-use ssi_jwk::{Base64urlUInt, OctetParams, Params, JWK};
+use static_iref::iri;
+
+mod json_ld_context;
+use json_ld_context::*;
+use ssi_jwk::JWK;
 
 const DID_KEY_ED25519_PREFIX: [u8; 2] = [0xed, 0x01];
 const DID_KEY_SECP256K1_PREFIX: [u8; 2] = [0xe7, 0x01];
@@ -25,275 +24,38 @@ const DID_KEY_P256_PREFIX: [u8; 2] = [0x80, 0x24];
 const DID_KEY_P384_PREFIX: [u8; 2] = [0x81, 0x24];
 const DID_KEY_RSA_PREFIX: [u8; 2] = [0x85, 0x24];
 
-#[derive(Error, Debug)]
-pub enum DIDKeyError {
-    #[error("Unsupported key type")]
-    UnsupportedKeyType,
-    #[error("Unsupported curve: {0}")]
-    UnsupportedCurve(String),
-    #[error("Unsupported source")]
-    UnsupportedSource,
+#[derive(Debug, thiserror::Error)]
+pub enum Unsupported {
+    #[error("did:key type secp256k1 not supported")]
+    Secp256k1,
+
+    #[error("did:key type P-256 not supported")]
+    P256,
+
+    #[error("did:key type P-384 not supported")]
+    P384,
 }
 
 pub struct DIDKey;
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl DIDResolver for DIDKey {
-    async fn resolve(
-        &self,
-        did: &str,
-        _input_metadata: &ResolutionInputMetadata,
-    ) -> (
-        ResolutionMetadata,
-        Option<Document>,
-        Option<DocumentMetadata>,
-    ) {
-        let vm_type;
-        let vm_type_iri;
-        if !did.starts_with("did:key:") {
-            return (
-                ResolutionMetadata {
-                    error: Some(ERROR_INVALID_DID.to_string()),
-                    content_type: None,
-                    property_set: None,
-                },
-                None,
-                None,
-            );
-        }
-        let method_specific_id = &did[8..];
-        let (_base, data) = match multibase::decode(method_specific_id) {
-            Ok((base, data)) => (base, data),
-            Err(_err) => {
-                // TODO: pass through these errors somehow
-                return (
-                    ResolutionMetadata {
-                        error: Some(ERROR_INVALID_DID.to_string()),
-                        content_type: None,
-                        property_set: None,
-                    },
-                    None,
-                    None,
-                );
-            }
-        };
-        if data.len() < 2 {
-            return (
-                ResolutionMetadata {
-                    error: Some(ERROR_INVALID_DID.to_string()),
-                    content_type: None,
-                    property_set: None,
-                },
-                None,
-                None,
-            );
-        }
-        let mut context = BTreeMap::new();
-        context.insert(
-            "publicKeyJwk".to_string(),
-            serde_json::json!({
-                "@id": "https://w3id.org/security#publicKeyJwk",
-                "@type": "@json"
-            }),
-        );
-
-        let jwk = if data[0] == DID_KEY_ED25519_PREFIX[0] && data[1] == DID_KEY_ED25519_PREFIX[1] {
-            if data.len() - 2 != 32 {
-                return (
-                    ResolutionMetadata {
-                        error: Some(ERROR_INVALID_DID.to_string()),
-                        content_type: None,
-                        property_set: None,
-                    },
-                    None,
-                    None,
-                );
-            }
-            vm_type = "Ed25519VerificationKey2018".to_string();
-            vm_type_iri = "https://w3id.org/security#Ed25519VerificationKey2018".to_string();
-            JWK {
-                params: Params::OKP(OctetParams {
-                    curve: "Ed25519".to_string(),
-                    public_key: Base64urlUInt(data[2..].to_vec()),
-                    private_key: None,
-                }),
-                public_key_use: None,
-                key_operations: None,
-                algorithm: None,
-                key_id: None,
-                x509_url: None,
-                x509_certificate_chain: None,
-                x509_thumbprint_sha1: None,
-                x509_thumbprint_sha256: None,
-            }
-        } else if data[0] == DID_KEY_SECP256K1_PREFIX[0] && data[1] == DID_KEY_SECP256K1_PREFIX[1] {
-            if data.len() - 2 != 33 {
-                return (
-                    ResolutionMetadata::from_error(ERROR_INVALID_DID),
-                    None,
-                    None,
-                );
-            }
-            #[cfg(feature = "secp256k1")]
-            match secp256k1_parse(&data[2..]) {
-                Ok(jwk) => {
-                    vm_type = "EcdsaSecp256k1VerificationKey2019".to_string();
-                    vm_type_iri =
-                        "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019".to_string();
-                    jwk
-                }
-                Err(err) => return (ResolutionMetadata::from_error(&err.to_string()), None, None),
-            }
-            #[cfg(not(feature = "secp256k1"))]
-            return (
-                ResolutionMetadata::from_error("did:key type secp256k1 not supported"),
-                None,
-                None,
-            );
-        } else if data[0] == DID_KEY_P256_PREFIX[0] && data[1] == DID_KEY_P256_PREFIX[1] {
-            #[cfg(feature = "secp256r1")]
-            match p256_parse(&data[2..]) {
-                Ok(jwk) => {
-                    vm_type = "EcdsaSecp256r1VerificationKey2019".to_string();
-                    vm_type_iri =
-                        "https://w3id.org/security#EcdsaSecp256r1VerificationKey2019".to_string();
-                    jwk
-                }
-                Err(err) => return (ResolutionMetadata::from_error(&err.to_string()), None, None),
-            }
-            #[cfg(not(feature = "secp256r1"))]
-            return (
-                ResolutionMetadata::from_error("did:key type P-256 not supported"),
-                None,
-                None,
-            );
-        } else if data[0] == DID_KEY_P384_PREFIX[0] && data[1] == DID_KEY_P384_PREFIX[1] {
-            #[cfg(feature = "secp384r1")]
-            match ssi_jwk::p384_parse(&data[2..]) {
-                Ok(jwk) => {
-                    vm_type = "JsonWebKey2020".to_string();
-                    vm_type_iri = "https://w3id.org/security#JsonWebKey2020".to_string();
-                    jwk
-                }
-                Err(err) => return (ResolutionMetadata::from_error(&err.to_string()), None, None),
-            }
-            #[cfg(not(feature = "secp384r1"))]
-            return (
-                ResolutionMetadata::from_error("did:key type P-384 not supported"),
-                None,
-                None,
-            );
-        } else if data[0] == DID_KEY_RSA_PREFIX[0] && data[1] == DID_KEY_RSA_PREFIX[1] {
-            match rsa_x509_pub_parse(&data[2..]) {
-                Ok(jwk) => {
-                    vm_type = "JsonWebKey2020".to_string();
-                    vm_type_iri = "https://w3id.org/security#JsonWebKey2020".to_string();
-                    jwk
-                }
-                Err(err) => return (ResolutionMetadata::from_error(&err.to_string()), None, None),
-            }
-        } else if data[0] == DID_KEY_BLS12381_G2_PREFIX[0]
-            && data[1] == DID_KEY_BLS12381_G2_PREFIX[1]
-        {
-            {
-                if data.len() - 2 != 96 {
-                    return (
-                        ResolutionMetadata::from_error(ERROR_INVALID_DID),
-                        None,
-                        None,
-                    );
-                }
-                vm_type = "Bls12381G2Key2020".to_string();
-                vm_type_iri = "https://w3id.org/security#Bls12381G2Key2020".to_string();
-                // https://datatracker.ietf.org/doc/html/draft-denhartog-pairing-curves-jose-cose-00#section-3.1.3
-                JWK::from(Params::OKP(OctetParams {
-                    curve: "Bls12381G2".to_string(),
-                    public_key: Base64urlUInt(data[2..].to_vec()),
-                    private_key: None,
-                }))
-            }
-        } else {
-            return (
-                ResolutionMetadata {
-                    error: Some(ERROR_NOT_FOUND.to_string()),
-                    content_type: None,
-                    property_set: None,
-                },
-                None,
-                None,
-            );
-        };
-        context.insert(vm_type.to_string(), Value::String(vm_type_iri));
-        let vm_didurl = DIDURL {
-            did: did.to_string(),
-            fragment: Some(method_specific_id.to_string()),
-            ..Default::default()
-        };
-        let doc = Document {
-            context: Contexts::Many(vec![
-                Context::URI(DEFAULT_CONTEXT.into()),
-                Context::Object(context),
-            ]),
-            id: did.to_string(),
-            verification_method: Some(vec![VerificationMethod::Map(VerificationMethodMap {
-                id: format!("{}#{}", did, method_specific_id),
-                type_: vm_type,
-                controller: did.to_string(),
-                public_key_jwk: Some(jwk),
-                ..Default::default()
-            })]),
-            authentication: Some(vec![VerificationMethod::DIDURL(vm_didurl.clone())]),
-            assertion_method: Some(vec![VerificationMethod::DIDURL(vm_didurl)]),
-            ..Default::default()
-        };
-        (
-            ResolutionMetadata::default(),
-            Some(doc),
-            Some(DocumentMetadata::default()),
-        )
-    }
-}
-
-impl DIDMethod for DIDKey {
-    fn name(&self) -> &'static str {
-        "key"
-    }
-
-    fn generate(&self, source: &Source) -> Option<String> {
-        let jwk = match source {
-            Source::Key(jwk) => jwk,
-            Source::KeyAndPattern(jwk, pattern) => {
-                if !pattern.is_empty() {
-                    // pattern not supported
-                    return None;
-                }
-                jwk
-            }
-            _ => return None,
-        };
-        let did = match jwk.params {
+impl DIDKey {
+    pub fn generate(jwk: &JWK) -> Option<DIDBuf> {
+        use ssi_jwk::Params;
+        let id = match jwk.params {
             Params::OKP(ref params) => {
                 match &params.curve[..] {
-                    "Ed25519" => {
-                        "did:key:".to_string()
-                            + &multibase::encode(
-                                multibase::Base::Base58Btc,
-                                [DID_KEY_ED25519_PREFIX.to_vec(), params.public_key.0.clone()]
-                                    .concat(),
-                            )
-                    }
-                    "Bls12381G2" => {
-                        "did:key:".to_string()
-                            + &multibase::encode(
-                                multibase::Base::Base58Btc,
-                                [
-                                    DID_KEY_BLS12381_G2_PREFIX.to_vec(),
-                                    params.public_key.0.clone(),
-                                ]
-                                .concat(),
-                            )
-                    }
+                    "Ed25519" => Some(multibase::encode(
+                        multibase::Base::Base58Btc,
+                        [DID_KEY_ED25519_PREFIX.to_vec(), params.public_key.0.clone()].concat(),
+                    )),
+                    "Bls12381G2" => Some(multibase::encode(
+                        multibase::Base::Base58Btc,
+                        [
+                            DID_KEY_BLS12381_G2_PREFIX.to_vec(),
+                            params.public_key.0.clone(),
+                        ]
+                        .concat(),
+                    )),
                     //_ => return Some(Err(DIDKeyError::UnsupportedCurve(params.curve.clone()))),
                     _ => return None,
                 }
@@ -311,15 +73,15 @@ impl DIDMethod for DIDKey {
                             Ok(pk) => pk,
                             Err(_err) => return None,
                         };
-                        "did:key:".to_string()
-                            + &multibase::encode(
-                                multibase::Base::Base58Btc,
-                                [
-                                    DID_KEY_SECP256K1_PREFIX.to_vec(),
-                                    pk.to_encoded_point(true).as_bytes().to_vec(),
-                                ]
-                                .concat(),
-                            )
+
+                        Some(multibase::encode(
+                            multibase::Base::Base58Btc,
+                            [
+                                DID_KEY_SECP256K1_PREFIX.to_vec(),
+                                pk.to_encoded_point(true).as_bytes().to_vec(),
+                            ]
+                            .concat(),
+                        ))
                     }
                     #[cfg(feature = "secp256r1")]
                     "P-256" => {
@@ -328,15 +90,15 @@ impl DIDMethod for DIDKey {
                             Ok(pk) => pk,
                             Err(_err) => return None,
                         };
-                        "did:key:".to_string()
-                            + &multibase::encode(
-                                multibase::Base::Base58Btc,
-                                [
-                                    DID_KEY_P256_PREFIX.to_vec(),
-                                    pk.to_encoded_point(true).as_bytes().to_vec(),
-                                ]
-                                .concat(),
-                            )
+
+                        Some(multibase::encode(
+                            multibase::Base::Base58Btc,
+                            [
+                                DID_KEY_P256_PREFIX.to_vec(),
+                                pk.to_encoded_point(true).as_bytes().to_vec(),
+                            ]
+                            .concat(),
+                        ))
                     }
                     #[cfg(feature = "secp384r1")]
                     "P-384" => {
@@ -344,11 +106,11 @@ impl DIDMethod for DIDKey {
                             Ok(pk) => pk,
                             Err(_err) => return None,
                         };
-                        "did:key:".to_string()
-                            + &multibase::encode(
-                                multibase::Base::Base58Btc,
-                                [DID_KEY_P384_PREFIX.to_vec(), pk_bytes].concat(),
-                            )
+
+                        Some(multibase::encode(
+                            multibase::Base::Base58Btc,
+                            [DID_KEY_P384_PREFIX.to_vec(), pk_bytes].concat(),
+                        ))
                     }
                     //_ => return Some(Err(DIDKeyError::UnsupportedCurve(params.curve.clone()))),
                     _ => return None,
@@ -356,62 +118,294 @@ impl DIDMethod for DIDKey {
             }
             Params::RSA(ref params) => {
                 let der = simple_asn1::der_encode(&params.to_public()).ok()?;
-                "did:key:".to_string()
-                    + &multibase::encode(
-                        multibase::Base::Base58Btc,
-                        [DID_KEY_RSA_PREFIX.to_vec(), der.to_vec()].concat(),
-                    )
+                Some(multibase::encode(
+                    multibase::Base::Base58Btc,
+                    [DID_KEY_RSA_PREFIX.to_vec(), der.to_vec()].concat(),
+                ))
             }
             _ => return None, // _ => return Some(Err(DIDKeyError::UnsupportedKeyType)),
         };
-        Some(did)
+
+        id.map(|id| DIDBuf::from_string(format!("did:key:{id}")).unwrap())
+    }
+}
+
+impl DIDMethodResolver for DIDKey {
+    fn method_name(&self) -> &str {
+        "key"
     }
 
-    fn to_resolver(&self) -> &dyn DIDResolver {
-        self
+    async fn resolve_method_representation<'a>(
+        &'a self,
+        id: &'a str,
+        options: resolution::Options,
+    ) -> Result<resolution::Output<Vec<u8>>, Error> {
+        let did = DIDBuf::from_string(format!("did:key:{id}")).unwrap();
+
+        let (_base, data) =
+            multibase::decode(id).map_err(|_| Error::InvalidMethodSpecificId(id.to_owned()))?;
+
+        let (public_key, vm_type) = build_public_key(id, &data)?;
+
+        let mut json_ld_context = JsonLdContext::default();
+        json_ld_context.add_verification_method_type(vm_type);
+
+        let vm_didurl = DIDURLBuf::from_string(format!("{did}#{id}")).unwrap();
+
+        let mut doc = Document::new(did.to_owned());
+        doc.verification_method.push(
+            VerificationMethod {
+                id: vm_didurl.clone(),
+                type_: vm_type,
+                controller: did,
+                public_key,
+            }
+            .into(),
+        );
+        doc.verification_relationships
+            .authentication
+            .push(ValueOrReference::Reference(vm_didurl.clone().into()));
+        doc.verification_relationships
+            .assertion_method
+            .push(ValueOrReference::Reference(vm_didurl.into()));
+
+        let content_type = options.accept.unwrap_or(MediaType::JsonLd);
+        let represented = doc.into_representation(representation::Options::from_media_type(
+            content_type,
+            move || representation::json_ld::Options {
+                context: representation::json_ld::Context::array(
+                    representation::json_ld::DIDContext::V1,
+                    json_ld_context.into_entries(),
+                ),
+            },
+        ));
+
+        Ok(resolution::Output::new(
+            represented.to_bytes(),
+            document::Metadata::default(),
+            resolution::Metadata::from_content_type(Some(content_type.to_string())),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum VerificationMethodType {
+    Ed25519VerificationKey2018,
+    EcdsaSecp256k1VerificationKey2019,
+    EcdsaSecp256r1VerificationKey2019,
+    JsonWebKey2020,
+    Bls12381G2Key2020,
+}
+
+impl VerificationMethodType {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Ed25519VerificationKey2018 => "Ed25519VerificationKey2018",
+            Self::EcdsaSecp256k1VerificationKey2019 => "EcdsaSecp256k1VerificationKey2019",
+            Self::EcdsaSecp256r1VerificationKey2019 => "EcdsaSecp256r1VerificationKey2019",
+            Self::JsonWebKey2020 => "JsonWebKey2020",
+            Self::Bls12381G2Key2020 => "Bls12381G2Key2020",
+        }
+    }
+
+    pub fn iri(&self) -> &'static Iri {
+        match self {
+            Self::Ed25519VerificationKey2018 => {
+                iri!("https://w3id.org/security#Ed25519VerificationKey2018")
+            }
+            Self::EcdsaSecp256k1VerificationKey2019 => {
+                iri!("https://w3id.org/security#EcdsaSecp256k1VerificationKey2019")
+            }
+            Self::EcdsaSecp256r1VerificationKey2019 => {
+                iri!("https://w3id.org/security#EcdsaSecp256r1VerificationKey2019")
+            }
+            Self::JsonWebKey2020 => iri!("https://w3id.org/security#JsonWebKey2020"),
+            Self::Bls12381G2Key2020 => iri!("https://w3id.org/security#Bls12381G2Key2020"),
+        }
+    }
+}
+
+pub struct VerificationMethod {
+    id: DIDURLBuf,
+    type_: VerificationMethodType,
+    controller: DIDBuf,
+    public_key: PublicKey,
+}
+
+impl From<VerificationMethod> for DIDVerificationMethod {
+    fn from(value: VerificationMethod) -> Self {
+        let mut properties = BTreeMap::new();
+
+        match value.public_key {
+            PublicKey::Jwk(jwk) => {
+                properties.insert(
+                    "publicKeyJwk".to_owned(),
+                    serde_json::to_value(jwk).unwrap(),
+                );
+            }
+            PublicKey::Base58(key) => {
+                properties.insert("publicKeyBase58".to_owned(), key.into());
+            }
+            PublicKey::Multibase(key) => {
+                properties.insert("publicKeyMultibase".to_owned(), key.into());
+            }
+        }
+
+        Self {
+            id: value.id,
+            type_: value.type_.name().to_owned(),
+            controller: value.controller,
+            properties,
+        }
+    }
+}
+
+pub enum PublicKey {
+    Jwk(JWK),
+    Base58(String),
+    Multibase(String),
+}
+
+fn build_public_key(id: &str, data: &[u8]) -> Result<(PublicKey, VerificationMethodType), Error> {
+    use ssi_jwk::{Base64urlUInt, OctetParams, Params};
+
+    if data.len() < 2 {
+        return Err(Error::InvalidMethodSpecificId(id.to_owned()));
+    }
+
+    if data[0] == DID_KEY_ED25519_PREFIX[0] && data[1] == DID_KEY_ED25519_PREFIX[1] {
+        if data.len() - 2 != 32 {
+            return Err(Error::InvalidMethodSpecificId(id.to_owned()));
+        }
+
+        // let jwk = JWK {
+        //     params: Params::OKP(OctetParams {
+        //         curve: "Ed25519".to_string(),
+        //         public_key: Base64urlUInt(data[2..].to_vec()),
+        //         private_key: None,
+        //     }),
+        //     public_key_use: None,
+        //     key_operations: None,
+        //     algorithm: None,
+        //     key_id: None,
+        //     x509_url: None,
+        //     x509_certificate_chain: None,
+        //     x509_thumbprint_sha1: None,
+        //     x509_thumbprint_sha256: None,
+        // };
+
+        let key = bs58::encode(&data[2..]).into_string();
+
+        Ok((
+            PublicKey::Base58(key),
+            VerificationMethodType::Ed25519VerificationKey2018,
+        ))
+    } else if data[0] == DID_KEY_SECP256K1_PREFIX[0] && data[1] == DID_KEY_SECP256K1_PREFIX[1] {
+        if data.len() - 2 != 33 {
+            return Err(Error::InvalidMethodSpecificId(id.to_owned()));
+        }
+
+        #[cfg(feature = "secp256k1")]
+        match ssi_jwk::secp256k1_parse(&data[2..]) {
+            Ok(jwk) => Ok((
+                PublicKey::Jwk(jwk),
+                VerificationMethodType::EcdsaSecp256k1VerificationKey2019,
+            )),
+            Err(_) => Err(Error::InvalidMethodSpecificId(id.to_owned())),
+        }
+        #[cfg(not(feature = "secp256k1"))]
+        Err(Error::Internal(Box::new(Unsupported::Secp256k1)))
+    } else if data[0] == DID_KEY_P256_PREFIX[0] && data[1] == DID_KEY_P256_PREFIX[1] {
+        #[cfg(feature = "secp256r1")]
+        {
+            let encoded_key =
+                ssi_multicodec::MultiEncodedBuf::encode(ssi_multicodec::P256_PUB, &data[2..]);
+            let multibase_key =
+                multibase::encode(multibase::Base::Base58Btc, encoded_key.as_bytes());
+
+            Ok((
+                PublicKey::Multibase(multibase_key),
+                VerificationMethodType::EcdsaSecp256r1VerificationKey2019,
+            ))
+        }
+        #[cfg(not(feature = "secp256r1"))]
+        return Err(Error::Internal(Box::new(Unsupported::P256)));
+    } else if data[0] == DID_KEY_P384_PREFIX[0] && data[1] == DID_KEY_P384_PREFIX[1] {
+        #[cfg(feature = "secp384r1")]
+        match ssi_jwk::p384_parse(&data[2..]) {
+            Ok(jwk) => Ok((PublicKey::Jwk(jwk), VerificationMethodType::JsonWebKey2020)),
+            Err(_) => Err(Error::InvalidMethodSpecificId(id.to_owned())),
+        }
+        #[cfg(not(feature = "secp384r1"))]
+        Err(Error::Internal(Box::new(Unsupported::P384)))
+    } else if data[0] == DID_KEY_RSA_PREFIX[0] && data[1] == DID_KEY_RSA_PREFIX[1] {
+        match ssi_jwk::rsa_x509_pub_parse(&data[2..]) {
+            Ok(jwk) => Ok((PublicKey::Jwk(jwk), VerificationMethodType::JsonWebKey2020)),
+            Err(_) => Err(Error::InvalidMethodSpecificId(id.to_owned())),
+        }
+    } else if data[0] == DID_KEY_BLS12381_G2_PREFIX[0] && data[1] == DID_KEY_BLS12381_G2_PREFIX[1] {
+        if data.len() - 2 != 96 {
+            return Err(Error::InvalidMethodSpecificId(id.to_owned()));
+        }
+
+        let jwk = JWK::from(Params::OKP(OctetParams {
+            curve: "Bls12381G2".to_string(),
+            public_key: Base64urlUInt(data[2..].to_vec()),
+            private_key: None,
+        }));
+
+        // https://datatracker.ietf.org/doc/html/draft-denhartog-pairing-curves-jose-cose-00#section-3.1.3
+        // FIXME: This should be a base 58 key according to the spec.
+        Ok((
+            PublicKey::Jwk(jwk),
+            VerificationMethodType::Bls12381G2Key2020,
+        ))
+    } else {
+        Err(Error::NotFound)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use iref::IriBuf;
+    use rand_chacha::rand_core::SeedableRng as SeedableRngOld;
+    use rand_chacha_old::rand_core::SeedableRng;
+    use ssi_dids::{did, resolution::Options, DIDResolver, DIDVerifier, DIDURL};
+    use ssi_top::data_integrity::{AnyInputContext, AnySuite, AnySuiteOptions};
+    use ssi_vc_ldp::{
+        verification::{
+            method::{signer::SingleSecretSigner, ProofPurpose},
+            MethodReferenceOrOwned,
+        },
+        CryptographicSuiteInput, ProofConfiguration,
+    };
+
     use super::*;
-    use ssi_dids::did_resolve::{dereference, Content, DereferencingInputMetadata};
-    use ssi_dids::Resource;
+    // use ssi_dids::did_resolve::{dereference, Content, DereferencingInputMetadata};
+    // use ssi_dids::Resource;
 
     #[async_std::test]
     async fn from_did_key() {
-        let vm = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
-        let (res_meta, object, _meta) =
-            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
-        assert_eq!(res_meta.error, None);
-        let vm = match object {
-            Content::Object(Resource::VerificationMethod(vm)) => vm,
-            _ => unreachable!(),
-        };
-        vm.public_key_jwk.unwrap();
+        let did_url = DIDURL::new(b"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap();
+        let output = DIDKey.dereference(did_url).await.unwrap();
+        let vm = output.content.into_verification_method().unwrap();
+        vm.properties.get("publicKeyBase58").unwrap();
     }
 
     #[async_std::test]
     #[cfg(feature = "secp256k1")]
     async fn from_did_key_secp256k1() {
-        let did = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
-        let (res_meta, _doc, _doc_meta) = DIDKey
-            .resolve(did, &ResolutionInputMetadata::default())
-            .await;
-        assert_eq!(res_meta.error, None);
+        let did = did!("did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme");
+        DIDKey.resolve_with(did, Options::default()).await.unwrap();
 
-        let vm = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme#zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
-        let (res_meta, object, _meta) =
-            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
-        assert_eq!(res_meta.error, None);
-        let vm = match object {
-            Content::Object(Resource::VerificationMethod(vm)) => vm,
-            _ => unreachable!(),
-        };
-        let key = vm.public_key_jwk.unwrap();
+        let did_url = DIDURL::new(b"did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme#zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme").unwrap();
+        let output = DIDKey.dereference(did_url).await.unwrap();
+        let mut vm = output.content.into_verification_method().unwrap();
+        let key: JWK =
+            serde_json::from_value(vm.properties.remove("publicKeyJwk").unwrap()).unwrap();
 
         // convert back to DID from JWK
-        let did1 = DIDKey.generate(&Source::Key(&key)).unwrap();
+        let did1 = DIDKey::generate(&key).unwrap();
         assert_eq!(did1, did);
     }
 
@@ -419,21 +413,23 @@ mod tests {
     #[async_std::test]
     async fn from_did_key_p256() {
         // https://w3c-ccg.github.io/did-method-key/#p-256
-        let did = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
-        let (res_meta, _doc, _doc_meta) = DIDKey
-            .resolve(did, &ResolutionInputMetadata::default())
-            .await;
-        assert_eq!(res_meta.error, None);
+        let did = did!("did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169");
+        DIDKey.resolve_with(did, Options::default()).await.unwrap();
 
-        let vm = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169#zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
-        let (res_meta, object, _meta) =
-            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
-        assert_eq!(res_meta.error, None);
-        let vm = match object {
-            Content::Object(Resource::VerificationMethod(vm)) => vm,
-            _ => unreachable!(),
-        };
-        let key = vm.public_key_jwk.unwrap();
+        let did_url = DIDURL::new(b"did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169#zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169").unwrap();
+        let output = DIDKey.dereference(did_url).await.unwrap();
+        let vm = output.content.into_verification_method().unwrap();
+        let multibase_key = vm
+            .properties
+            .get("publicKeyMultibase")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let (base, encoded_key) = multibase::decode(multibase_key).unwrap();
+        assert_eq!(base, multibase::Base::Base58Btc);
+        let encoded_key = ssi_multicodec::MultiEncodedBuf::new(encoded_key).unwrap();
+        assert_eq!(encoded_key.codec(), ssi_multicodec::P256_PUB);
+        let key = ssi_jwk::JWK::from_multicodec(&encoded_key).unwrap();
         eprintln!("key {}", serde_json::to_string_pretty(&key).unwrap());
 
         // https://github.com/w3c-ccg/did-method-key/blob/master/test-vectors/nist-curves.json#L64-L69
@@ -446,28 +442,21 @@ mod tests {
         .unwrap();
         assert_eq!(key, key_expected);
 
-        let did1 = DIDKey.generate(&Source::Key(&key)).unwrap();
+        let did1 = DIDKey::generate(&key).unwrap();
         assert_eq!(did1, did);
     }
 
     #[async_std::test]
     async fn from_did_key_bls() {
         // https://w3c-ccg.github.io/did-method-key/#bls-12381
-        let did = "did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY";
-        let (res_meta, _doc, _doc_meta) = DIDKey
-            .resolve(did, &ResolutionInputMetadata::default())
-            .await;
-        assert_eq!(res_meta.error, None);
+        let did = did!("did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY");
+        DIDKey.resolve_with(did, Options::default()).await.unwrap();
 
-        let vm = "did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY#zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY";
-        let (res_meta, object, _meta) =
-            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
-        assert_eq!(res_meta.error, None);
-        let vm = match object {
-            Content::Object(Resource::VerificationMethod(vm)) => vm,
-            _ => unreachable!(),
-        };
-        let key = vm.public_key_jwk.unwrap();
+        let did_url = DIDURL::new(b"did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY#zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY").unwrap();
+        let output = DIDKey.dereference(did_url).await.unwrap();
+        let mut vm = output.content.into_verification_method().unwrap();
+        let key: JWK =
+            serde_json::from_value(vm.properties.remove("publicKeyJwk").unwrap()).unwrap();
         eprintln!("key {}", serde_json::to_string_pretty(&key).unwrap());
 
         // Note: this "x" value is generated by this implementation - not yet confirmed with other
@@ -481,27 +470,20 @@ mod tests {
         .unwrap();
         assert_eq!(key, key_expected);
 
-        let did1 = DIDKey.generate(&Source::Key(&key)).unwrap();
+        let did1 = DIDKey::generate(&key).unwrap();
         assert_eq!(did1, did);
     }
 
     #[async_std::test]
     async fn from_did_key_rsa() {
-        let did = "did:key:z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i";
-        let (res_meta, _doc, _doc_meta) = DIDKey
-            .resolve(did, &ResolutionInputMetadata::default())
-            .await;
-        assert_eq!(res_meta.error, None);
+        let did = did!("did:key:z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i");
+        DIDKey.resolve_with(did, Options::default()).await.unwrap();
 
-        let vm = "did:key:z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i#z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i";
-        let (res_meta, object, _meta) =
-            dereference(&DIDKey, vm, &DereferencingInputMetadata::default()).await;
-        assert_eq!(res_meta.error, None);
-        let vm = match object {
-            Content::Object(Resource::VerificationMethod(vm)) => vm,
-            _ => unreachable!(),
-        };
-        let key = vm.public_key_jwk.unwrap();
+        let vm = DIDURL::new(b"did:key:z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i#z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i").unwrap();
+        let output = DIDKey.dereference(vm).await.unwrap();
+        let mut vm = output.content.into_verification_method().unwrap();
+        let key: JWK =
+            serde_json::from_value(vm.properties.remove("publicKeyJwk").unwrap()).unwrap();
         eprintln!("key {}", serde_json::to_string_pretty(&key).unwrap());
 
         let key_expected: JWK = serde_json::from_value(serde_json::json!({
@@ -512,135 +494,233 @@ mod tests {
         .unwrap();
         assert_eq!(key, key_expected);
 
-        let did1 = DIDKey.generate(&Source::Key(&key)).unwrap();
+        let did1 = DIDKey::generate(&key).unwrap();
         assert_eq!(did1, did);
+    }
+
+    #[derive(Clone, serde::Serialize, linked_data::Serialize)]
+    #[ld(prefix("cred" = "https://www.w3.org/2018/credentials#"))]
+    #[ld(type = "cred:VerifiableCredential")]
+    #[serde(rename_all = "camelCase")]
+    struct TestCredential {
+        #[ld(id)]
+        id: Option<IriBuf>,
+
+        #[ld("cred:issuer")]
+        issuer: IriBuf,
+
+        #[ld("cred:issuanceDate")]
+        issuance_date: xsd_types::DateTime,
+
+        #[ld("cred:credentialSubject")]
+        credential_subject: CredentialSubject,
+    }
+
+    #[derive(Clone, serde::Serialize, linked_data::Serialize)]
+    struct CredentialSubject {
+        #[ld(id)]
+        id: IriBuf,
     }
 
     #[async_std::test]
     async fn credential_prove_verify_did_key() {
-        use ssi_vc::{get_verification_method, Credential, Issuer, LinkedDataProofOptions, URI};
-        let vc_str = r###"{
-            "@context": "https://www.w3.org/2018/credentials/v1",
-            "id": "http://example.org/credentials/3731",
-            "type": ["VerifiableCredential"],
-            "issuer": "did:example:30e07a529f32d234f6181736bd3",
-            "issuanceDate": "2020-08-19T21:41:50Z",
-            "credentialSubject": {
-                "id": "did:example:d23dd687a7dc6787646f2eb98d0"
-            }
-        }"###;
-        let mut vc: Credential = Credential::from_json_unsigned(vc_str).unwrap();
+        let didkey = DIDVerifier::new(DIDKey);
 
-        let key = JWK::generate_ed25519().unwrap();
-        let did = DIDKey.generate(&Source::Key(&key)).unwrap();
-        let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
-        let mut issue_options = LinkedDataProofOptions::default();
-        let mut context_loader = ssi_json_ld::ContextLoader::default();
-        vc.issuer = Some(Issuer::URI(URI::String(did.clone())));
-        issue_options.verification_method = Some(URI::String(verification_method));
-        let proof = vc
-            .generate_proof(&key, &issue_options, &DIDKey, &mut context_loader)
+        let mut rng = rand_chacha_old::ChaCha8Rng::seed_from_u64(2);
+        let key = JWK::generate_ed25519_from(&mut rng).unwrap();
+        let did = DIDKey::generate(&key).unwrap();
+
+        let cred = TestCredential {
+            id: Some(iri!("http://example.org/credentials/3731").to_owned()),
+            issuer: did.clone().into(),
+            issuance_date: "2020-08-19T21:41:50Z".parse().unwrap(),
+            credential_subject: CredentialSubject {
+                id: iri!("did:example:d23dd687a7dc6787646f2eb98d0").to_owned(),
+            },
+        };
+
+        let verification_method = DIDKey
+            .resolve_into_any_verification_method(&did)
+            .await
+            .unwrap()
+            .unwrap();
+        let verification_method_ref =
+            MethodReferenceOrOwned::Reference(verification_method.id.into());
+        // issue_options.verification_method = Some(URI::String(verification_method));
+        let suite = AnySuite::pick(&key, Some(&verification_method_ref)).unwrap();
+
+        let issue_options = ProofConfiguration {
+            created: "2020-08-19T21:41:50Z".parse().unwrap(),
+            verification_method: verification_method_ref,
+            proof_purpose: ProofPurpose::Assertion,
+            options: AnySuiteOptions::default(),
+        };
+        let signer = SingleSecretSigner::new(&didkey, key);
+        let vc = suite
+            .sign(cred, AnyInputContext::default(), &signer, issue_options)
             .await
             .unwrap();
-        println!("{}", serde_json::to_string_pretty(&proof).unwrap());
-        vc.add_proof(proof);
-        vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDKey, &mut context_loader).await;
-        println!("{:#?}", verification_result);
-        assert!(verification_result.errors.is_empty());
+        println!(
+            "proof: {}",
+            serde_json::to_string_pretty(vc.proof()).unwrap()
+        );
+        assert_eq!(vc.proof().signature().jws.as_ref().unwrap().as_str(), "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..o4SzDo1RBQqdK49OPdmfVRVh68xCTNEmb7hq39IVqISkelld6t6Aatg4PCXKpopIXmX8RCCF4BwrO8ERg1YFBg");
+        assert!(vc.verify(&didkey).await.unwrap().is_valid());
 
         // test that issuer is verified
-        vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(!vc
-            .verify(None, &DIDKey, &mut context_loader)
+        let vc_bad_issuer = vc
+            .clone()
+            .async_try_map(|di, proof| async {
+                di.map(
+                    AnyInputContext::default(),
+                    proof.suite(),
+                    proof.configuration(),
+                    |mut cred| {
+                        cred.issuer = iri!("did:pkh:example:bad").to_owned();
+                        cred
+                    },
+                )
+                .await
+                .map(|di| (di, proof))
+            })
             .await
-            .errors
-            .is_empty());
+            .unwrap();
+        // It should fail.
+        assert!(vc_bad_issuer.verify(&didkey).await.unwrap().is_invalid());
     }
 
     #[async_std::test]
     #[cfg(feature = "secp256k1")]
     async fn credential_prove_verify_did_key_secp256k1() {
-        use serde_json::json;
-        use ssi_vc::{get_verification_method, Credential, Issuer, LinkedDataProofOptions, URI};
-        let key = JWK::generate_secp256k1().unwrap();
-        let did = DIDKey.generate(&Source::Key(&key)).unwrap();
-        let mut vc: Credential = serde_json::from_value(json!({
-            "@context": "https://www.w3.org/2018/credentials/v1",
-            "type": ["VerifiableCredential"],
-            "issuer": did.clone(),
-            "issuanceDate": "2021-02-18T20:17:46Z",
-            "credentialSubject": {
-                "id": "did:example:d23dd687a7dc6787646f2eb98d0"
-            }
-        }))
-        .unwrap();
-        vc.validate_unsigned().unwrap();
+        let didkey = DIDVerifier::new(DIDKey);
 
-        let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
-        let mut issue_options = LinkedDataProofOptions::default();
-        let mut context_loader = ssi_json_ld::ContextLoader::default();
-        issue_options.verification_method = Some(URI::String(verification_method));
-        let proof = vc
-            .generate_proof(&key, &issue_options, &DIDKey, &mut context_loader)
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(2);
+        let key = JWK::generate_secp256k1_from(&mut rng).unwrap();
+        let did = DIDKey::generate(&key).unwrap();
+
+        let cred = TestCredential {
+            id: None,
+            issuer: did.clone().into(),
+            issuance_date: "2021-02-18T20:17:46Z".parse().unwrap(),
+            credential_subject: CredentialSubject {
+                id: iri!("did:example:d23dd687a7dc6787646f2eb98d0").to_owned(),
+            },
+        };
+
+        let verification_method = DIDKey
+            .resolve_into_any_verification_method(&did)
+            .await
+            .unwrap()
+            .unwrap();
+        let verification_method_ref =
+            MethodReferenceOrOwned::Reference(verification_method.id.into());
+        // issue_options.verification_method = Some(URI::String(verification_method));
+        let suite = AnySuite::pick(&key, Some(&verification_method_ref)).unwrap();
+        eprintln!("suite: {suite:?}");
+        let issue_options = ProofConfiguration {
+            created: "2021-02-18T20:17:46Z".parse().unwrap(),
+            verification_method: verification_method_ref,
+            proof_purpose: ProofPurpose::Assertion,
+            options: AnySuiteOptions::default(),
+        };
+        let signer = SingleSecretSigner::new(&didkey, key);
+        let vc = suite
+            .sign(cred, AnyInputContext::default(), &signer, issue_options)
             .await
             .unwrap();
-        println!("{}", serde_json::to_string_pretty(&proof).unwrap());
-        vc.add_proof(proof);
-        vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDKey, &mut context_loader).await;
-        println!("{:#?}", verification_result);
-        assert!(verification_result.errors.is_empty());
+        println!(
+            "proof: {}",
+            serde_json::to_string_pretty(vc.proof()).unwrap()
+        );
+        assert_eq!(vc.proof().signature().jws.as_ref().unwrap().as_str(), "eyJhbGciOiJFUzI1NksiLCJjcml0IjpbImI2NCJdLCJiNjQiOmZhbHNlfQ..jTUkFd_eYI72Y8j2OS5LRLhlc3gZn-gVsb76soi3FuJ5gWrbOb0W2CW6D-sjEsCuLkvSOfYd8Y8hB9pyeeZ2TQ");
+        assert!(vc.verify(&didkey).await.unwrap().is_valid());
 
         // test that issuer is verified
-        vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(!vc
-            .verify(None, &DIDKey, &mut context_loader)
+        let vc_bad_issuer = vc
+            .clone()
+            .async_try_map(|di, proof| async {
+                di.map(
+                    AnyInputContext::default(),
+                    proof.suite(),
+                    proof.configuration(),
+                    |mut cred| {
+                        cred.issuer = iri!("did:pkh:example:bad").to_owned();
+                        cred
+                    },
+                )
+                .await
+                .map(|di| (di, proof))
+            })
             .await
-            .errors
-            .is_empty());
+            .unwrap();
+        // It should fail.
+        assert!(vc_bad_issuer.verify(&didkey).await.unwrap().is_invalid());
     }
 
     #[async_std::test]
     #[cfg(feature = "secp256r1")]
     async fn credential_prove_verify_did_key_p256() {
-        use serde_json::json;
-        use ssi_vc::{get_verification_method, Credential, Issuer, LinkedDataProofOptions, URI};
-        let key = JWK::generate_p256().unwrap();
-        let did = DIDKey.generate(&Source::Key(&key)).unwrap();
-        let mut vc: Credential = serde_json::from_value(json!({
-            "@context": "https://www.w3.org/2018/credentials/v1",
-            "type": ["VerifiableCredential"],
-            "issuer": did.clone(),
-            "issuanceDate": "2021-02-18T20:17:46Z",
-            "credentialSubject": {
-                "id": "did:example:d23dd687a7dc6787646f2eb98d0"
-            }
-        }))
-        .unwrap();
-        vc.validate_unsigned().unwrap();
+        let didkey = DIDVerifier::new(DIDKey);
 
-        let verification_method = get_verification_method(&did, &DIDKey).await.unwrap();
-        let mut issue_options = LinkedDataProofOptions::default();
-        let mut context_loader = ssi_json_ld::ContextLoader::default();
-        issue_options.verification_method = Some(URI::String(verification_method));
-        let proof = vc
-            .generate_proof(&key, &issue_options, &DIDKey, &mut context_loader)
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(2);
+        let key = JWK::generate_p256_from(&mut rng).unwrap();
+        let did = DIDKey::generate(&key).unwrap();
+
+        let cred = TestCredential {
+            id: None,
+            issuer: did.clone().into(),
+            issuance_date: "2021-02-18T20:17:46Z".parse().unwrap(),
+            credential_subject: CredentialSubject {
+                id: iri!("did:example:d23dd687a7dc6787646f2eb98d0").to_owned(),
+            },
+        };
+
+        let verification_method = DIDKey
+            .resolve_into_any_verification_method(&did)
+            .await
+            .unwrap()
+            .unwrap();
+        let verification_method_ref =
+            MethodReferenceOrOwned::Reference(verification_method.id.into());
+        // issue_options.verification_method = Some(URI::String(verification_method));
+        let suite = AnySuite::pick(&key, Some(&verification_method_ref)).unwrap();
+        eprintln!("suite: {suite:?}");
+        let issue_options = ProofConfiguration {
+            created: "2021-02-18T20:17:46Z".parse().unwrap(),
+            verification_method: verification_method_ref,
+            proof_purpose: ProofPurpose::Assertion,
+            options: AnySuiteOptions::default(),
+        };
+        let signer = SingleSecretSigner::new(&didkey, key);
+        let vc = suite
+            .sign(cred, AnyInputContext::default(), &signer, issue_options)
             .await
             .unwrap();
-        println!("{}", serde_json::to_string_pretty(&proof).unwrap());
-        vc.add_proof(proof);
-        vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDKey, &mut context_loader).await;
-        println!("{:#?}", verification_result);
-        assert!(verification_result.errors.is_empty());
+        println!(
+            "proof: {}",
+            serde_json::to_string_pretty(vc.proof()).unwrap()
+        );
+        assert!(vc.verify(&didkey).await.unwrap().is_valid());
 
         // test that issuer is verified
-        vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(!vc
-            .verify(None, &DIDKey, &mut context_loader)
+        let vc_bad_issuer = vc
+            .clone()
+            .async_try_map(|di, proof| async {
+                di.map(
+                    AnyInputContext::default(),
+                    proof.suite(),
+                    proof.configuration(),
+                    |mut cred| {
+                        cred.issuer = iri!("did:pkh:example:bad").to_owned();
+                        cred
+                    },
+                )
+                .await
+                .map(|di| (di, proof))
+            })
             .await
-            .errors
-            .is_empty());
+            .unwrap();
+        // It should fail.
+        assert!(vc_bad_issuer.verify(&didkey).await.unwrap().is_invalid());
     }
 }

--- a/did-pkh/src/lib.rs
+++ b/did-pkh/src/lib.rs
@@ -1597,7 +1597,8 @@ mod tests {
         other_key_p256.algorithm = Some(Algorithm::ES256);
     }
 
-    async fn test_verify_vc(vc_str: &str, num_warnings: usize) {
+    async fn test_verify_vc(vc_str: &str, _num_warnings: usize) {
+        // TODO check warnings maybe?
         eprintln!("input: {vc_str}");
 
         let vc = ssi_top::data_integrity::from_json_ld_str_with_defaults(vc_str)

--- a/did-tezos/src/lib.rs
+++ b/did-tezos/src/lib.rs
@@ -23,7 +23,7 @@ use json_patch::patch;
 use serde::Deserialize;
 use ssi_jwk::{p256_parse, secp256k1_parse, Base64urlUInt, OctetParams, Params, JWK};
 use ssi_jws::{decode_unverified, decode_verify};
-use std::{collections::BTreeMap, future::Future, pin::Pin};
+use std::{collections::BTreeMap, future::Future};
 
 mod explorer;
 mod prefix;
@@ -532,7 +532,7 @@ impl DIDTz {
                         let curve = VerificationMethodType::from_prefix(prefix)
                             .curve()
                             .to_string();
-    
+
                         let kid = match patch_metadata.key_id {
                             Some(k) => DIDURLBuf::from_string(k)
                                 .map_err(|e| UpdateError::InvalidPatchKeyId(e.0)),
@@ -541,7 +541,7 @@ impl DIDTz {
                                 Err(UpdateError::MissingPatchKeyId)
                             }
                         }?;
-    
+
                         // TODO need to compare address + network instead of the String
                         // did:tz:tz1blahblah == did:tz:mainnet:tz1blahblah
                         let kid_doc = if kid.did() == &doc.id {
@@ -559,12 +559,12 @@ impl DIDTz {
                                 }
                             }
                         };
-    
+
                         if let Some(public_key) = get_public_key_from_doc(&kid_doc, &kid) {
                             let jwk = match prefix {
                                 Prefix::TZ1 | Prefix::KT1 => {
                                     let pk = decode_public_key(public_key)?;
-    
+
                                     JWK {
                                         params: Params::OKP(OctetParams {
                                             curve,
@@ -601,8 +601,8 @@ impl DIDTz {
                                     return Err(UpdateError::PrefixNotEnabled(p));
                                 }
                             };
-                            let (_, patch_) =
-                                decode_verify(&jws, &jwk).map_err(|e| UpdateError::InvalidJws(e))?;
+                            let (_, patch_) = decode_verify(&jws, &jwk)
+                                .map_err(|e| UpdateError::InvalidJws(e))?;
                             patch(
                                 &mut doc_json,
                                 &serde_json::from_slice(
@@ -615,7 +615,7 @@ impl DIDTz {
                                 .map_err(|e| UpdateError::InvalidPatch(e))?,
                             )
                             .map_err(|e| UpdateError::Patch(e))?;
-    
+
                             *doc = serde_json::from_value(doc_json)
                                 .map_err(|e| UpdateError::InvalidPatchedDocument(e))?;
                         } else {
@@ -625,7 +625,7 @@ impl DIDTz {
                     }
                 }
             }
-    
+
             Ok(())
         })
     }

--- a/did-tezos/tests/did.rs
+++ b/did-tezos/tests/did.rs
@@ -44,13 +44,16 @@ fn jwk_to_tz3() {
 async fn test_too_short_did() {
     // Subslicing this method-specific id by byte range 0..3 would overflow.
     let bad_did = did!("did:tz:tz");
-    assert!(DIDTZ.resolve(bad_did, Options::default()).await.is_err())
+    assert!(DIDTZ
+        .resolve_with(bad_did, Options::default())
+        .await
+        .is_err())
 }
 
 #[tokio::test]
 async fn test_derivation_tz1() {
     let output = DIDTZ
-        .resolve(
+        .resolve_with(
             did!("did:tz:mainnet:tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8"),
             Options::default(),
         )
@@ -88,7 +91,7 @@ async fn test_derivation_tz1() {
 #[tokio::test]
 async fn test_derivation_tz2() {
     let output = DIDTZ
-        .resolve(
+        .resolve_with(
             did!("did:tz:mainnet:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"),
             Options::default(),
         )
@@ -126,7 +129,7 @@ async fn test_derivation_tz2() {
 #[tokio::test]
 async fn test_derivation_tz3() {
     let resolved = DIDTZ
-        .resolve(
+        .resolve_with(
             did!("did:tz:mainnet:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX"),
             Options::default(),
         )

--- a/ssi-dids/src/document.rs
+++ b/ssi-dids/src/document.rs
@@ -152,6 +152,15 @@ impl Document {
     pub fn into_representation(self, options: representation::Options) -> Represented {
         Represented::new(self, options)
     }
+
+    /// Consumes the document and returns any verification method in contains.
+    ///
+    /// This will return the first verification method found, although users
+    /// should not expect the DID documents to always list verification methods
+    /// in the same order.
+    pub fn into_any_verification_method(self) -> Option<DIDVerificationMethod> {
+        self.verification_method.into_iter().next()
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/ssi-dids/src/resolution.rs
+++ b/ssi-dids/src/resolution.rs
@@ -1,21 +1,17 @@
 use std::collections::BTreeMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::task;
 
 use iref::IriRefBuf;
-use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    document::{self, representation, InvalidData},
-    Document, Fragment, PrimaryDIDURL, DID, DIDURL,
+    document::{self, representation, DIDVerificationMethod, InvalidData},
+    Document, PrimaryDIDURL, DID, DIDURL,
 };
 
-mod composition;
+// mod composition;
 mod dereference;
 
-pub use composition::*;
+// pub use composition::*;
 pub use dereference::*;
 
 #[cfg(feature = "http")]
@@ -93,106 +89,6 @@ pub enum ErrorKind {
     Internal,
 }
 
-#[pin_project]
-pub struct Resolve<'a, T: 'a + ?Sized + DIDResolver> {
-    #[pin]
-    inner: T::ResolveRepresentation<'a>,
-}
-
-impl<'a, T: 'a + ?Sized + DIDResolver> Resolve<'a, T> {
-    fn new(f: T::ResolveRepresentation<'a>) -> Self {
-        Self { inner: f }
-    }
-}
-
-impl<'a, T: ?Sized + DIDResolver> Future for Resolve<'a, T> {
-    type Output = Result<Output, Error>;
-
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.inner.poll(cx).map(|result| {
-            result.and_then(|output| match &output.metadata.content_type {
-                None => Err(Error::NoRepresentation),
-                Some(ty) => {
-                    let ty: representation::MediaType = ty.parse()?;
-                    output
-                        .try_map(|bytes| Document::from_bytes(ty, &bytes))
-                        .map_err(Error::InvalidData)
-                }
-            })
-        })
-    }
-}
-
-#[pin_project]
-pub struct DereferencePrimary<'a, T: ?Sized + DIDResolver> {
-    resolver: &'a T,
-
-    primary_did_url: &'a PrimaryDIDURL,
-
-    parameters: Option<Parameters>,
-
-    options: &'a DerefOptions,
-
-    #[pin]
-    resolution: Resolve<'a, T>,
-
-    #[pin]
-    dereference: Option<DereferencePrimaryResource<'a, T>>,
-}
-
-impl<'a, T: ?Sized + DIDResolver> DereferencePrimary<'a, T> {
-    fn new(
-        resolver: &'a T,
-        primary_did_url: &'a PrimaryDIDURL,
-        parameters: Parameters,
-        options: &'a DerefOptions,
-        resolution: Resolve<'a, T>,
-    ) -> Self {
-        Self {
-            resolver,
-            primary_did_url,
-            parameters: Some(parameters),
-            options,
-            resolution,
-            dereference: None,
-        }
-    }
-}
-
-impl<'a, T: ?Sized + DIDResolver> Future for DereferencePrimary<'a, T> {
-    type Output = Result<DerefOutput<PrimaryContent>, DerefError>;
-
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> task::Poll<Self::Output> {
-        let mut this = self.project();
-        if this.dereference.is_none() {
-            match this.resolution.poll(cx) {
-                task::Poll::Ready(Ok(resolution_output)) => {
-                    // 3
-                    this.dereference.set(Some(dereference_primary_resource::<T>(
-                        this.resolver,
-                        this.primary_did_url,
-                        this.parameters.take().unwrap(),
-                        this.options,
-                        resolution_output,
-                    )))
-                }
-                task::Poll::Ready(Err(e)) => return task::Poll::Ready(Err(e.into())),
-                task::Poll::Pending => return task::Poll::Pending,
-            }
-        }
-
-        let dereference = this.dereference.as_pin_mut().unwrap();
-        dereference.poll(cx)
-    }
-}
-
 pub trait DIDResolverByMethod {
     type MethodResolver: DIDMethodResolver;
 
@@ -205,110 +101,99 @@ pub trait DIDResolverByMethod {
 }
 
 impl<T: DIDResolverByMethod> DIDResolver for T {
-    type ResolveRepresentation<'a> = ResolveRepresentationByMethod<'a, T::MethodResolver> where Self: 'a;
-
-    fn resolve_representation<'a>(
+    async fn resolve_representation<'a>(
         &'a self,
         did: &'a DID,
         options: Options,
-    ) -> Self::ResolveRepresentation<'a> {
+    ) -> Result<Output<Vec<u8>>, Error> {
         match self.get_method(did.method_name()) {
-            Some(m) => ResolveRepresentationByMethod::pending(
-                m.resolve_method_representation(did.method_specific_id(), options),
-            ),
-            None => ResolveRepresentationByMethod::err(Error::MethodNotSupported(
-                did.method_name().to_string(),
-            )),
+            Some(m) => {
+                m.resolve_method_representation(did.method_specific_id(), options)
+                    .await
+            }
+            None => Err(Error::MethodNotSupported(did.method_name().to_string())),
         }
     }
 }
-
-#[pin_project]
-pub struct ResolveRepresentationByMethod<'a, M: 'a + ?Sized + DIDMethodResolver> {
-    #[pin]
-    inner: ResolveRepresentationByMethodInner<'a, M>,
-}
-
-impl<'a, M: ?Sized + DIDMethodResolver> ResolveRepresentationByMethod<'a, M> {
-    fn pending(f: M::ResolveMethodRepresentation<'a>) -> Self {
-        Self {
-            inner: ResolveRepresentationByMethodInner::Pending(f),
-        }
-    }
-
-    fn err(e: Error) -> Self {
-        Self {
-            inner: ResolveRepresentationByMethodInner::Err(Some(e)),
-        }
-    }
-}
-
-#[pin_project(project = ResolveRepresentationByMethodProj)]
-pub enum ResolveRepresentationByMethodInner<'a, M: 'a + ?Sized + DIDMethodResolver> {
-    Err(Option<Error>),
-    Pending(#[pin] M::ResolveMethodRepresentation<'a>),
-}
-
-impl<'a, M: ?Sized + DIDMethodResolver> Future for ResolveRepresentationByMethod<'a, M> {
-    type Output = Result<Output<Vec<u8>>, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        match this.inner.project() {
-            ResolveRepresentationByMethodProj::Err(e) => task::Poll::Ready(Err(e.take().unwrap())),
-            ResolveRepresentationByMethodProj::Pending(f) => f.poll(cx),
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub type BoxedResolveRepresentation<'a> =
-    Pin<Box<dyn 'a + Send + Future<Output = Result<Output<Vec<u8>>, Error>>>>;
-#[cfg(target_arch = "wasm32")]
-pub type BoxedResolveRepresentation<'a> =
-    Pin<Box<dyn 'a + Future<Output = Result<Output<Vec<u8>>, Error>>>>;
 
 /// A [DID resolver](https://www.w3.org/TR/did-core/#dfn-did-resolvers),
 /// implementing the [DID Resolution](https://www.w3.org/TR/did-core/#did-resolution)
 /// [algorithm](https://w3c-ccg.github.io/did-resolution/#resolving-algorithm) and
 /// optionally [DID URL Dereferencing](https://www.w3.org/TR/did-core/#did-url-dereferencing).
 pub trait DIDResolver {
-    /// Future returned by the `resolve_representation` method.
-    type ResolveRepresentation<'a>: 'a + Future<Output = Result<Output<Vec<u8>>, Error>>
-    where
-        Self: 'a;
-
     /// Resolves a DID representation.
     ///
     /// Fetches the DID document representation referenced by the input DID
     /// using the given options.
     ///
     /// See: <https://www.w3.org/TR/did-core/#did-resolution>
-    fn resolve_representation<'a>(
+    #[allow(async_fn_in_trait)]
+    async fn resolve_representation<'a>(
         &'a self,
         did: &'a DID,
         options: Options,
-    ) -> Self::ResolveRepresentation<'a>;
+    ) -> Result<Output<Vec<u8>>, Error>;
 
-    /// Resolves a DID.
+    /// Resolves a DID with the given options.
     ///
     /// Fetches the DID document referenced by the input DID using the given
     /// options.
     ///
     /// See: <https://www.w3.org/TR/did-core/#did-resolution>
-    fn resolve<'a>(&'a self, did: &'a DID, options: Options) -> Resolve<Self> {
-        Resolve::new(self.resolve_representation(did, options))
+    #[allow(async_fn_in_trait)]
+    async fn resolve_with<'a>(&'a self, did: &'a DID, options: Options) -> Result<Output, Error> {
+        let output = self.resolve_representation(did, options).await?;
+        match &output.metadata.content_type {
+            None => Err(Error::NoRepresentation),
+            Some(ty) => {
+                let ty: representation::MediaType = ty.parse()?;
+                output
+                    .try_map(|bytes| Document::from_bytes(ty, &bytes))
+                    .map_err(Error::InvalidData)
+            }
+        }
+    }
+
+    /// Resolves a DID.
+    ///
+    /// Fetches the DID document referenced by the input DID using the default
+    /// options.
+    ///
+    /// See: <https://www.w3.org/TR/did-core/#did-resolution>
+    #[allow(async_fn_in_trait)]
+    async fn resolve<'a>(&'a self, did: &'a DID) -> Result<Output, Error> {
+        self.resolve_with(did, Options::default()).await
+    }
+
+    /// Resolves a DID and extracts one of the verification methods it defines.
+    ///
+    /// This will return the first verification method found, although users
+    /// should not expect the DID documents to always list verification methods
+    /// in the same order.
+    ///
+    /// See: [`Document::into_any_verification_method()`].
+    #[allow(async_fn_in_trait)]
+    async fn resolve_into_any_verification_method<'a>(
+        &'a self,
+        did: &'a DID,
+    ) -> Result<Option<DIDVerificationMethod>, Error> {
+        Ok(self
+            .resolve(did)
+            .await?
+            .document
+            .into_document()
+            .into_any_verification_method())
     }
 
     /// Dereference a DID URL to retrieve the primary content.
     ///
     /// See: <https://www.w3.org/TR/did-core/#did-url-dereferencing>
     /// See: <https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm>
-    fn dereference_primary<'a>(
+    #[allow(async_fn_in_trait)]
+    async fn dereference_primary<'a>(
         &'a self,
         primary_did_url: &'a PrimaryDIDURL,
-        options: &'a DerefOptions,
-    ) -> DereferencePrimary<'a, Self> {
+    ) -> Result<DerefOutput<PrimaryContent>, DerefError> {
         // 2
         let resolve_options: Options = match primary_did_url.query() {
             Some(query) => serde_urlencoded::from_str(query.as_str()).unwrap(),
@@ -317,89 +202,50 @@ pub trait DIDResolver {
 
         let parameters = resolve_options.parameters.clone();
 
-        DereferencePrimary::new(
-            self,
-            primary_did_url,
-            parameters,
-            options,
-            self.resolve(primary_did_url.did(), resolve_options),
-        )
+        let resolution_output = self
+            .resolve_with(primary_did_url.did(), resolve_options)
+            .await?;
+
+        dereference_primary_resource(self, primary_did_url, parameters, resolution_output).await
+    }
+
+    /// Dereference a DID URL with a path or query to retrieve the primary
+    /// content.
+    ///
+    /// This function is called from [`Self::dereference_primary()`] only if
+    /// the primary DID url has a path and/or query, and the query does not
+    /// include any service.
+    /// Users should always call [`Self::dereference_primary()`].
+    ///
+    /// See: <https://www.w3.org/TR/did-core/#did-url-dereferencing>
+    /// See: <https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm>
+    #[allow(async_fn_in_trait)]
+    async fn dereference_primary_with_path_or_query<'a>(
+        &'a self,
+        _primary_did_url: &'a PrimaryDIDURL,
+    ) -> Result<DerefOutput<PrimaryContent>, DerefError> {
+        Err(DerefError::NotFound)
     }
 
     /// Dereference a DID URL.
     ///
     /// See: <https://www.w3.org/TR/did-core/#did-url-dereferencing>
     /// See: <https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm>
-    fn dereference<'a>(
-        &'a self,
-        did_url: &'a DIDURL,
-        options: &'a DerefOptions,
-    ) -> Dereference<'a, Self> {
+    #[allow(async_fn_in_trait)]
+    async fn dereference<'a>(&'a self, did_url: &'a DIDURL) -> Result<DerefOutput, DerefError> {
         let (primary_did_url, fragment) = did_url.without_fragment();
-        Dereference::new(
-            primary_did_url,
-            fragment,
-            options,
-            self.dereference_primary(primary_did_url, options),
-        )
-    }
-}
-
-#[pin_project]
-pub struct Dereference<'a, T: ?Sized + DIDResolver> {
-    primary_did_url: &'a PrimaryDIDURL,
-
-    fragment: Option<&'a Fragment>,
-
-    options: &'a DerefOptions,
-
-    #[pin]
-    dereference_primary: DereferencePrimary<'a, T>,
-}
-
-impl<'a, T: ?Sized + DIDResolver> Dereference<'a, T> {
-    pub fn new(
-        primary_did_url: &'a PrimaryDIDURL,
-        fragment: Option<&'a Fragment>,
-        options: &'a DerefOptions,
-        dereference_primary: DereferencePrimary<'a, T>,
-    ) -> Self {
-        Self {
-            primary_did_url,
-            fragment,
-            options,
-            dereference_primary,
+        let primary_deref_output = self.dereference_primary(primary_did_url).await?;
+        // 4
+        match fragment {
+            Some(fragment) => {
+                dereference_secondary_resource(primary_did_url, fragment, primary_deref_output)
+            }
+            None => Ok(primary_deref_output.cast()),
         }
     }
 }
 
-impl<'a, T: ?Sized + DIDResolver> Future for Dereference<'a, T> {
-    type Output = Result<DerefOutput, DerefError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.dereference_primary.poll(cx).map(|result| {
-            result.and_then(|primary_deref_output| {
-                // 4
-                match this.fragment {
-                    Some(fragment) => dereference_secondary_resource(
-                        this.primary_did_url,
-                        fragment,
-                        this.options,
-                        primary_deref_output,
-                    ),
-                    None => Ok(primary_deref_output.cast()),
-                }
-            })
-        })
-    }
-}
-
 pub trait DIDMethodResolver {
-    type ResolveMethodRepresentation<'a>: 'a + Future<Output = Result<Output<Vec<u8>>, Error>>
-    where
-        Self: 'a;
-
     /// Returns the name of the method handled by this resolver.
     fn method_name(&self) -> &str;
 
@@ -409,26 +255,25 @@ pub trait DIDMethodResolver {
     /// specific identifier using the given options.
     ///
     /// See: <https://www.w3.org/TR/did-core/#did-resolution>
-    fn resolve_method_representation<'a>(
+    #[allow(async_fn_in_trait)]
+    async fn resolve_method_representation<'a>(
         &'a self,
         method_specific_id: &'a str,
         options: Options,
-    ) -> Self::ResolveMethodRepresentation<'a>;
+    ) -> Result<Output<Vec<u8>>, Error>;
 }
 
 impl<'a, T: DIDMethodResolver> DIDMethodResolver for &'a T {
-    type ResolveMethodRepresentation<'b> = T::ResolveMethodRepresentation<'b> where Self: 'b;
-
     fn method_name(&self) -> &str {
         T::method_name(*self)
     }
 
-    fn resolve_method_representation<'b>(
+    async fn resolve_method_representation<'b>(
         &'b self,
         method_specific_id: &'b str,
         options: Options,
-    ) -> Self::ResolveMethodRepresentation<'b> {
-        T::resolve_method_representation(*self, method_specific_id, options)
+    ) -> Result<Output<Vec<u8>>, Error> {
+        T::resolve_method_representation(*self, method_specific_id, options).await
     }
 }
 

--- a/ssi-dids/src/resolution/dereference.rs
+++ b/ssi-dids/src/resolution/dereference.rs
@@ -1,18 +1,12 @@
 use iref::{Iri, IriBuf};
-use pin_project::pin_project;
 use ssi_core::one_or_many::OneOrMany;
-use std::future::Future;
-use std::pin::Pin;
-use std::task;
 
 use crate::{
     document::{self, representation, service, DIDVerificationMethod, Represented, Resource},
     DIDURLBuf, Fragment, PrimaryDIDURL, DIDURL,
 };
 
-use super::{
-    DIDResolver, DereferencePrimary, Error, Metadata, Options, Output, Parameters, MEDIA_TYPE_URL,
-};
+use super::{DIDResolver, Error, Metadata, Options, Output, Parameters, MEDIA_TYPE_URL};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DerefError {
@@ -37,19 +31,11 @@ pub enum DerefError {
     #[error("tried to dereference null primary content")]
     NullDereference,
 
+    #[error("DID document not found")]
+    NotFound,
+
     #[error("could not find resource `{0}` in DID document")]
     ResourceNotFound(DIDURLBuf),
-}
-
-#[derive(Debug, Default)]
-pub struct DerefOptions {
-    // ...
-}
-
-impl From<Options> for DerefOptions {
-    fn from(_value: Options) -> Self {
-        Self {}
-    }
 }
 
 pub struct DerefOutput<T = Content> {
@@ -113,6 +99,7 @@ impl From<IriBuf> for PrimaryContent {
     }
 }
 
+#[derive(Debug)]
 pub enum Content {
     Null,
     Url(IriBuf), // TODO must be an URL
@@ -152,53 +139,13 @@ pub struct ContentMetadata {
     // ...
 }
 
-#[pin_project(project = DereferencePrimaryResourceProj)]
-pub(crate) enum DereferencePrimaryResource<'a, R: ?Sized + DIDResolver> {
-    Ready(Option<Result<DerefOutput<PrimaryContent>, DerefError>>),
-    Pending(#[pin] Pin<Box<DereferencePrimary<'a, R>>>),
-}
-
-impl<'a, R: ?Sized + DIDResolver> DereferencePrimaryResource<'a, R> {
-    fn err(e: DerefError) -> Self {
-        Self::Ready(Some(Err(e)))
-    }
-
-    fn ok(o: DerefOutput<PrimaryContent>) -> Self {
-        Self::Ready(Some(Ok(o)))
-    }
-}
-
-impl<'a, R: ?Sized + DIDResolver> Future for DereferencePrimaryResource<'a, R> {
-    type Output = Result<DerefOutput<PrimaryContent>, DerefError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        match self.project() {
-            DereferencePrimaryResourceProj::Ready(r) => task::Poll::Ready(r.take().unwrap()),
-            DereferencePrimaryResourceProj::Pending(f) => {
-                // 3.1
-                f.poll(cx).map(|result| match result {
-                    Ok(output) => Ok(output),
-                    Err(DerefError::Resolution(Error::MethodNotSupported(_))) => {
-                        Ok(DerefOutput::null())
-                    }
-                    Err(e) => Err(e),
-                })
-
-                // 3.2
-                // TODO: enable the client to dereference the DID URL
-            }
-        }
-    }
-}
-
 /// [Dereferencing the Primary Resource](https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm-primary) - a subalgorithm of [DID URL dereferencing](https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm)
-pub(crate) fn dereference_primary_resource<'a, R: ?Sized + DIDResolver>(
+pub(crate) async fn dereference_primary_resource<'a, R: ?Sized + DIDResolver>(
     resolver: &'a R,
     primary_did_url: &'a PrimaryDIDURL,
     parameters: Parameters,
-    options: &'a DerefOptions,
     resolution_output: Output,
-) -> DereferencePrimaryResource<'a, R> {
+) -> Result<DerefOutput<PrimaryContent>, DerefError> {
     // 1
     match &parameters.service {
         Some(id) => {
@@ -208,21 +155,13 @@ pub(crate) fn dereference_primary_resource<'a, R: ?Sized + DIDResolver>(
                     // 1.2, 1.2.1
                     // TODO: support these other cases?
                     let input_service_endpoint_url = match &service.service_endpoint {
-                        None => {
-                            return DereferencePrimaryResource::err(
-                                DerefError::MissingServiceEndpoint(id.clone()),
-                            )
-                        }
+                        None => return Err(DerefError::MissingServiceEndpoint(id.clone())),
                         Some(OneOrMany::One(service::Endpoint::Uri(uri))) => uri.as_iri(),
                         Some(OneOrMany::One(service::Endpoint::Map(_))) => {
-                            return DereferencePrimaryResource::err(
-                                DerefError::UnsupportedServiceEndpointMap,
-                            )
+                            return Err(DerefError::UnsupportedServiceEndpointMap)
                         }
                         Some(OneOrMany::Many(_)) => {
-                            return DereferencePrimaryResource::err(
-                                DerefError::UnsupportedMultipleServiceEndpoints,
-                            )
+                            return Err(DerefError::UnsupportedMultipleServiceEndpoints)
                         }
                     };
 
@@ -236,21 +175,19 @@ pub(crate) fn dereference_primary_resource<'a, R: ?Sized + DIDResolver>(
                     match r {
                         Ok(output_service_endpoint_url) => {
                             // 1.3
-                            DereferencePrimaryResource::ok(DerefOutput::url(
-                                output_service_endpoint_url,
-                            ))
+                            Ok(DerefOutput::url(output_service_endpoint_url))
                         }
-                        Err(e) => DereferencePrimaryResource::err(e.into()),
+                        Err(e) => Err(e.into()),
                     }
                 }
-                None => DereferencePrimaryResource::ok(DerefOutput::null()),
+                None => Err(DerefError::MissingServiceEndpoint(id.clone())),
             }
         }
         None => {
             // 2
             if primary_did_url.path().is_empty() && primary_did_url.query().is_none() {
                 // 2.1
-                return DereferencePrimaryResource::ok(DerefOutput::new(
+                return Ok(DerefOutput::new(
                     PrimaryContent::Document(resolution_output.document),
                     ContentMetadata::default(),
                     resolution_output.metadata,
@@ -259,13 +196,13 @@ pub(crate) fn dereference_primary_resource<'a, R: ?Sized + DIDResolver>(
 
             // 3
             if !primary_did_url.path().is_empty() || primary_did_url.query().is_some() {
-                return DereferencePrimaryResource::Pending(Box::pin(
-                    resolver.dereference_primary(primary_did_url, options),
-                ));
+                return resolver
+                    .dereference_primary_with_path_or_query(primary_did_url)
+                    .await;
             }
 
             // 4
-            DereferencePrimaryResource::ok(DerefOutput::null())
+            Err(DerefError::NotFound)
         }
     }
 }
@@ -327,7 +264,6 @@ impl Represented {
         self,
         primary_did_url: &PrimaryDIDURL,
         fragment: &Fragment,
-        options: &DerefOptions,
         content_metadata: ContentMetadata,
         metadata: Metadata,
     ) -> Result<DerefOutput, DerefError> {
@@ -335,14 +271,12 @@ impl Represented {
             Self::Json(d) => d.dereference_secondary_resource(
                 primary_did_url,
                 fragment,
-                options,
                 content_metadata,
                 metadata,
             ),
             Self::JsonLd(d) => d.dereference_secondary_resource(
                 primary_did_url,
                 fragment,
-                options,
                 content_metadata,
                 metadata,
             ),
@@ -355,7 +289,6 @@ impl representation::Json {
         self,
         primary_did_url: &PrimaryDIDURL,
         fragment: &Fragment,
-        _options: &DerefOptions,
         content_metadata: ContentMetadata,
         metadata: Metadata,
     ) -> Result<DerefOutput, DerefError> {
@@ -376,7 +309,6 @@ impl representation::JsonLd {
         self,
         primary_did_url: &PrimaryDIDURL,
         fragment: &Fragment,
-        _options: &DerefOptions,
         content_metadata: ContentMetadata,
         metadata: Metadata,
     ) -> Result<DerefOutput, DerefError> {
@@ -400,7 +332,6 @@ impl representation::JsonLd {
 pub(crate) fn dereference_secondary_resource(
     primary_did_url: &PrimaryDIDURL,
     fragment: &Fragment,
-    options: &DerefOptions,
     primary_deref_output: DerefOutput<PrimaryContent>,
 ) -> Result<DerefOutput, DerefError> {
     // 1
@@ -408,7 +339,6 @@ pub(crate) fn dereference_secondary_resource(
         PrimaryContent::Document(doc) => doc.dereference_secondary_resource(
             primary_did_url,
             fragment,
-            options,
             primary_deref_output.content_metadata,
             primary_deref_output.metadata,
         ),

--- a/ssi-dids/src/resolution/dereference.rs
+++ b/ssi-dids/src/resolution/dereference.rs
@@ -6,7 +6,7 @@ use crate::{
     DIDURLBuf, Fragment, PrimaryDIDURL, DIDURL,
 };
 
-use super::{DIDResolver, Error, Metadata, Options, Output, Parameters, MEDIA_TYPE_URL};
+use super::{DIDResolver, Error, Metadata, Output, Parameters, MEDIA_TYPE_URL};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DerefError {

--- a/ssi-dids/src/verifier.rs
+++ b/ssi-dids/src/verifier.rs
@@ -1,18 +1,8 @@
-use crate::{
-    document::Document,
-    resolution::{self, DerefError, DerefOptions, DerefOutput, Dereference, Resolve},
-    DIDResolver, DID, DIDURL,
-};
-use pin_project::pin_project;
-use ssi_core::futures::{RefFutureBinder, SelfRefFuture, UnboundedRefFuture};
+use crate::{document::Document, resolution, DIDResolver, DID, DIDURL};
 use ssi_verification_methods::{
     ControllerError, GenericVerificationMethod, InvalidVerificationMethod, ProofPurposes,
-    Referencable, ReferenceOrOwnedRef, VerificationMethodResolutionError,
+    ReferenceOrOwnedRef, VerificationMethodResolutionError,
 };
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task;
 
 pub struct DIDVerifier<T> {
     resolver: T,
@@ -49,174 +39,28 @@ impl ssi_verification_methods::Controller for Document {
     }
 }
 
-#[pin_project]
-pub struct GetController<'a, T: ?Sized + DIDResolver> {
-    #[pin]
-    inner: GetControllerInner<'a, T>,
-}
-
-impl<'a, T: ?Sized + DIDResolver> GetController<'a, T> {
-    fn pending(resolve: Resolve<'a, T>) -> Self {
-        Self {
-            inner: GetControllerInner::Pending(resolve),
-        }
-    }
-
-    fn err(e: ControllerError) -> Self {
-        Self {
-            inner: GetControllerInner::Err(Some(e)),
-        }
-    }
-}
-
-impl<'a, T: ?Sized + DIDResolver> Future for GetController<'a, T> {
-    type Output = Result<Option<Document>, ControllerError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        match this.inner.project() {
-            GetControllerProj::Pending(f) => f.poll(cx).map(|result| match result {
-                Ok(output) => Ok(Some(output.document.into_document())),
-                Err(resolution::Error::NotFound) => Ok(None),
-                Err(e) => Err(ssi_verification_methods::ControllerError::InternalError(
-                    e.to_string(),
-                )),
-            }),
-            GetControllerProj::Err(e) => task::Poll::Ready(Err(e.take().unwrap())),
-        }
-    }
-}
-
-#[pin_project(project = GetControllerProj)]
-enum GetControllerInner<'a, T: ?Sized + DIDResolver> {
-    Pending(#[pin] Resolve<'a, T>),
-    Err(Option<ControllerError>),
-}
-
 impl<T: DIDResolver> ssi_verification_methods::ControllerProvider for DIDVerifier<T> {
     type Controller<'a> = Document where Self: 'a;
 
-    type GetController<'a> = GetController<'a, T> where Self: 'a;
-
-    fn get_controller<'a>(&'a self, id: &'a iref::Iri) -> Self::GetController<'_> {
+    async fn get_controller<'a>(
+        &'a self,
+        id: &'a iref::Iri,
+    ) -> Result<Option<Document>, ControllerError> {
         if id.scheme().as_str() == "did" {
             match DID::new(id.as_bytes()) {
-                Ok(did) => GetController::pending(self.resolver.resolve(did, self.options.clone())),
-                Err(_) => GetController::err(ssi_verification_methods::ControllerError::Invalid),
+                Ok(did) => match self.resolver.resolve_with(did, self.options.clone()).await {
+                    Ok(output) => Ok(Some(output.document.into_document())),
+                    Err(resolution::Error::NotFound) => Ok(None),
+                    Err(e) => Err(ssi_verification_methods::ControllerError::InternalError(
+                        e.to_string(),
+                    )),
+                },
+                Err(_) => Err(ssi_verification_methods::ControllerError::Invalid),
             }
         } else {
-            GetController::err(ssi_verification_methods::ControllerError::Invalid)
+            Err(ssi_verification_methods::ControllerError::Invalid)
         }
     }
-}
-
-#[pin_project]
-pub struct ResolveVerificationMethod<'a, M: 'a + Referencable, T: ?Sized + DIDResolver> {
-    #[pin]
-    inner: ResolveVerificationMethodInner<'a, T>,
-    m: PhantomData<&'a M>,
-}
-
-impl<'a, M: 'a + Referencable, T: ?Sized + DIDResolver> ResolveVerificationMethod<'a, M, T> {
-    fn dereference(resolver: &'a T, url: &'a DIDURL, options: DerefOptions) -> Self {
-        Self {
-            inner: ResolveVerificationMethodInner::Pending {
-                method_id: url,
-                dereference: SelfRefFuture::new(options, SetupDereference { resolver, url }),
-            },
-            m: PhantomData,
-        }
-    }
-
-    fn err(e: VerificationMethodResolutionError) -> Self {
-        Self {
-            inner: ResolveVerificationMethodInner::Err(Some(e)),
-            m: PhantomData,
-        }
-    }
-}
-
-impl<'a, M: 'a + Referencable, T: ?Sized + DIDResolver> Future
-    for ResolveVerificationMethod<'a, M, T>
-where
-    M: TryFrom<GenericVerificationMethod, Error = InvalidVerificationMethod>,
-{
-    type Output = Result<ssi_verification_methods::Cow<'a, M>, VerificationMethodResolutionError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        match this.inner.project() {
-            ResolveVerificationMethodProj::Pending {
-                method_id,
-                dereference,
-            } => {
-                dereference.poll(cx).map(|(result, _)| match result {
-                    Ok(deref) => match deref.content.into_verification_method() {
-                        Ok(any_method) => Ok(ssi_verification_methods::Cow::Owned(M::try_from(
-                            any_method.into(),
-                        )?)),
-                        Err(_) => {
-                            // The IRI is not referring to a verification method.
-                            Err(VerificationMethodResolutionError::InvalidKeyId(
-                                method_id.to_string(),
-                            ))
-                        }
-                    },
-                    Err(e) => {
-                        // Dereferencing failed for some reason.
-                        Err(VerificationMethodResolutionError::InternalError(
-                            e.to_string(),
-                        ))
-                    }
-                })
-            }
-            ResolveVerificationMethodProj::Err(e) => task::Poll::Ready(Err(e.take().unwrap())),
-        }
-    }
-}
-
-#[pin_project(project = ResolveVerificationMethodProj)]
-enum ResolveVerificationMethodInner<'a, T: 'a + ?Sized + DIDResolver> {
-    Pending {
-        method_id: &'a DIDURL,
-
-        #[pin]
-        dereference: SelfRefFuture<'a, UnboundedDereference<T>>,
-    },
-    Err(Option<VerificationMethodResolutionError>),
-}
-
-struct UnboundedDereference<T: ?Sized>(PhantomData<T>);
-
-impl<'max, T: 'max + ?Sized + DIDResolver> UnboundedRefFuture<'max> for UnboundedDereference<T> {
-    type Bound<'a> = Dereference<'a, T> where 'max: 'a;
-
-    type Owned = DerefOptions;
-
-    type Output = Result<DerefOutput, DerefError>;
-}
-
-struct SetupDereference<'a, T: ?Sized> {
-    resolver: &'a T,
-    url: &'a DIDURL,
-}
-
-impl<'max, T: 'max + ?Sized + DIDResolver> RefFutureBinder<'max, UnboundedDereference<T>>
-    for SetupDereference<'max, T>
-{
-    fn bind<'a>(context: Self, options: &'a DerefOptions) -> Dereference<'a, T>
-    where
-        'max: 'a,
-    {
-        context.resolver.dereference(context.url, options)
-    }
-}
-
-impl<T: DIDResolver, M> ssi_verification_methods::Verifier<M> for DIDVerifier<T>
-where
-    M: ssi_verification_methods::VerificationMethod,
-    M: TryFrom<GenericVerificationMethod, Error = InvalidVerificationMethod>,
-{
 }
 
 // #[async_trait]
@@ -225,42 +69,54 @@ where
     M: ssi_verification_methods::VerificationMethod,
     M: TryFrom<GenericVerificationMethod, Error = InvalidVerificationMethod>,
 {
-    type ResolveVerificationMethod<'a> = ResolveVerificationMethod<'a, M, T> where Self: 'a, M: 'a;
+    // type ResolveVerificationMethod<'a> = ResolveVerificationMethod<'a, M, T> where Self: 'a, M: 'a;
 
-    fn resolve_verification_method<'a, 'm: 'a>(
+    async fn resolve_verification_method<'a, 'm: 'a>(
         &'a self,
         _issuer: Option<&'a iref::Iri>,
         method: Option<ReferenceOrOwnedRef<'m, M>>,
-    ) -> Self::ResolveVerificationMethod<'a> {
+    ) -> Result<ssi_verification_methods::Cow<'a, M>, VerificationMethodResolutionError> {
         match method {
             Some(method) => {
                 if method.id().scheme().as_str() == "did" {
                     match DIDURL::new(method.id().as_bytes()) {
                         Ok(url) => {
-                            let options = self.options.clone().into();
-                            ResolveVerificationMethod::dereference(&self.resolver, url, options)
+                            match self.resolver.dereference(url).await {
+                                Ok(deref) => match deref.content.into_verification_method() {
+                                    Ok(any_method) => Ok(ssi_verification_methods::Cow::Owned(
+                                        M::try_from(any_method.into())?,
+                                    )),
+                                    Err(_) => {
+                                        // The IRI is not referring to a verification method.
+                                        Err(VerificationMethodResolutionError::InvalidKeyId(
+                                            method.id().to_string(),
+                                        ))
+                                    }
+                                },
+                                Err(e) => {
+                                    // Dereferencing failed for some reason.
+                                    Err(VerificationMethodResolutionError::InternalError(
+                                        e.to_string(),
+                                    ))
+                                }
+                            }
+                            // ResolveVerificationMethod::dereference(&self.resolver, url, options)
                         }
                         Err(_) => {
                             // The IRI is not a valid DID URL.
-                            ResolveVerificationMethod::err(
-                                VerificationMethodResolutionError::InvalidKeyId(
-                                    method.id().to_string(),
-                                ),
-                            )
+                            Err(VerificationMethodResolutionError::InvalidKeyId(
+                                method.id().to_string(),
+                            ))
                         }
                     }
                 } else {
                     // Not a DID scheme.
-                    ResolveVerificationMethod::err(
-                        VerificationMethodResolutionError::UnsupportedKeyId(
-                            method.id().to_string(),
-                        ),
-                    )
+                    Err(VerificationMethodResolutionError::UnsupportedKeyId(
+                        method.id().to_string(),
+                    ))
                 }
             }
-            None => ResolveVerificationMethod::err(
-                VerificationMethodResolutionError::MissingVerificationMethod,
-            ),
+            None => Err(VerificationMethodResolutionError::MissingVerificationMethod),
         }
     }
 }

--- a/ssi-eip712/src/lib.rs
+++ b/ssi-eip712/src/lib.rs
@@ -6,7 +6,6 @@ mod hashing;
 mod ty;
 mod value;
 
-pub use encode::*;
 pub use hashing::TypedDataHashError;
 pub use ty::*;
 pub use value::*;

--- a/ssi-eip712/src/value.rs
+++ b/ssi-eip712/src/value.rs
@@ -1,8 +1,6 @@
 use core::fmt;
 use indexmap::{Equivalent, IndexMap};
-use linked_data::{
-    LinkedData, LinkedDataGraph, LinkedDataPredicateObjects, LinkedDataResource, LinkedDataSubject,
-};
+use linked_data::{LinkedData, LinkedDataGraph};
 use rdf_types::{Interpretation, Vocabulary};
 use serde::{Deserialize, Serialize};
 use ssi_crypto::hashes::keccak::bytes_to_lowerhex;

--- a/ssi-jwk/src/lib.rs
+++ b/ssi-jwk/src/lib.rs
@@ -287,6 +287,19 @@ impl JWK {
         }
     }
 
+    #[cfg(feature = "ed25519")]
+    #[cfg(not(feature = "ring"))]
+    pub fn generate_ed25519_from(
+        rng: &mut (impl rand_old::CryptoRng + rand_old::RngCore),
+    ) -> Result<JWK, Error> {
+        let keypair = ed25519_dalek::Keypair::generate(rng);
+        Ok(JWK::from(Params::OKP(OctetParams {
+            curve: "Ed25519".to_string(),
+            public_key: Base64urlUInt(keypair.public.as_ref().to_vec()),
+            private_key: Some(Base64urlUInt(keypair.secret.as_ref().to_vec())),
+        })))
+    }
+
     #[cfg(feature = "secp256k1")]
     pub fn generate_secp256k1() -> Result<JWK, Error> {
         let mut rng = rand::rngs::OsRng {};

--- a/ssi-jwk/src/lib.rs
+++ b/ssi-jwk/src/lib.rs
@@ -1,11 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::fmt;
-use linked_data::rdf_types::{Interpretation, Vocabulary};
-use linked_data::{
-    LinkedDataDeserializePredicateObjects, LinkedDataDeserializeSubject,
-    LinkedDataPredicateObjects, LinkedDataSubject,
-};
 use num_bigint::{BigInt, Sign};
 use simple_asn1::{ASN1Block, ASN1Class, ToASN1};
 use ssi_multicodec::MultiEncoded;

--- a/ssi-top/src/data_integrity/options.rs
+++ b/ssi-top/src/data_integrity/options.rs
@@ -31,12 +31,12 @@ pub struct AnySuiteOptions {
 
     #[ld("eip712:eip712-domain")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="eip712Domain")]
+    #[serde(rename = "eip712Domain")]
     pub eip712: Option<ssi_vc_ldp::suite::ethereum_eip712_signature_2021::Eip712Options>,
 
     #[ld("eip712v0.1:eip712-domain")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename="eip712Domain")]
+    #[serde(rename = "eip712Domain")]
     pub eip712_v0_1: Option<ssi_vc_ldp::suite::ethereum_eip712_signature_2021::v0_1::Eip712Options>,
 }
 
@@ -81,7 +81,7 @@ impl Referencable for AnySuiteOptions {
     type Reference<'a> = AnySuiteOptionsRef<'a>;
 
     fn as_reference(&self) -> Self::Reference<'_> {
-                AnySuiteOptionsRef {
+        AnySuiteOptionsRef {
             public_key_jwk: self.public_key_jwk.as_deref(),
             public_key_multibase: self.public_key_multibase.as_deref(),
             eip712: self

--- a/ssi-vc-jwt/src/signing.rs
+++ b/ssi-vc-jwt/src/signing.rs
@@ -155,15 +155,13 @@ impl SignatureAlgorithm<verification::AnyJwkMethod> for VcJwtSignatureAlgorithm 
 
     type Protocol = ();
 
-    type Sign<'a, S: 'a + MessageSigner<()>> = Sign<'a, S>;
-
-    fn sign<'a, S: 'a + MessageSigner<()>>(
+    async fn sign<S: MessageSigner<()>>(
         &self,
         options: (),
         method: verification::AnyJwkMethodRef,
-        payload: &'a [u8],
+        payload: &[u8],
         signer: S,
-    ) -> Self::Sign<'a, S> {
+    ) -> Result<Self::Signature, SignatureError> {
         // Prepare JWS header.
         let header = ssi_jws::Header {
             algorithm: method.public_key_jwk.algorithm.unwrap_or_default(),

--- a/ssi-vc-ldp/Cargo.toml
+++ b/ssi-vc-ldp/Cargo.toml
@@ -66,6 +66,7 @@ ssi-crypto.workspace = true
 ssi-jwk.workspace = true
 ssi-jws.workspace = true
 ssi-rdf.workspace = true
+ssi-json-ld.workspace = true
 ssi-vc.workspace = true
 ssi-security.workspace = true
 ssi-tzkey = { workspace = true, optional = true }

--- a/ssi-vc-ldp/examples/sign.rs
+++ b/ssi-vc-ldp/examples/sign.rs
@@ -11,7 +11,7 @@ use locspan::Meta;
 use rdf_types::{vocabulary::IriIndex, IndexVocabulary, IriVocabularyMut};
 use ssi_core::futures::FailibleFuture;
 use ssi_crypto::MessageSignatureError;
-use ssi_vc_ldp::{suite::Ed25519Signature2020, DataIntegrity};
+use ssi_vc_ldp::{suite::Ed25519Signature2020, DataIntegrity, CryptographicSuiteInput};
 use ssi_verification_methods::{
     Controller, ControllerError, ControllerProvider, Ed25519VerificationKey2020, ProofPurpose,
     ProofPurposes, ReferenceOrOwnedRef, SignatureAlgorithm, SignatureError, Signer,
@@ -20,14 +20,14 @@ use ssi_verification_methods::{
 };
 use static_iref::{iri, iri_ref, uri};
 
-#[derive(LinkedData)]
+#[derive(linked_data::Serialize)]
 #[ld(prefix("sec" = "https://w3id.org/security#"))]
 pub struct Credential {
     #[ld("sec:credentialSubject")]
     subject: CredentialSubject,
 }
 
-#[derive(LinkedData)]
+#[derive(linked_data::Serialize)]
 #[ld(prefix("ex" = "https://example.org/sign#"))]
 pub struct CredentialSubject {
     #[ld("ex:content")]
@@ -74,9 +74,10 @@ async fn main() {
     // Signature options, defining the crypto suite, signature date,
     // signing key and proof purpose.
     let proof_options = ssi_vc_ldp::ProofConfiguration::new(
-        Utc::now().fixed_offset(),
+        Utc::now().fixed_offset().into(),
         iri!("https://example.com/controller#key").to_owned().into(),
         ProofPurpose::Assertion,
+        ()
     );
 
     // We use the Linked-Data-based cryptographic suite `Ed25519Signature2020`.
@@ -85,18 +86,15 @@ async fn main() {
     // dataset.
     let mut vocabulary: IndexVocabulary = Default::default();
     let mut interpretation = rdf_types::interpretation::Indexed::new();
+    let rdf = ssi_vc_ldp::LinkedDataInput::new(vocabulary, interpretation);
 
     // Sign the credential.
-    let verifiable_credential = DataIntegrity::sign_ld(
-        &mut vocabulary,
-        &mut interpretation,
-        &keyring,
+    let verifiable_credential = Ed25519Signature2020.sign(
         credential,
-        Ed25519Signature2020,
-        proof_options.clone(),
-        (),
-    )
-    .await
+        rdf,
+        &keyring,
+        proof_options.clone()
+    ).await
     .expect("signing failed");
 
     // Verify the generated verifiable credential.
@@ -213,35 +211,42 @@ impl Keyring {
     }
 }
 
-impl Signer<Ed25519VerificationKey2020, ()> for Keyring {
-    type Sign<'a, A: SignatureAlgorithm<Ed25519VerificationKey2020, Protocol = ()>> = FailibleFuture<A::Sign<'a, MessageSigner<'a>>, SignatureError> where A: 'a, A::Signature: 'a;
-
-    fn sign<'a, 'm: 'a, A: SignatureAlgorithm<Ed25519VerificationKey2020, Protocol = ()>>(
+impl Signer<Ed25519VerificationKey2020, ssi_jwk::algorithm::EdDSA, ()> for Keyring {
+    async fn sign<
+        'a,
+        'o: 'a,
+        'm: 'a,
+        A,
+    >(
         &'a self,
         algorithm: A,
-        _issuer: Option<&'a Iri>,
+        options: <A::Options as ssi_verification_methods::Referencable>::Reference<'o>,
+        issuer: Option<&'a Iri>,
         method: Option<ReferenceOrOwnedRef<'m, Ed25519VerificationKey2020>>,
         bytes: &'a [u8],
-    ) -> Self::Sign<'a, A>
+    ) -> Result<A::Signature, SignatureError>
     where
         A: 'a,
         A::Signature: 'a,
+        A: SignatureAlgorithm<Ed25519VerificationKey2020, MessageSignatureAlgorithm = ssi_jwk::algorithm::EdDSA, Protocol = ()>
     {
-        let id = match method {
-            Some(ReferenceOrOwnedRef::Owned(key)) => key.id(),
-            Some(ReferenceOrOwnedRef::Reference(id)) => id,
-            None => return FailibleFuture::err(SignatureError::MissingVerificationMethod),
-        };
-
-        match self.keys.get(id) {
-            Some((method, key_pair)) => FailibleFuture::ok(algorithm.sign(
-                (),
-                method,
-                bytes,
-                MessageSigner { method, key_pair },
-            )),
-            None => FailibleFuture::err(SignatureError::UnknownVerificationMethod),
-        }
+            let id = match method {
+                Some(ReferenceOrOwnedRef::Owned(key)) => key.id(),
+                Some(ReferenceOrOwnedRef::Reference(id)) => id,
+                None => return Err(SignatureError::MissingVerificationMethod),
+            };
+    
+            match self.keys.get(id) {
+                Some((method, key_pair)) => {
+                    algorithm.sign(
+                        options,
+                        method,
+                        bytes,
+                        MessageSigner { method, key_pair },
+                    ).await
+                },
+                None => Err(SignatureError::UnknownVerificationMethod),
+            }
     }
 }
 
@@ -250,55 +255,42 @@ pub struct MessageSigner<'a> {
     key_pair: &'a ssi_verification_methods::ed25519_dalek::Keypair,
 }
 
-impl<'a> ssi_crypto::MessageSigner for MessageSigner<'a> {
-    type Sign<'s> = std::future::Ready<Result<Vec<u8>, MessageSignatureError>> where Self: 's;
-
-    fn sign<'s>(self, _protocol: (), message: &'s [u8]) -> Self::Sign<'s>
-    where
-        Self: 's,
-    {
-        std::future::ready(Ok(self.method.sign_bytes(message, self.key_pair)))
+impl<'a> ssi_crypto::MessageSigner<ssi_jwk::algorithm::EdDSA> for MessageSigner<'a> {
+    async fn sign(self, _algorithm: ssi_jwk::algorithm::EdDSA, _protocol: (), message: &[u8]) -> Result<Vec<u8>, MessageSignatureError> {
+        Ok(self.method.sign_bytes(message, self.key_pair))
     }
 }
 
 impl ControllerProvider for Keyring {
     type Controller<'a> = &'a KeyController;
 
-    type GetController<'a> = future::Ready<Result<Option<Self::Controller<'a>>, ControllerError>>;
-
-    fn get_controller(&self, id: &Iri) -> Self::GetController<'_> {
-        future::ready(Ok(self.controllers.get(&id.to_owned())))
+    async fn get_controller<'a>(
+        &'a self,
+        id: &'a Iri,
+    ) -> Result<Option<Self::Controller<'a>>, ControllerError> {
+        Ok(self.controllers.get(&id.to_owned()))
     }
 }
 
 impl VerificationMethodResolver<Ed25519VerificationKey2020> for Keyring {
-    type ResolveVerificationMethod<'a> = future::Ready<
-        Result<
-            ssi_verification_methods::Cow<'a, Ed25519VerificationKey2020>,
-            VerificationMethodResolutionError,
-        >,
-    >;
-
-    fn resolve_verification_method<'a, 'm: 'a>(
+    async fn resolve_verification_method<'a, 'm: 'a>(
         &'a self,
-        _issuer: Option<&Iri>,
+        _issuer: Option<&'a Iri>,
         method: Option<ReferenceOrOwnedRef<'m, Ed25519VerificationKey2020>>,
-    ) -> Self::ResolveVerificationMethod<'a> {
-        let result = match method {
-            Some(ReferenceOrOwnedRef::Owned(_key)) => {
-                // If we get here, this means the VC embeds the public key used
-                // to sign itself. It cannot really be trusted then.
-                // It would be safer to either throw an error or at least fetch
-                // the actual key using its id.
-                todo!()
+    ) -> Result<ssi_verification_methods::Cow<'a, Ed25519VerificationKey2020>, VerificationMethodResolutionError> {
+            match method {
+                Some(ReferenceOrOwnedRef::Owned(_key)) => {
+                    // If we get here, this means the VC embeds the public key used
+                    // to sign itself. It cannot really be trusted then.
+                    // It would be safer to either throw an error or at least fetch
+                    // the actual key using its id.
+                    todo!()
+                }
+                Some(ReferenceOrOwnedRef::Reference(id)) => match self.keys.get(id) {
+                    Some((key, _)) => Ok(ssi_verification_methods::Cow::Borrowed(key)),
+                    None => Err(VerificationMethodResolutionError::UnknownKey),
+                },
+                None => Err(VerificationMethodResolutionError::MissingVerificationMethod),
             }
-            Some(ReferenceOrOwnedRef::Reference(id)) => match self.keys.get(id) {
-                Some((key, _)) => Ok(ssi_verification_methods::Cow::Borrowed(key)),
-                None => Err(VerificationMethodResolutionError::UnknownKey),
-            },
-            None => Err(VerificationMethodResolutionError::MissingVerificationMethod),
-        };
-
-        future::ready(result)
     }
 }

--- a/ssi-vc-ldp/src/decode/from_json_ld.rs
+++ b/ssi-vc-ldp/src/decode/from_json_ld.rs
@@ -4,6 +4,7 @@ use std::pin::Pin;
 use std::task;
 
 use futures::future::BoxFuture;
+use iref::IriBuf;
 use json_ld::{ContextLoader, IntoDocumentResult, Loader, RemoteDocumentReference};
 use linked_data::{LinkedDataResource, LinkedDataSubject};
 use locspan::{Meta, Stripped};
@@ -17,7 +18,7 @@ use super::{DataIntegrityInput, DecodeError, PROOF_IRI};
 /// This is a simple wrapper around [`RemoteDocumentReference<I>`] that adds
 /// the ability to expand and extract a Data-Integrity proof from the wrapped
 /// (remote) JSON-LD document.
-pub struct JsonLdInput<'l, I, L> {
+pub struct JsonLdInput<'l, I = IriBuf, L = ssi_json_ld::ContextLoader> {
     document: RemoteDocumentReference<I>,
     loader: &'l mut L,
 }

--- a/ssi-vc-ldp/src/eip712/signature.rs
+++ b/ssi-vc-ldp/src/eip712/signature.rs
@@ -1,15 +1,11 @@
 use iref::UriBuf;
 use linked_data::{LinkedData, LinkedDataGraph};
-use pin_project::pin_project;
 use rdf_types::{Interpretation, Vocabulary};
 use ssi_crypto::MessageSigner;
 use ssi_jwk::algorithm::AnyESKeccakK;
 use ssi_verification_methods::{
     covariance_rule, InvalidSignature, Referencable, SignatureError, VerificationError,
 };
-use std::future::Future;
-use std::pin::Pin;
-use std::task;
 
 use crate::suite::{AnySignature, AnySignatureRef};
 
@@ -30,6 +26,15 @@ impl Eip712Signature {
         Self {
             proof_value: format!("0x{}", hex::encode(signature_bytes)),
         }
+    }
+
+    pub async fn sign<'a, S: MessageSigner<AnyESKeccakK>>(
+        bytes: &'a [u8],
+        signer: S,
+        algorithm: AnyESKeccakK
+    ) -> Result<Self, SignatureError> {
+        let signature = signer.sign(algorithm, (), bytes).await?;
+        Ok(Eip712Signature::from_bytes(signature))
     }
 }
 
@@ -163,71 +168,5 @@ impl<V: Vocabulary, I: Interpretation> LinkedData<I, V> for TypesOrURI {
     {
         visitor.default_graph(self)?;
         visitor.end()
-    }
-}
-
-#[pin_project]
-pub struct Eip712Sign<'a, S: 'a + MessageSigner<AnyESKeccakK>> {
-    #[pin]
-    inner: Eip712SignInner<'a, S>,
-}
-
-impl<'a, S: 'a + MessageSigner<AnyESKeccakK>> Eip712Sign<'a, S> {
-    pub fn new(bytes: &'a [u8], signer: S, algorithm: AnyESKeccakK) -> Self {
-        Self {
-            inner: Eip712SignInner::Ok(Eip712SignOk {
-                sign: signer.sign(algorithm, (), bytes),
-            }),
-        }
-    }
-
-    pub fn err(error: SignatureError) -> Self {
-        Self {
-            inner: Eip712SignInner::Err(Some(error)),
-        }
-    }
-}
-
-impl<'a, S: 'a + MessageSigner<AnyESKeccakK>> Future for Eip712Sign<'a, S> {
-    type Output = Result<Eip712Signature, SignatureError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.inner.poll(cx)
-    }
-}
-
-#[pin_project(project = Eip712SignInnerProject)]
-enum Eip712SignInner<'a, S: 'a + MessageSigner<AnyESKeccakK>> {
-    Ok(#[pin] Eip712SignOk<'a, S>),
-    Err(Option<SignatureError>),
-}
-
-impl<'a, S: 'a + MessageSigner<AnyESKeccakK>> Future for Eip712SignInner<'a, S> {
-    type Output = Result<Eip712Signature, SignatureError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        match self.project() {
-            Eip712SignInnerProject::Ok(f) => f.poll(cx),
-            Eip712SignInnerProject::Err(e) => task::Poll::Ready(Err(e.take().unwrap())),
-        }
-    }
-}
-
-#[pin_project]
-struct Eip712SignOk<'a, S: 'a + MessageSigner<AnyESKeccakK>> {
-    #[pin]
-    sign: S::Sign<'a>,
-}
-
-impl<'a, S: 'a + MessageSigner<AnyESKeccakK>> Future for Eip712SignOk<'a, S> {
-    type Output = Result<Eip712Signature, SignatureError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.sign.poll(cx).map(|r| {
-            let signature = r?;
-            Ok(Eip712Signature::from_bytes(signature))
-        })
     }
 }

--- a/ssi-vc-ldp/src/eip712/signature.rs
+++ b/ssi-vc-ldp/src/eip712/signature.rs
@@ -31,7 +31,7 @@ impl Eip712Signature {
     pub async fn sign<'a, S: MessageSigner<AnyESKeccakK>>(
         bytes: &'a [u8],
         signer: S,
-        algorithm: AnyESKeccakK
+        algorithm: AnyESKeccakK,
     ) -> Result<Self, SignatureError> {
         let signature = signer.sign(algorithm, (), bytes).await?;
         Ok(Eip712Signature::from_bytes(signature))

--- a/ssi-vc-ldp/src/lib.rs
+++ b/ssi-vc-ldp/src/lib.rs
@@ -1,9 +1,5 @@
 use educe::Educe;
-use pin_project::pin_project;
-use ssi_core::futures::{RefFutureBinder, SelfRefFuture, UnboundedRefFuture};
-use std::marker::PhantomData;
 use std::ops::Deref;
-use std::{future::Future, pin::Pin, task};
 use suite::{HashError, TransformError};
 
 mod decode;
@@ -42,65 +38,27 @@ pub struct DataIntegrity<T, S: CryptographicSuite> {
     hash: S::Hashed,
 }
 
-#[pin_project]
-pub struct BuildDataIntegrity<'a, T: 'a, S: 'a + CryptographicSuiteInput<T, X>, X: 'a> {
-    suite: &'a S,
-
-    params: ProofConfigurationRef<'a, S::VerificationMethod, S::Options>,
-
-    #[pin]
-    transform: SelfRefFuture<'a, UnboundedTransform<T, X, S>>,
-}
-
-impl<'a, T: 'a, S: 'a + CryptographicSuiteInput<T, X>, X: 'a> Future
-    for BuildDataIntegrity<'a, T, S, X>
-{
-    type Output = Result<DataIntegrity<T, S>, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        match this.transform.poll(cx) {
-            task::Poll::Pending => task::Poll::Pending,
-            task::Poll::Ready((Err(e), _)) => task::Poll::Ready(Err(Error::Transform(e))),
-            task::Poll::Ready((Ok(transformed), input)) => {
-                match this.suite.hash(transformed, *this.params) {
-                    Err(e) => task::Poll::Ready(Err(Error::HashFailed(e))),
-                    Ok(hashed) => task::Poll::Ready(Ok(DataIntegrity::new_hashed(input, hashed))),
-                }
-            }
-        }
-    }
-}
-
 impl<T, S: CryptographicSuite> DataIntegrity<T, S> {
     /// Creates a new data integrity credential from the given input data.
     ///
     /// This will transform and hash the input data using the cryptographic
     /// suite's transformation and hashing algorithms.
-    pub fn new<'a, 'c: 'a, X: 'a>(
+    pub async fn new<'a, 'c: 'a, X: 'a>(
         input: T,
         context: X,
         suite: &'a S,
         params: ProofConfigurationRef<'c, S::VerificationMethod, S::Options>,
-    ) -> BuildDataIntegrity<'a, T, S, X>
+    ) -> Result<Self, Error>
     where
         T: 'a,
         S: CryptographicSuiteInput<T, X>,
     {
         let params = params.shorten_lifetime();
-        BuildDataIntegrity {
-            suite,
-            params,
-            // input: Some(input),
-            transform: SelfRefFuture::new(
-                input,
-                TransformParameters {
-                    suite,
-                    context,
-                    params,
-                },
-            ),
-        }
+        let transformed = suite.transform(&input, context, params).await?;
+
+        let hashed = suite.hash(transformed, params)?;
+
+        Ok(Self::new_hashed(input, hashed))
     }
 
     pub fn new_hashed(credential: T, hashed: S::Hashed) -> Self {
@@ -130,17 +88,17 @@ impl<T, S: CryptographicSuite> DataIntegrity<T, S> {
         (self.value, self.hash)
     }
 
-    pub fn map<'a, 'c: 'a, U: 'a, X: 'a>(
+    pub async fn map<'a, 'c: 'a, U: 'a, X: 'a>(
         self,
         context: X,
         suite: &'a S,
         params: ProofConfigurationRef<'c, S::VerificationMethod, S::Options>,
         f: impl FnOnce(T) -> U,
-    ) -> BuildDataIntegrity<'a, U, S, X>
+    ) -> Result<DataIntegrity<U, S>, Error>
     where
         S: CryptographicSuiteInput<U, X>,
     {
-        DataIntegrity::new(f(self.value), context, suite, params)
+        DataIntegrity::new(f(self.value), context, suite, params).await
     }
 }
 
@@ -149,36 +107,5 @@ impl<T, S: CryptographicSuite> Deref for DataIntegrity<T, S> {
 
     fn deref(&self) -> &Self::Target {
         &self.value
-    }
-}
-
-struct UnboundedTransform<T, X, S>(PhantomData<(T, X, S)>);
-
-impl<'max, T: 'max, X: 'max, S: 'max + CryptographicSuiteInput<T, X>> UnboundedRefFuture<'max>
-    for UnboundedTransform<T, X, S>
-{
-    type Bound<'a> = S::Transform<'a> where 'max: 'a;
-
-    type Owned = T;
-
-    type Output = Result<S::Transformed, TransformError>;
-}
-
-struct TransformParameters<'a, X, S: CryptographicSuite> {
-    suite: &'a S,
-    context: X,
-    params: ProofConfigurationRef<'a, S::VerificationMethod, S::Options>,
-}
-
-impl<'max, T: 'max, X: 'max, S: 'max + CryptographicSuiteInput<T, X>>
-    RefFutureBinder<'max, UnboundedTransform<T, X, S>> for TransformParameters<'max, X, S>
-{
-    fn bind<'a>(context: Self, value: &'a T) -> S::Transform<'a>
-    where
-        'max: 'a,
-    {
-        context
-            .suite
-            .transform(value, context.context, context.params)
     }
 }

--- a/ssi-vc-ldp/src/proof.rs
+++ b/ssi-vc-ldp/src/proof.rs
@@ -141,26 +141,6 @@ where
     }
 }
 
-// impl<T: CryptographicSuite, V: Vocabulary, I: Interpretation> LinkedDataDeserializeSubject<I, V> for Proof<T> {
-//     fn deserialize_subject<D>(
-//         vocabulary: &V,
-//         interpretation: &I,
-//         dataset: &D,
-//         graph: &D::Graph,
-//         resource: &I::Resource,
-//     ) -> Result<Self, linked_data::FromLinkedDataError>
-//     where
-//         D: grdf::Dataset<
-//             Subject = I::Resource,
-//             Predicate = I::Resource,
-//             Object = I::Resource,
-//             GraphLabel = I::Resource,
-//         >
-//     {
-//         // ...
-//     }
-// }
-
 impl<T: CryptographicSuite, V: Vocabulary, I: Interpretation> LinkedDataPredicateObjects<I, V>
     for Proof<T>
 where

--- a/ssi-vc-ldp/src/signing.rs
+++ b/ssi-vc-ldp/src/signing.rs
@@ -1,12 +1,9 @@
-use pin_project::pin_project;
-use ssi_core::futures::{RefFutureBinder, SelfRefFuture, UnboundedRefFuture};
 use ssi_vc::Verifiable;
 use ssi_verification_methods::{SignatureError, Signer};
-use std::{future::Future, marker::PhantomData, pin::Pin, task};
 
 use crate::{
-    suite::{CryptographicSuiteInput, GenerateProof, HashError, TransformError},
-    BuildDataIntegrity, CryptographicSuite, DataIntegrity, ProofConfiguration, UntypedProof,
+    suite::{CryptographicSuiteInput, HashError, TransformError},
+    CryptographicSuite, DataIntegrity, ProofConfiguration,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -33,246 +30,40 @@ impl From<crate::Error> for Error {
     }
 }
 
-pub fn sign<'max, T, S: CryptographicSuite, X, I>(
+pub async fn sign<'max, T, S: CryptographicSuite, X, I>(
     input: T,
     context: X,
     signer: &'max I,
     suite: S,
     params: ProofConfiguration<S::VerificationMethod, S::Options>,
-) -> SignLinkedData<'max, T, S, X, I>
+) -> Result<Verifiable<DataIntegrity<T, S>>, Error>
 where
     S: CryptographicSuiteInput<T, X>,
     S::VerificationMethod: 'max,
     I: 'max + Signer<S::VerificationMethod, S::MessageSignatureAlgorithm, S::SignatureProtocol>,
 {
-    DataIntegrity::<T, S>::sign(input, context, signer, suite, params)
+    DataIntegrity::<T, S>::sign(input, context, signer, suite, params).await
 }
 
 impl<T, S: CryptographicSuite> DataIntegrity<T, S> {
     /// Sign the given credential with the given Data Integrity cryptographic
     /// suite.
-    //
-    // # Why is this not an `async` function?
-    //
-    // For some reason the Rust compiler is unable to build a future that
-    // returns a value of type `Verifiable<DataIntegrity<C, S>>`.
-    // See: <https://github.com/rust-lang/rust/issues/103532>
-    pub fn sign<'max, X, I>(
+    pub async fn sign<'max, X, I>(
         input: T,
         context: X,
         signer: &'max I,
         suite: S,
         params: ProofConfiguration<S::VerificationMethod, S::Options>,
-    ) -> SignLinkedData<'max, T, S, X, I>
+    ) -> Result<Verifiable<DataIntegrity<T, S>>, Error>
     where
         S: CryptographicSuiteInput<T, X>,
         S::VerificationMethod: 'max,
         I: 'max + Signer<S::VerificationMethod, S::MessageSignatureAlgorithm, S::SignatureProtocol>,
     {
-        SignLinkedData {
-            signer,
-            build: SelfRefFuture::new(
-                BuildBounds { suite, params },
-                BuildParameters { input, context },
-            ),
-            inner: None,
-        }
-    }
-}
+        let di = DataIntegrity::new(input, context, &suite, params.borrowed()).await?;
 
-struct UnboundedBuild<T, S, X>(PhantomData<(T, S, X)>);
+        let proof = suite.generate_proof(&di.hash, signer, params).await?;
 
-impl<'max, T: 'max, S: 'max + CryptographicSuiteInput<T, X>, X: 'max> UnboundedRefFuture<'max>
-    for UnboundedBuild<T, S, X>
-{
-    type Bound<'a> = BuildDataIntegrity<'a, T, S, X> where 'max: 'a;
-
-    type Owned = BuildBounds<S>;
-
-    type Output = Result<DataIntegrity<T, S>, crate::Error>;
-}
-
-struct BuildBounds<S: CryptographicSuite> {
-    suite: S,
-    params: ProofConfiguration<S::VerificationMethod, S::Options>,
-}
-
-struct BuildParameters<T, X> {
-    input: T,
-    context: X,
-}
-
-impl<'max, T: 'max, S: 'max + CryptographicSuiteInput<T, X>, X: 'max>
-    RefFutureBinder<'max, UnboundedBuild<T, S, X>> for BuildParameters<T, X>
-{
-    fn bind<'a>(context: Self, bounds: &'a BuildBounds<S>) -> BuildDataIntegrity<'a, T, S, X>
-    where
-        'max: 'a,
-    {
-        DataIntegrity::new(
-            context.input,
-            context.context,
-            &bounds.suite,
-            bounds.params.borrowed(),
-        )
-    }
-}
-
-struct UnboundedGenerateProof<S, T>(PhantomData<(S, T)>);
-
-impl<
-        'max,
-        S: 'max + CryptographicSuite,
-        T: 'max + Signer<S::VerificationMethod, S::MessageSignatureAlgorithm, S::SignatureProtocol>,
-    > UnboundedRefFuture<'max> for UnboundedGenerateProof<S, T>
-where
-    S::Hashed: 'max,
-    S::VerificationMethod: 'max,
-    S::SignatureAlgorithm: 'max,
-    S::Options: 'max,
-    S::Signature: 'max,
-{
-    type Owned = (S, S::Hashed);
-
-    type Bound<'a> = GenerateProof<'a, S, T> where 'max: 'a;
-
-    type Output =
-        Result<UntypedProof<S::VerificationMethod, S::Options, S::Signature>, SignatureError>;
-}
-
-struct Binder<'a, S: CryptographicSuite, T> {
-    params: ProofConfiguration<S::VerificationMethod, S::Options>,
-    signer: &'a T,
-}
-
-impl<
-        'max,
-        S: 'max + CryptographicSuite,
-        T: 'max + Signer<S::VerificationMethod, S::MessageSignatureAlgorithm, S::SignatureProtocol>,
-    > RefFutureBinder<'max, UnboundedGenerateProof<S, T>> for Binder<'max, S, T>
-where
-    S::Hashed: 'max,
-    S::VerificationMethod: 'max,
-    S::SignatureAlgorithm: 'max,
-    S::Options: 'max,
-    S::Signature: 'max,
-{
-    fn bind<'a>(context: Self, (suite, hash): &'a (S, S::Hashed)) -> GenerateProof<'a, S, T>
-    where
-        'max: 'a,
-    {
-        suite.generate_proof(hash, context.signer, context.params)
-    }
-}
-
-/// Future returned by the [`DataIntegrity::sign_ld`] method.
-//
-// # Why write the future by hand?
-//
-// For some reason the Rust compiler is unable to build a future that
-// returns a value of type `Verifiable<DataIntegrity<C, S>>`.
-// See: <https://github.com/rust-lang/rust/issues/103532>
-#[pin_project]
-pub struct SignLinkedData<'max, T, S, X, I>
-where
-    T: 'max,
-    S: 'max + CryptographicSuiteInput<T, X>,
-    S::VerificationMethod: 'max,
-    S::SignatureAlgorithm: 'max,
-    S::Options: 'max,
-    X: 'max,
-    I: 'max + Signer<S::VerificationMethod, S::MessageSignatureAlgorithm, S::SignatureProtocol>,
-{
-    signer: &'max I,
-
-    #[pin]
-    build: SelfRefFuture<'max, UnboundedBuild<T, S, X>>,
-
-    #[pin]
-    inner: Option<SignLinkedDataOk<'max, T, S, I>>,
-}
-
-impl<'max, T, S, X, I> Future for SignLinkedData<'max, T, S, X, I>
-where
-    S: CryptographicSuiteInput<T, X>,
-    S::VerificationMethod: 'max,
-    I: 'max + Signer<S::VerificationMethod, S::MessageSignatureAlgorithm, S::SignatureProtocol>,
-{
-    type Output = Result<Verifiable<DataIntegrity<T, S>>, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let mut this = self.project();
-
-        loop {
-            if this.inner.is_some() {
-                let inner = this.inner.as_pin_mut().unwrap();
-                break inner.poll(cx);
-            } else {
-                match this.build.as_mut().poll(cx) {
-                    task::Poll::Pending => break task::Poll::Pending,
-                    task::Poll::Ready((Ok(di), BuildBounds { suite, params })) => {
-                        let (input, hash) = di.into_parts();
-
-                        let sign = SelfRefFuture::new(
-                            (suite, hash),
-                            Binder {
-                                params,
-                                signer: *this.signer,
-                            },
-                        );
-
-                        this.inner.set(Some(SignLinkedDataOk {
-                            payload: Some(input),
-                            sign,
-                        }));
-                    }
-                    task::Poll::Ready((Err(e), _)) => break task::Poll::Ready(Err(e.into())),
-                }
-            }
-        }
-    }
-}
-
-/// Private implementation of the `SignLinkedData` type, with the signature
-/// preparation succeded.
-#[pin_project]
-struct SignLinkedDataOk<'max, C, S, T>
-where
-    S: 'max + CryptographicSuite,
-    S::Hashed: 'max,
-    S::VerificationMethod: 'max,
-    S::SignatureAlgorithm: 'max,
-    S::Options: 'max,
-    S::Signature: 'max,
-    T: 'max + Signer<S::VerificationMethod, S::MessageSignatureAlgorithm, S::SignatureProtocol>,
-{
-    payload: Option<C>,
-
-    #[pin]
-    sign: SelfRefFuture<'max, UnboundedGenerateProof<S, T>>,
-}
-
-impl<'max, C, S, T> Future for SignLinkedDataOk<'max, C, S, T>
-where
-    S: CryptographicSuite,
-    S::VerificationMethod: 'max,
-    T: 'max + Signer<S::VerificationMethod, S::MessageSignatureAlgorithm, S::SignatureProtocol>,
-{
-    type Output = Result<Verifiable<DataIntegrity<C, S>>, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-
-        this.sign.poll(cx).map(|(result, (suite, hash))| {
-            result
-                .map(|proof| {
-                    let data = this.payload.take().unwrap();
-                    Verifiable::new(
-                        DataIntegrity::new_hashed(data, hash),
-                        proof.into_typed(suite),
-                    )
-                })
-                .map_err(Into::into)
-        })
+        Ok(Verifiable::new(di, proof.into_typed(suite)))
     }
 }

--- a/ssi-vc-ldp/src/suite/signatures.rs
+++ b/ssi-vc-ldp/src/suite/signatures.rs
@@ -165,7 +165,7 @@ impl JwsSignature {
         payload: &[u8],
         signer: S,
         key_id: Option<String>,
-        algorithm: A
+        algorithm: A,
     ) -> Result<Self, SignatureError> {
         let header = ssi_jws::Header::new_unencoded(algorithm.clone().into(), key_id);
         let signing_bytes = header.encode_signing_bytes(payload);

--- a/ssi-vc-ldp/src/suite/unspecified/aleo_signature_2021.rs
+++ b/ssi-vc-ldp/src/suite/unspecified/aleo_signature_2021.rs
@@ -120,16 +120,13 @@ impl ssi_verification_methods::SignatureAlgorithm<VerificationMethod> for Signat
 
     type MessageSignatureAlgorithm = ssi_jwk::Algorithm;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        future::Ready<Result<Self::Signature, SignatureError>>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: (),
-        method: VerificationMethodRef,
-        bytes: &'a [u8],
+        options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        method: <VerificationMethod as ssi_verification_methods::Referencable>::Reference<'_>,
+        bytes: &[u8],
         signer: S,
-    ) -> Self::Sign<'a, S> {
+    ) -> Result<Self::Signature, SignatureError> {
         todo!()
     }
 

--- a/ssi-vc-ldp/src/suite/unspecified/aleo_signature_2021.rs
+++ b/ssi-vc-ldp/src/suite/unspecified/aleo_signature_2021.rs
@@ -1,5 +1,3 @@
-use std::future;
-
 use ssi_crypto::{protocol::Base58BtcMultibase, MessageSignatureError, MessageSigner};
 use ssi_jwk::JWK;
 use ssi_verification_methods::{
@@ -122,10 +120,10 @@ impl ssi_verification_methods::SignatureAlgorithm<VerificationMethod> for Signat
 
     async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
-        method: <VerificationMethod as ssi_verification_methods::Referencable>::Reference<'_>,
-        bytes: &[u8],
-        signer: S,
+        _options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        _method: <VerificationMethod as ssi_verification_methods::Referencable>::Reference<'_>,
+        _bytes: &[u8],
+        _signer: S,
     ) -> Result<Self::Signature, SignatureError> {
         todo!()
     }

--- a/ssi-vc-ldp/src/suite/unspecified/ethereum_personal_signature_2021.rs
+++ b/ssi-vc-ldp/src/suite/unspecified/ethereum_personal_signature_2021.rs
@@ -1,8 +1,3 @@
-use pin_project::pin_project;
-use std::future::Future;
-use std::pin::Pin;
-use std::task;
-
 use ssi_crypto::{protocol::EthereumWallet, MessageSigner};
 use ssi_jwk::JWK;
 use ssi_rdf::IntoNQuads;
@@ -218,17 +213,18 @@ impl ssi_verification_methods::SignatureAlgorithm<VerificationMethod> for Signat
 
     type Protocol = EthereumWallet;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        EthereumWalletSign<'a, S>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: (),
-        method: VerificationMethodRef,
-        bytes: &'a [u8],
+        _options: <() as Referencable>::Reference<'_>,
+        method: <VerificationMethod as Referencable>::Reference<'_>,
+        bytes: &[u8],
         signer: S,
-    ) -> Self::Sign<'a, S> {
-        EthereumWalletSign::new(signer.sign(method.algorithm().into(), EthereumWallet, bytes))
+    ) -> Result<Self::Signature, SignatureError> {
+        let proof_value_bytes = signer.sign(method.algorithm().into(), EthereumWallet, bytes).await?;
+        match String::from_utf8(proof_value_bytes) {
+            Ok(proof_value) => Ok(Signature::new(proof_value)),
+            Err(_) => Err(SignatureError::InvalidSignature),
+        }
     }
 
     fn verify(
@@ -255,36 +251,36 @@ impl<'a> VerificationMethodRef<'a> {
     }
 }
 
-#[pin_project]
-pub struct EthereumWalletSign<
-    'a,
-    S: 'a + MessageSigner<ssi_jwk::algorithm::AnyESKeccakK, EthereumWallet>,
-> {
-    #[pin]
-    inner: S::Sign<'a>,
-}
+// #[pin_project]
+// pub struct EthereumWalletSign<
+//     'a,
+//     S: 'a + MessageSigner<ssi_jwk::algorithm::AnyESKeccakK, EthereumWallet>,
+// > {
+//     #[pin]
+//     inner: S::Sign<'a>,
+// }
 
-impl<'a, S: 'a + MessageSigner<ssi_jwk::algorithm::AnyESKeccakK, EthereumWallet>>
-    EthereumWalletSign<'a, S>
-{
-    pub fn new(inner: S::Sign<'a>) -> Self {
-        Self { inner }
-    }
-}
+// impl<'a, S: 'a + MessageSigner<ssi_jwk::algorithm::AnyESKeccakK, EthereumWallet>>
+//     EthereumWalletSign<'a, S>
+// {
+//     pub fn new(inner: S::Sign<'a>) -> Self {
+//         Self { inner }
+//     }
+// }
 
-impl<'a, S: 'a + MessageSigner<ssi_jwk::algorithm::AnyESKeccakK, EthereumWallet>> Future
-    for EthereumWalletSign<'a, S>
-{
-    type Output = Result<Signature, SignatureError>;
+// impl<'a, S: 'a + MessageSigner<ssi_jwk::algorithm::AnyESKeccakK, EthereumWallet>> Future
+//     for EthereumWalletSign<'a, S>
+// {
+//     type Output = Result<Signature, SignatureError>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.inner.poll(cx).map(|r| {
-            let proof_value = r?;
-            match String::from_utf8(proof_value) {
-                Ok(proof_value) => Ok(Signature::new(proof_value)),
-                Err(_) => Err(SignatureError::InvalidSignature),
-            }
-        })
-    }
-}
+//     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+//         let this = self.project();
+//         this.inner.poll(cx).map(|r| {
+//             let proof_value = r?;
+//             match String::from_utf8(proof_value) {
+//                 Ok(proof_value) => Ok(Signature::new(proof_value)),
+//                 Err(_) => Err(SignatureError::InvalidSignature),
+//             }
+//         })
+//     }
+// }

--- a/ssi-vc-ldp/src/suite/unspecified/ethereum_personal_signature_2021.rs
+++ b/ssi-vc-ldp/src/suite/unspecified/ethereum_personal_signature_2021.rs
@@ -220,7 +220,9 @@ impl ssi_verification_methods::SignatureAlgorithm<VerificationMethod> for Signat
         bytes: &[u8],
         signer: S,
     ) -> Result<Self::Signature, SignatureError> {
-        let proof_value_bytes = signer.sign(method.algorithm().into(), EthereumWallet, bytes).await?;
+        let proof_value_bytes = signer
+            .sign(method.algorithm().into(), EthereumWallet, bytes)
+            .await?;
         match String::from_utf8(proof_value_bytes) {
             Ok(proof_value) => Ok(Signature::new(proof_value)),
             Err(_) => Err(SignatureError::InvalidSignature),

--- a/ssi-vc-ldp/src/suite/unspecified/solana_signature_2021.rs
+++ b/ssi-vc-ldp/src/suite/unspecified/solana_signature_2021.rs
@@ -1,5 +1,3 @@
-use std::future;
-
 use ssi_crypto::{protocol::Base58Btc, MessageSignatureError, MessageSigner};
 use ssi_jwk::JWK;
 use ssi_verification_methods::{
@@ -188,16 +186,13 @@ impl ssi_verification_methods::SignatureAlgorithm<SolanaMethod2021> for Signatur
 
     type MessageSignatureAlgorithm = ssi_jwk::algorithm::EdDSA;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        future::Ready<Result<Self::Signature, SignatureError>>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: (),
-        method: &SolanaMethod2021,
-        bytes: &'a [u8],
-        signer: S,
-    ) -> Self::Sign<'a, S> {
+        _options: <Self::Options as Referencable>::Reference<'_>,
+        _method: <SolanaMethod2021 as Referencable>::Reference<'_>,
+        _bytes: &[u8],
+        _signer: S,
+    ) -> Result<Self::Signature, SignatureError> {
         todo!()
     }
 

--- a/ssi-vc-ldp/src/suite/unspecified/tezos.rs
+++ b/ssi-vc-ldp/src/suite/unspecified/tezos.rs
@@ -97,7 +97,7 @@ impl Signature {
     pub async fn sign<'a, S: 'a + MessageSigner<AnyBlake2b, TezosWallet>>(
         public_key: Option<&JWK>,
         message: &'a [u8],
-        signer: S
+        signer: S,
     ) -> Result<Self, SignatureError> {
         match public_key {
             Some(jwk) => match jwk.algorithm.try_into() {
@@ -107,10 +107,10 @@ impl Signature {
                         Ok(proof_value) => Ok(Signature::new(proof_value)),
                         Err(_) => Err(SignatureError::InvalidSignature),
                     }
-                },
-                Err(e) => Err(MessageSignatureError::from(e).into())
+                }
+                Err(e) => Err(MessageSignatureError::from(e).into()),
             },
-            None => Err(SignatureError::MissingPublicKey)
+            None => Err(SignatureError::MissingPublicKey),
         }
     }
 }

--- a/ssi-vc-ldp/src/suite/unspecified/tezos.rs
+++ b/ssi-vc-ldp/src/suite/unspecified/tezos.rs
@@ -5,11 +5,7 @@ pub mod p256_blake2b_digest_size20_base58_check_encoded_signature_2021;
 pub mod tezos_jcs_signature_2021;
 pub mod tezos_signature_2021;
 
-use pin_project::pin_project;
 use std::borrow::Cow;
-use std::future::Future;
-use std::pin::Pin;
-use std::task;
 
 pub use ed25519_blake2b_digest_size20_base58_check_encoded_signature_2021::Ed25519BLAKE2BDigestSize20Base58CheckEncodedSignature2021;
 pub use p256_blake2b_digest_size20_base58_check_encoded_signature_2021::P256BLAKE2BDigestSize20Base58CheckEncodedSignature2021;
@@ -96,6 +92,26 @@ pub struct Signature {
 impl Signature {
     pub fn new(proof_value: String) -> Self {
         Self { proof_value }
+    }
+
+    pub async fn sign<'a, S: 'a + MessageSigner<AnyBlake2b, TezosWallet>>(
+        public_key: Option<&JWK>,
+        message: &'a [u8],
+        signer: S
+    ) -> Result<Self, SignatureError> {
+        match public_key {
+            Some(jwk) => match jwk.algorithm.try_into() {
+                Ok(algorithm) => {
+                    let proof_value_bytes = signer.sign(algorithm, TezosWallet, message).await?;
+                    match String::from_utf8(proof_value_bytes) {
+                        Ok(proof_value) => Ok(Signature::new(proof_value)),
+                        Err(_) => Err(SignatureError::InvalidSignature),
+                    }
+                },
+                Err(e) => Err(MessageSignatureError::from(e).into())
+            },
+            None => Err(SignatureError::MissingPublicKey)
+        }
     }
 }
 
@@ -210,78 +226,6 @@ impl SignatureProtocol<AnyBlake2b> for TezosWallet {
         encoded_signature: &'s [u8],
     ) -> Result<Cow<'s, [u8]>, InvalidProtocolSignature> {
         Self::decode_signature(encoded_signature).map(|(_, s)| Cow::Owned(s))
-    }
-}
-
-#[pin_project]
-pub struct TezosSign<'a, S: 'a + MessageSigner<AnyBlake2b, TezosWallet>> {
-    #[pin]
-    inner: TezosSignInner<'a, S>,
-}
-
-impl<'a, S: MessageSigner<AnyBlake2b, TezosWallet>> TezosSign<'a, S> {
-    pub fn new(public_key: Option<&JWK>, message: &'a [u8], signer: S) -> Self {
-        let inner = match public_key {
-            Some(jwk) => match jwk.algorithm.try_into() {
-                Ok(algorithm) => TezosSignInner::Ok(TezosSignOk {
-                    sign: signer.sign(algorithm, TezosWallet, message),
-                }),
-                Err(e) => TezosSignInner::Err(Some(MessageSignatureError::from(e).into())),
-            },
-            None => TezosSignInner::Err(Some(SignatureError::MissingPublicKey)),
-        };
-
-        Self { inner }
-    }
-
-    pub fn err(e: SignatureError) -> Self {
-        Self {
-            inner: TezosSignInner::Err(Some(e)),
-        }
-    }
-}
-
-impl<'a, S: 'a + MessageSigner<AnyBlake2b, TezosWallet>> Future for TezosSign<'a, S> {
-    type Output = Result<Signature, SignatureError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.inner.poll(cx)
-    }
-}
-
-#[pin_project(project = TezosSignInnerProj)]
-enum TezosSignInner<'a, S: 'a + MessageSigner<AnyBlake2b, TezosWallet>> {
-    Ok(#[pin] TezosSignOk<'a, S>),
-    Err(Option<SignatureError>),
-}
-
-impl<'a, S: 'a + MessageSigner<AnyBlake2b, TezosWallet>> Future for TezosSignInner<'a, S> {
-    type Output = Result<Signature, SignatureError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        match self.project() {
-            TezosSignInnerProj::Ok(f) => f.poll(cx),
-            TezosSignInnerProj::Err(e) => task::Poll::Ready(Err(e.take().unwrap())),
-        }
-    }
-}
-
-#[pin_project]
-struct TezosSignOk<'a, S: 'a + MessageSigner<AnyBlake2b, TezosWallet>> {
-    #[pin]
-    sign: S::Sign<'a>,
-}
-
-impl<'a, S: 'a + MessageSigner<AnyBlake2b, TezosWallet>> Future for TezosSignOk<'a, S> {
-    type Output = Result<Signature, SignatureError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.sign.poll(cx).map(|r| match String::from_utf8(r?) {
-            Ok(proof_value) => Ok(Signature::new(proof_value)),
-            Err(_) => Err(SignatureError::InvalidSignature),
-        })
     }
 }
 

--- a/ssi-vc-ldp/src/suite/unspecified/tezos/p256_blake2b_digest_size20_base58_check_encoded_signature_2021.rs
+++ b/ssi-vc-ldp/src/suite/unspecified/tezos/p256_blake2b_digest_size20_base58_check_encoded_signature_2021.rs
@@ -2,13 +2,13 @@ use super::{Options, OptionsRef};
 use iref::Iri;
 use ssi_crypto::MessageSigner;
 use ssi_verification_methods::{
-    P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021, VerificationError,
+    P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021, SignatureError, VerificationError,
 };
 use static_iref::iri;
 
 use crate::{
     impl_rdf_input_urdna2015,
-    suite::{sha256_hash, HashError, JwsSignature, JwsSignatureRef, SignIntoDetachedJws},
+    suite::{sha256_hash, HashError, JwsSignature, JwsSignatureRef},
     CryptographicSuite, ProofConfigurationRef,
 };
 
@@ -140,22 +140,20 @@ impl
 
     type MessageSignatureAlgorithm = ssi_jwk::algorithm::ESBlake2b;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        SignIntoDetachedJws<'a, S, Self::MessageSignatureAlgorithm>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        options: OptionsRef<'a>,
-        _method: &P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021,
-        bytes: &'a [u8],
+        options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        _method: <P256PublicKeyBLAKE2BDigestSize20Base58CheckEncoded2021 as ssi_verification_methods::Referencable>::Reference<'_>,
+        bytes: &[u8],
         signer: S,
-    ) -> Self::Sign<'a, S> {
-        SignIntoDetachedJws::new(
+    ) -> Result<Self::Signature, SignatureError> {
+        JwsSignature::sign_detached(
             bytes,
             signer,
             options.public_key_jwk.key_id.clone(),
             ssi_jwk::algorithm::ESBlake2b,
         )
+        .await
     }
 
     fn verify(

--- a/ssi-vc-ldp/src/suite/w3c/ecdsa_secp256k1_signature_2019.rs
+++ b/ssi-vc-ldp/src/suite/w3c/ecdsa_secp256k1_signature_2019.rs
@@ -1,5 +1,3 @@
-use std::future;
-
 use ssi_crypto::MessageSigner;
 use ssi_verification_methods::{
     ecdsa_secp_256k1_verification_key_2019::DigestFunction, EcdsaSecp256k1VerificationKey2019,

--- a/ssi-vc-ldp/src/suite/w3c/ecdsa_secp256r1_signature_2019.rs
+++ b/ssi-vc-ldp/src/suite/w3c/ecdsa_secp256r1_signature_2019.rs
@@ -1,5 +1,3 @@
-use std::future;
-
 use ssi_crypto::MessageSigner;
 use ssi_verification_methods::{EcdsaSecp256r1VerificationKey2019, SignatureError};
 use static_iref::iri;
@@ -72,17 +70,16 @@ impl ssi_verification_methods::SignatureAlgorithm<EcdsaSecp256r1VerificationKey2
 
     type MessageSignatureAlgorithm = ssi_jwk::algorithm::ES256;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        future::Ready<Result<Self::Signature, SignatureError>>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: (),
-        method: &EcdsaSecp256r1VerificationKey2019,
-        bytes: &'a [u8],
+        _options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        _method: <EcdsaSecp256r1VerificationKey2019 as ssi_verification_methods::Referencable>::Reference<'_>,
+        bytes: &[u8],
         signer: S,
-    ) -> Self::Sign<'a, S> {
-        todo!()
+    ) -> Result<Self::Signature, SignatureError> {
+        Ok(MultibaseSignature::new_base58btc(
+            signer.sign(ssi_jwk::algorithm::ES256, (), bytes).await?,
+        ))
     }
 
     fn verify(
@@ -92,6 +89,7 @@ impl ssi_verification_methods::SignatureAlgorithm<EcdsaSecp256r1VerificationKey2
         method: &EcdsaSecp256r1VerificationKey2019,
         bytes: &[u8],
     ) -> Result<bool, ssi_verification_methods::VerificationError> {
-        todo!()
+        let signature_bytes = signature.decode()?;
+        method.verify_bytes(bytes, &signature_bytes)
     }
 }

--- a/ssi-vc-ldp/src/suite/w3c/ed25519_signature_2018.rs
+++ b/ssi-vc-ldp/src/suite/w3c/ed25519_signature_2018.rs
@@ -72,8 +72,8 @@ impl ssi_verification_methods::SignatureAlgorithm<Ed25519VerificationKey2018>
 
     async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
-        method: <Ed25519VerificationKey2018 as ssi_verification_methods::Referencable>::Reference<
+        _options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        _method: <Ed25519VerificationKey2018 as ssi_verification_methods::Referencable>::Reference<
             '_,
         >,
         bytes: &[u8],

--- a/ssi-vc-ldp/src/suite/w3c/ed25519_signature_2020.rs
+++ b/ssi-vc-ldp/src/suite/w3c/ed25519_signature_2020.rs
@@ -103,8 +103,8 @@ impl ssi_verification_methods::SignatureAlgorithm<Ed25519VerificationKey2020>
 
     async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
-        method: <Ed25519VerificationKey2020 as ssi_verification_methods::Referencable>::Reference<
+        _options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        _method: <Ed25519VerificationKey2020 as ssi_verification_methods::Referencable>::Reference<
             '_,
         >,
         bytes: &[u8],

--- a/ssi-vc-ldp/src/suite/w3c/ed25519_signature_2020.rs
+++ b/ssi-vc-ldp/src/suite/w3c/ed25519_signature_2020.rs
@@ -101,19 +101,19 @@ impl ssi_verification_methods::SignatureAlgorithm<Ed25519VerificationKey2020>
 
     type MessageSignatureAlgorithm = ssi_jwk::algorithm::EdDSA;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        futures::future::Map<S::Sign<'a>, MessageBuilder>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: (),
-        _method: &Ed25519VerificationKey2020,
-        bytes: &'a [u8],
+        options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        method: <Ed25519VerificationKey2020 as ssi_verification_methods::Referencable>::Reference<
+            '_,
+        >,
+        bytes: &[u8],
         signer: S,
-    ) -> Self::Sign<'a, S> {
+    ) -> Result<Self::Signature, SignatureError> {
         signer
             .sign(ssi_jwk::algorithm::EdDSA, (), bytes)
             .map(build_signature)
+            .await
     }
 
     fn verify(
@@ -123,8 +123,7 @@ impl ssi_verification_methods::SignatureAlgorithm<Ed25519VerificationKey2020>
         method: &Ed25519VerificationKey2020,
         bytes: &[u8],
     ) -> Result<bool, VerificationError> {
-        let (_, signature_bytes) = multibase::decode(signature.proof_value)
-            .map_err(|_| VerificationError::InvalidSignature)?;
+        let signature_bytes = signature.decode()?;
         method.verify_bytes(bytes, &signature_bytes)
     }
 }

--- a/ssi-vc-ldp/src/suite/w3c/eddsa_2022.rs
+++ b/ssi-vc-ldp/src/suite/w3c/eddsa_2022.rs
@@ -3,8 +3,6 @@
 //! This is the successor of the EdDSA Cryptosuite v2020.
 //!
 //! See: <https://w3c.github.io/vc-di-eddsa/>
-use std::future;
-
 use ssi_crypto::MessageSigner;
 use ssi_verification_methods::SignatureError;
 use static_iref::iri;

--- a/ssi-vc-ldp/src/suite/w3c/eddsa_2022.rs
+++ b/ssi-vc-ldp/src/suite/w3c/eddsa_2022.rs
@@ -79,25 +79,22 @@ impl ssi_verification_methods::SignatureAlgorithm<Multikey> for SignatureAlgorit
 
     type MessageSignatureAlgorithm = ssi_jwk::algorithm::EdDSA;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        future::Ready<Result<Self::Signature, SignatureError>>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: (),
-        method: &Multikey,
-        bytes: &'a [u8],
-        signer: S,
-    ) -> Self::Sign<'a, S> {
+        _options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        _method: <Multikey as ssi_verification_methods::Referencable>::Reference<'_>,
+        _bytes: &[u8],
+        _signer: S,
+    ) -> Result<Self::Signature, SignatureError> {
         todo!()
     }
 
     fn verify(
         &self,
         _options: (),
-        signature: MultibaseSignatureRef,
-        method: &Multikey,
-        bytes: &[u8],
+        _signature: MultibaseSignatureRef,
+        _method: &Multikey,
+        _bytes: &[u8],
     ) -> Result<bool, ssi_verification_methods::VerificationError> {
         todo!()
     }

--- a/ssi-vc-ldp/src/suite/w3c/ethereum_eip712_signature_2021.rs
+++ b/ssi-vc-ldp/src/suite/w3c/ethereum_eip712_signature_2021.rs
@@ -16,8 +16,7 @@ use std::{future::Future, pin::Pin, task};
 
 use crate::{
     eip712::{
-        Eip712Signature, Eip712SignatureRef, Input, TypesFetchError, TypesOrURI,
-        TypesProvider,
+        Eip712Signature, Eip712SignatureRef, Input, TypesFetchError, TypesOrURI, TypesProvider,
     },
     suite::{CryptographicSuiteOptions, HashError, TransformError},
     CryptographicSuite, CryptographicSuiteInput, ProofConfigurationRef,

--- a/ssi-vc-ldp/src/suite/w3c/ethereum_eip712_signature_2021.rs
+++ b/ssi-vc-ldp/src/suite/w3c/ethereum_eip712_signature_2021.rs
@@ -9,14 +9,14 @@ use ssi_jwk::algorithm::{AlgorithmError, AnyESKeccakK};
 use ssi_verification_methods::{
     ecdsa_secp_256k1_recovery_method_2020, ecdsa_secp_256k1_verification_key_2019,
     verification_method_union, EcdsaSecp256k1RecoveryMethod2020, EcdsaSecp256k1VerificationKey2019,
-    JsonWebKey2020, Referencable, VerificationError,
+    JsonWebKey2020, Referencable, SignatureError, VerificationError,
 };
 use static_iref::{iri, iri_ref};
 use std::{future::Future, pin::Pin, task};
 
 use crate::{
     eip712::{
-        Eip712Sign, Eip712Signature, Eip712SignatureRef, Input, TypesFetchError, TypesOrURI,
+        Eip712Signature, Eip712SignatureRef, Input, TypesFetchError, TypesOrURI,
         TypesProvider,
     },
     suite::{CryptographicSuiteOptions, HashError, TransformError},
@@ -417,19 +417,16 @@ impl ssi_verification_methods::SignatureAlgorithm<VerificationMethod> for Signat
 
     type MessageSignatureAlgorithm = ssi_jwk::algorithm::AnyESKeccakK;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        Eip712Sign<'a, S>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: OptionsRef<'a>,
-        method: VerificationMethodRef,
-        bytes: &'a [u8],
+        _options: <Self::Options as Referencable>::Reference<'_>,
+        method: <VerificationMethod as Referencable>::Reference<'_>,
+        bytes: &[u8],
         signer: S,
-    ) -> Self::Sign<'a, S> {
+    ) -> Result<Self::Signature, SignatureError> {
         match method.algorithm() {
-            Ok(algorithm) => Eip712Sign::new(bytes, signer, algorithm),
-            Err(e) => Eip712Sign::err(MessageSignatureError::into(e.into())),
+            Ok(algorithm) => Eip712Signature::sign(bytes, signer, algorithm).await,
+            Err(e) => Err(MessageSignatureError::into(e.into())),
         }
     }
 

--- a/ssi-vc-ldp/src/suite/w3c/json_web_signature_2020.rs
+++ b/ssi-vc-ldp/src/suite/w3c/json_web_signature_2020.rs
@@ -68,25 +68,22 @@ impl ssi_verification_methods::SignatureAlgorithm<JsonWebKey2020> for SignatureA
 
     type MessageSignatureAlgorithm = ssi_jwk::Algorithm;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        future::Ready<Result<Self::Signature, SignatureError>>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: (),
-        method: &JsonWebKey2020,
-        bytes: &'a [u8],
-        signer: S,
-    ) -> Self::Sign<'a, S> {
+        _options: <Self::Options as ssi_verification_methods::Referencable>::Reference<'_>,
+        _method: <JsonWebKey2020 as ssi_verification_methods::Referencable>::Reference<'_>,
+        _bytes: &[u8],
+        _signer: S,
+    ) -> Result<Self::Signature, SignatureError> {
         todo!()
     }
 
     fn verify(
         &self,
         _options: (),
-        signature: JwsSignatureRef,
-        method: &JsonWebKey2020,
-        bytes: &[u8],
+        _signature: JwsSignatureRef,
+        _method: &JsonWebKey2020,
+        _bytes: &[u8],
     ) -> Result<bool, ssi_verification_methods::VerificationError> {
         todo!()
     }

--- a/ssi-vc-ldp/src/suite/w3c/json_web_signature_2020.rs
+++ b/ssi-vc-ldp/src/suite/w3c/json_web_signature_2020.rs
@@ -1,5 +1,3 @@
-use std::future;
-
 use ssi_crypto::MessageSigner;
 use ssi_verification_methods::{JsonWebKey2020, SignatureError};
 use static_iref::iri;

--- a/ssi-vc-ldp/src/suite/w3c/rsa_signature_2018.rs
+++ b/ssi-vc-ldp/src/suite/w3c/rsa_signature_2018.rs
@@ -119,25 +119,22 @@ impl ssi_verification_methods::SignatureAlgorithm<RsaVerificationKey2018> for Si
 
     type MessageSignatureAlgorithm = ssi_jwk::algorithm::RS256;
 
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>> =
-        future::Ready<Result<Self::Signature, SignatureError>>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        _options: (),
-        method: &RsaVerificationKey2018,
-        bytes: &'a [u8],
-        signer: S,
-    ) -> Self::Sign<'a, S> {
+        _options: <Self::Options as Referencable>::Reference<'_>,
+        _method: <RsaVerificationKey2018 as Referencable>::Reference<'_>,
+        _bytes: &[u8],
+        _signer: S,
+    ) -> Result<Self::Signature, SignatureError> {
         todo!()
     }
 
     fn verify(
         &self,
         _options: (),
-        signature: SignatureRef,
-        method: &RsaVerificationKey2018,
-        bytes: &[u8],
+        _signature: SignatureRef,
+        _method: &RsaVerificationKey2018,
+        _bytes: &[u8],
     ) -> Result<bool, ssi_verification_methods::VerificationError> {
         todo!()
     }

--- a/ssi-vc-ldp/src/suite/w3c/rsa_signature_2018.rs
+++ b/ssi-vc-ldp/src/suite/w3c/rsa_signature_2018.rs
@@ -1,5 +1,3 @@
-use std::future;
-
 use ssi_crypto::MessageSigner;
 use ssi_verification_methods::{
     covariance_rule, InvalidSignature, Referencable, RsaVerificationKey2018, SignatureError,

--- a/ssi-vc-ldp/src/verification.rs
+++ b/ssi-vc-ldp/src/verification.rs
@@ -1,6 +1,7 @@
-use method::Verifier;
+use method::{VerificationError, Verifier};
+use ssi_vc::ProofValidity;
 
-use crate::{suite::VerifyProof, CryptographicSuite, DataIntegrity, Proof};
+use crate::{CryptographicSuite, DataIntegrity, Proof};
 
 pub use method::{ReferenceOrOwned as MethodReferenceOrOwned, VerificationMethod};
 pub use ssi_verification_methods as method;
@@ -12,14 +13,14 @@ where
     type Proof = Proof<S>;
     type Method = S::VerificationMethod;
 
-    type VerifyWith<'a, V: Verifier<S::VerificationMethod>> = VerifyProof<'a, S, V> where Self: 'a, V: 'a;
-
-    fn verify_with<'a, V: Verifier<Self::Method>>(
+    async fn verify_with<'a, V: Verifier<Self::Method>>(
         &'a self,
         verifier: &'a V,
         proof: &'a Self::Proof,
-    ) -> VerifyProof<'a, S, V> {
+    ) -> Result<ProofValidity, VerificationError> {
         let suite = proof.suite();
-        suite.verify_proof(&self.hash, verifier, proof.untyped().borrowed())
+        suite
+            .verify_proof(&self.hash, verifier, proof.untyped().borrowed())
+            .await
     }
 }

--- a/ssi-vc/src/verification.rs
+++ b/ssi-vc/src/verification.rs
@@ -10,6 +10,7 @@ pub trait VerifiableWith {
     /// Proof type.
     type Proof;
 
+    #[allow(async_fn_in_trait)]
     async fn verify_with<'a, V: Verifier<Self::Method>>(
         &'a self,
         verifier: &'a V,

--- a/ssi-vc/src/verification.rs
+++ b/ssi-vc/src/verification.rs
@@ -1,5 +1,4 @@
 use ssi_verification_methods::{Referencable, VerificationError, Verifier};
-use std::future::Future;
 
 use crate::Verifiable;
 
@@ -11,18 +10,11 @@ pub trait VerifiableWith {
     /// Proof type.
     type Proof;
 
-    /// Future returned by `verify_with`.
-    type VerifyWith<'a, V: Verifier<Self::Method>>: 'a
-        + Future<Output = Result<ProofValidity, VerificationError>>
-    where
-        Self: 'a,
-        V: 'a;
-
-    fn verify_with<'a, V: Verifier<Self::Method>>(
+    async fn verify_with<'a, V: Verifier<Self::Method>>(
         &'a self,
         verifier: &'a V,
         proof: &'a Self::Proof,
-    ) -> Self::VerifyWith<'a, V>;
+    ) -> Result<ProofValidity, VerificationError>;
 
     fn with_proof(self, proof: Self::Proof) -> Verifiable<Self>
     where

--- a/ssi-verification-methods/src/controller.rs
+++ b/ssi-verification-methods/src/controller.rs
@@ -1,6 +1,4 @@
 use iref::Iri;
-use pin_project::pin_project;
-use std::{future::Future, pin::Pin, task};
 
 use crate::{ProofPurpose, ProofPurposes, VerificationError};
 
@@ -35,36 +33,33 @@ pub trait ControllerProvider {
     where
         Self: 'a;
 
-    /// Future returned by the `get_controller` method.
-    type GetController<'a>: Future<Output = Result<Option<Self::Controller<'a>>, ControllerError>>
-    where
-        Self: 'a;
-
     /// Returns the controller with the given identifier, if it can be found.
-    fn get_controller<'a>(&'a self, id: &'a Iri) -> Self::GetController<'a>;
+    async fn get_controller<'a>(
+        &'a self,
+        id: &'a Iri,
+    ) -> Result<Option<Self::Controller<'a>>, ControllerError>;
 
     /// Returns the controller with the given identifier, or fails if it cannot
     /// be found.
-    fn require_controller<'a>(&'a self, id: &'a Iri) -> RequireController<'a, Self> {
-        RequireController {
-            id,
-            get: self.get_controller(id),
-        }
+    async fn require_controller<'a>(
+        &'a self,
+        id: &'a Iri,
+    ) -> Result<Self::Controller<'a>, ControllerError> {
+        self.get_controller(id)
+            .await?
+            .ok_or_else(|| ControllerError::NotFound(id.to_string()))
     }
 
     /// Checks that the controller identified by `controller_id` allows the use
     /// of the verification method `method_id` with the given proof purposes.
-    fn allows_verification_method<'a>(
+    async fn allows_verification_method<'a>(
         &'a self,
         controller_id: &'a Iri,
         method_id: &'a Iri,
         proof_purposes: ProofPurposes,
-    ) -> AllowsVerificationMethod<'a, Self> {
-        AllowsVerificationMethod {
-            method_id,
-            proof_purposes,
-            require: self.require_controller(controller_id),
-        }
+    ) -> Result<bool, ControllerError> {
+        let controller = self.require_controller(controller_id).await?;
+        Ok(controller.allows_verification_method(method_id, proof_purposes))
     }
 
     /// Ensures that the controller identified by `controller_id` allows the use
@@ -72,83 +67,18 @@ pub trait ControllerProvider {
     ///
     /// Contrarily to the [`allows_verification_method`] function, this function
     /// returns an error if one of the input proof purposes is not allowed.
-    fn ensure_allows_verification_method<'a>(
+    async fn ensure_allows_verification_method<'a>(
         &'a self,
         controller_id: &'a Iri,
         method_id: &'a Iri,
         proof_purpose: ProofPurpose,
-    ) -> EnsureAllowsVerificationMethod<'a, Self> {
-        EnsureAllowsVerificationMethod {
-            method_id,
-            proof_purpose,
-            require: self.require_controller(controller_id),
+    ) -> Result<(), VerificationError> {
+        let controller = self.require_controller(controller_id).await?;
+        if controller.allows_verification_method(method_id, proof_purpose.into()) {
+            Ok(())
+        } else {
+            Err(VerificationError::InvalidKeyUse(proof_purpose))
         }
-    }
-}
-
-#[pin_project]
-pub struct RequireController<'a, C: 'a + ?Sized + ControllerProvider> {
-    id: &'a Iri,
-
-    #[pin]
-    get: C::GetController<'a>,
-}
-
-impl<'a, C: 'a + ?Sized + ControllerProvider> Future for RequireController<'a, C> {
-    type Output = Result<C::Controller<'a>, ControllerError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.get.poll(cx).map(|result| {
-            result.and_then(|c| c.ok_or_else(|| ControllerError::NotFound(this.id.to_string())))
-        })
-    }
-}
-
-#[pin_project]
-pub struct AllowsVerificationMethod<'a, C: 'a + ?Sized + ControllerProvider> {
-    method_id: &'a Iri,
-
-    proof_purposes: ProofPurposes,
-
-    #[pin]
-    require: RequireController<'a, C>,
-}
-
-impl<'a, C: 'a + ?Sized + ControllerProvider> Future for AllowsVerificationMethod<'a, C> {
-    type Output = Result<bool, ControllerError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.require
-            .poll(cx)
-            .map_ok(|c| c.allows_verification_method(*this.method_id, *this.proof_purposes))
-    }
-}
-
-#[pin_project]
-pub struct EnsureAllowsVerificationMethod<'a, C: 'a + ?Sized + ControllerProvider> {
-    method_id: &'a Iri,
-
-    proof_purpose: ProofPurpose,
-
-    #[pin]
-    require: RequireController<'a, C>,
-}
-
-impl<'a, C: 'a + ?Sized + ControllerProvider> Future for EnsureAllowsVerificationMethod<'a, C> {
-    type Output = Result<(), VerificationError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = self.project();
-        this.require
-            .poll(cx)
-            .map_ok(|c| c.allows_verification_method(*this.method_id, (*this.proof_purpose).into()))
-            .map(|result| match result {
-                Ok(true) => Ok(()),
-                Ok(false) => Err(VerificationError::InvalidKeyUse(*this.proof_purpose)),
-                Err(e) => Err(e.into()),
-            })
     }
 }
 

--- a/ssi-verification-methods/src/controller.rs
+++ b/ssi-verification-methods/src/controller.rs
@@ -34,6 +34,7 @@ pub trait ControllerProvider {
         Self: 'a;
 
     /// Returns the controller with the given identifier, if it can be found.
+    #[allow(async_fn_in_trait)]
     async fn get_controller<'a>(
         &'a self,
         id: &'a Iri,
@@ -41,6 +42,7 @@ pub trait ControllerProvider {
 
     /// Returns the controller with the given identifier, or fails if it cannot
     /// be found.
+    #[allow(async_fn_in_trait)]
     async fn require_controller<'a>(
         &'a self,
         id: &'a Iri,
@@ -52,6 +54,7 @@ pub trait ControllerProvider {
 
     /// Checks that the controller identified by `controller_id` allows the use
     /// of the verification method `method_id` with the given proof purposes.
+    #[allow(async_fn_in_trait)]
     async fn allows_verification_method<'a>(
         &'a self,
         controller_id: &'a Iri,
@@ -67,6 +70,7 @@ pub trait ControllerProvider {
     ///
     /// Contrarily to the [`allows_verification_method`] function, this function
     /// returns an error if one of the input proof purposes is not allowed.
+    #[allow(async_fn_in_trait)]
     async fn ensure_allows_verification_method<'a>(
         &'a self,
         controller_id: &'a Iri,

--- a/ssi-verification-methods/src/lib.rs
+++ b/ssi-verification-methods/src/lib.rs
@@ -161,6 +161,7 @@ pub enum VerificationMethodResolutionError {
 
 pub trait VerificationMethodResolver<M: Referencable> {
     /// Resolve the verification method reference.
+    #[allow(async_fn_in_trait)]
     async fn resolve_verification_method<'a, 'm: 'a>(
         &'a self,
         issuer: Option<&'a Iri>,
@@ -234,14 +235,13 @@ impl<'m, 's, M: 'm + Referencable, S> MethodWithSecret<'m, 's, M, S> {
 impl<'m, 's, A: Copy, P: SignatureProtocol<A>, M: 'm + Referencable + SigningMethod<S, A>, S>
     MessageSigner<A, P> for MethodWithSecret<'m, 's, M, S>
 {
-    async fn sign(self, algorithm: A, protocol: P, message: &[u8]) -> Result<Vec<u8>, MessageSignatureError> {
-        M::sign_ref(
-            self.method,
-            self.secret,
-            algorithm,
-            protocol,
-            message,
-        )
+    async fn sign(
+        self,
+        algorithm: A,
+        protocol: P,
+        message: &[u8],
+    ) -> Result<Vec<u8>, MessageSignatureError> {
+        M::sign_ref(self.method, self.secret, algorithm, protocol, message)
     }
 }
 

--- a/ssi-verification-methods/src/lib.rs
+++ b/ssi-verification-methods/src/lib.rs
@@ -11,7 +11,6 @@
 use iref::{Iri, IriBuf};
 use ssi_crypto::{MessageSignatureError, MessageSigner, SignatureProtocol};
 use static_iref::iri;
-use std::future::Future;
 
 mod controller;
 mod methods;
@@ -161,35 +160,23 @@ pub enum VerificationMethodResolutionError {
 }
 
 pub trait VerificationMethodResolver<M: Referencable> {
-    /// Future returned by the `resolve_verification_method` method.
-    type ResolveVerificationMethod<'a>: 'a
-        + Future<Output = Result<Cow<'a, M>, VerificationMethodResolutionError>>
-    where
-        Self: 'a,
-        M: 'a;
-
     /// Resolve the verification method reference.
-    fn resolve_verification_method<'a, 'm: 'a>(
+    async fn resolve_verification_method<'a, 'm: 'a>(
         &'a self,
         issuer: Option<&'a Iri>,
         method: Option<ReferenceOrOwnedRef<'m, M>>,
-    ) -> Self::ResolveVerificationMethod<'a>;
+    ) -> Result<Cow<'a, M>, VerificationMethodResolutionError>;
 }
 
 impl<'t, M: Referencable, T: VerificationMethodResolver<M>> VerificationMethodResolver<M>
     for &'t T
 {
-    type ResolveVerificationMethod<'a> = T::ResolveVerificationMethod<'a>
-    where
-        Self: 'a,
-        M: 'a;
-
-    fn resolve_verification_method<'a, 'm: 'a>(
+    async fn resolve_verification_method<'a, 'm: 'a>(
         &'a self,
         issuer: Option<&'a Iri>,
         method: Option<ReferenceOrOwnedRef<'m, M>>,
-    ) -> Self::ResolveVerificationMethod<'a> {
-        T::resolve_verification_method(self, issuer, method)
+    ) -> Result<Cow<'a, M>, VerificationMethodResolutionError> {
+        T::resolve_verification_method(self, issuer, method).await
     }
 }
 
@@ -247,24 +234,14 @@ impl<'m, 's, M: 'm + Referencable, S> MethodWithSecret<'m, 's, M, S> {
 impl<'m, 's, A: Copy, P: SignatureProtocol<A>, M: 'm + Referencable + SigningMethod<S, A>, S>
     MessageSigner<A, P> for MethodWithSecret<'m, 's, M, S>
 {
-    type Sign<'a> = std::future::Ready<Result<Vec<u8>, MessageSignatureError>> where
-    Self: 'a,
-    A: 'a,
-    P: 'a;
-
-    fn sign<'a>(self, algorithm: A, protocol: P, message: &'a [u8]) -> Self::Sign<'a>
-    where
-        Self: 'a,
-        A: 'a,
-        P: 'a,
-    {
-        std::future::ready(M::sign_ref(
+    async fn sign(self, algorithm: A, protocol: P, message: &[u8]) -> Result<Vec<u8>, MessageSignatureError> {
+        M::sign_ref(
             self.method,
             self.secret,
             algorithm,
             protocol,
             message,
-        ))
+        )
     }
 }
 

--- a/ssi-verification-methods/src/methods/unspecified/solana_method_2021.rs
+++ b/ssi-verification-methods/src/methods/unspecified/solana_method_2021.rs
@@ -116,18 +116,17 @@ impl TypedVerificationMethod for SolanaMethod2021 {
 impl TryFrom<GenericVerificationMethod> for SolanaMethod2021 {
     type Error = InvalidVerificationMethod;
 
-    fn try_from(m: GenericVerificationMethod) -> Result<Self, Self::Error> {
+    fn try_from(mut m: GenericVerificationMethod) -> Result<Self, Self::Error> {
         Ok(Self {
             id: m.id,
             controller: m.controller,
             public_key: Box::new(
-                m.properties
-                    .get("publicKeyJwk")
-                    .ok_or_else(|| InvalidVerificationMethod::missing_property("publicKeyJwk"))?
-                    .as_str()
-                    .ok_or_else(|| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?
-                    .parse()
-                    .map_err(|_| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?,
+                serde_json::from_value(
+                    m.properties.remove("publicKeyJwk").ok_or_else(|| {
+                        InvalidVerificationMethod::missing_property("publicKeyJwk")
+                    })?,
+                )
+                .map_err(|_| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?,
             ),
         })
     }

--- a/ssi-verification-methods/src/methods/unspecified/tezos/tezos_method_2021.rs
+++ b/ssi-verification-methods/src/methods/unspecified/tezos/tezos_method_2021.rs
@@ -122,12 +122,10 @@ impl PublicKey {
         properties: &BTreeMap<String, serde_json::Value>,
     ) -> Result<Self, InvalidVerificationMethod> {
         match properties.get("publicKeyJwk") {
-            Some(serde_json::Value::String(value)) => {
-                Ok(Self::Jwk(Box::new(value.parse().map_err(|_| {
-                    InvalidVerificationMethod::invalid_property("publicKeyJwk")
-                })?)))
-            }
-            Some(_) => Err(InvalidVerificationMethod::invalid_property("publicKeyJwk")),
+            Some(value) => Ok(Self::Jwk(Box::new(
+                serde_json::from_value(value.clone())
+                    .map_err(|_| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?,
+            ))),
             None => match properties.get("blockchainAccountId") {
                 Some(serde_json::Value::String(value)) => {
                     Ok(Self::BlockchainAccountId(value.parse().map_err(|_| {

--- a/ssi-verification-methods/src/methods/w3c/json_web_key_2020.rs
+++ b/ssi-verification-methods/src/methods/w3c/json_web_key_2020.rs
@@ -125,18 +125,17 @@ impl TypedVerificationMethod for JsonWebKey2020 {
 impl TryFrom<GenericVerificationMethod> for JsonWebKey2020 {
     type Error = InvalidVerificationMethod;
 
-    fn try_from(m: GenericVerificationMethod) -> Result<Self, Self::Error> {
+    fn try_from(mut m: GenericVerificationMethod) -> Result<Self, Self::Error> {
         Ok(Self {
             id: m.id,
             controller: m.controller,
             public_key: Box::new(
-                m.properties
-                    .get("publicKeyJwk")
-                    .ok_or_else(|| InvalidVerificationMethod::missing_property("publicKeyJwk"))?
-                    .as_str()
-                    .ok_or_else(|| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?
-                    .parse()
-                    .map_err(|_| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?,
+                serde_json::from_value(
+                    m.properties.remove("publicKeyJwk").ok_or_else(|| {
+                        InvalidVerificationMethod::missing_property("publicKeyJwk")
+                    })?,
+                )
+                .map_err(|_| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?,
             ),
         })
     }

--- a/ssi-verification-methods/src/methods/w3c/rsa_verification_key_2018.rs
+++ b/ssi-verification-methods/src/methods/w3c/rsa_verification_key_2018.rs
@@ -112,18 +112,17 @@ impl TypedVerificationMethod for RsaVerificationKey2018 {
 impl TryFrom<GenericVerificationMethod> for RsaVerificationKey2018 {
     type Error = InvalidVerificationMethod;
 
-    fn try_from(m: GenericVerificationMethod) -> Result<Self, Self::Error> {
+    fn try_from(mut m: GenericVerificationMethod) -> Result<Self, Self::Error> {
         Ok(Self {
             id: m.id,
             controller: m.controller,
             public_key: Box::new(
-                m.properties
-                    .get("publicKeyJwk")
-                    .ok_or_else(|| InvalidVerificationMethod::missing_property("publicKeyJwk"))?
-                    .as_str()
-                    .ok_or_else(|| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?
-                    .parse()
-                    .map_err(|_| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?,
+                serde_json::from_value(
+                    m.properties.remove("publicKeyJwk").ok_or_else(|| {
+                        InvalidVerificationMethod::missing_property("publicKeyJwk")
+                    })?,
+                )
+                .map_err(|_| InvalidVerificationMethod::invalid_property("publicKeyJwk"))?,
             ),
         })
     }

--- a/ssi-verification-methods/src/signature.rs
+++ b/ssi-verification-methods/src/signature.rs
@@ -1,4 +1,3 @@
-use futures::Future;
 use ssi_crypto::MessageSigner;
 
 use crate::{
@@ -84,6 +83,7 @@ pub trait SignatureAlgorithm<M: ?Sized + Referencable> {
     /// Signature protocol.
     type Protocol: ssi_crypto::SignatureProtocol<Self::MessageSignatureAlgorithm>;
 
+    #[allow(async_fn_in_trait)]
     async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
         options: <Self::Options as Referencable>::Reference<'_>,

--- a/ssi-verification-methods/src/signature.rs
+++ b/ssi-verification-methods/src/signature.rs
@@ -84,17 +84,13 @@ pub trait SignatureAlgorithm<M: ?Sized + Referencable> {
     /// Signature protocol.
     type Protocol: ssi_crypto::SignatureProtocol<Self::MessageSignatureAlgorithm>;
 
-    /// Future returned by the `sign` method.
-    type Sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>: 'a
-        + Future<Output = Result<Self::Signature, SignatureError>>;
-
-    fn sign<'a, S: 'a + MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
+    async fn sign<S: MessageSigner<Self::MessageSignatureAlgorithm, Self::Protocol>>(
         &self,
-        options: <Self::Options as Referencable>::Reference<'a>,
+        options: <Self::Options as Referencable>::Reference<'_>,
         method: M::Reference<'_>,
-        bytes: &'a [u8],
+        bytes: &[u8],
         signer: S,
-    ) -> Self::Sign<'a, S>;
+    ) -> Result<Self::Signature, SignatureError>;
 
     fn verify<'o, 's, 'm>(
         &self,

--- a/ssi-verification-methods/src/signature/signer.rs
+++ b/ssi-verification-methods/src/signature/signer.rs
@@ -11,14 +11,7 @@ use crate::{Referencable, ReferenceOrOwnedRef, SignatureAlgorithm, SignatureErro
 /// `B` is the cryptographic signature algorithm to be used with the verification method.
 /// `P` is the signature protocol.
 pub trait Signer<M: Referencable, B, P> {
-    // type Sign<'a, A: SignatureAlgorithm<M, MessageSignatureAlgorithm = B, Protocol = P>>: 'a
-    //     + Future<Output = Result<A::Signature, SignatureError>>
-    // where
-    //     Self: 'a,
-    //     M: 'a,
-    //     A: 'a,
-    //     A::Signature: 'a;
-
+    #[allow(async_fn_in_trait)]
     async fn sign<
         'a,
         'o: 'a,

--- a/ssi-verification-methods/src/signature/signer.rs
+++ b/ssi-verification-methods/src/signature/signer.rs
@@ -1,6 +1,4 @@
 use iref::Iri;
-use std::future::Future;
-
 pub mod single_secret;
 
 pub use single_secret::SingleSecretSigner;
@@ -13,15 +11,15 @@ use crate::{Referencable, ReferenceOrOwnedRef, SignatureAlgorithm, SignatureErro
 /// `B` is the cryptographic signature algorithm to be used with the verification method.
 /// `P` is the signature protocol.
 pub trait Signer<M: Referencable, B, P> {
-    type Sign<'a, A: SignatureAlgorithm<M, MessageSignatureAlgorithm = B, Protocol = P>>: 'a
-        + Future<Output = Result<A::Signature, SignatureError>>
-    where
-        Self: 'a,
-        M: 'a,
-        A: 'a,
-        A::Signature: 'a;
+    // type Sign<'a, A: SignatureAlgorithm<M, MessageSignatureAlgorithm = B, Protocol = P>>: 'a
+    //     + Future<Output = Result<A::Signature, SignatureError>>
+    // where
+    //     Self: 'a,
+    //     M: 'a,
+    //     A: 'a,
+    //     A::Signature: 'a;
 
-    fn sign<
+    async fn sign<
         'a,
         'o: 'a,
         'm: 'a,
@@ -33,7 +31,7 @@ pub trait Signer<M: Referencable, B, P> {
         issuer: Option<&'a Iri>,
         method: Option<ReferenceOrOwnedRef<'m, M>>,
         bytes: &'a [u8],
-    ) -> Self::Sign<'a, A>
+    ) -> Result<A::Signature, SignatureError>
     where
         A: 'a,
         A::Signature: 'a;

--- a/ssi-verification-methods/src/verification/verifier.rs
+++ b/ssi-verification-methods/src/verification/verifier.rs
@@ -8,6 +8,7 @@ use iref::Iri;
 pub trait Verifier<M: Referencable>: VerificationMethodResolver<M> + ControllerProvider {
     /// Verify the given `signature`, signed using the given `algorithm`,
     /// against the input `signing`.
+    #[allow(async_fn_in_trait)]
     async fn verify<'f, 'o: 'f, 'm: 'f, 's: 'f, A: SignatureAlgorithm<M>>(
         &'f self,
         algorithm: A,

--- a/ssi-verification-methods/src/verification/verifier.rs
+++ b/ssi-verification-methods/src/verification/verifier.rs
@@ -1,18 +1,14 @@
 use crate::{
-    ControllerProvider, Cow, EnsureAllowsVerificationMethod, ProofPurpose, Referencable,
-    ReferenceOrOwnedRef, SignatureAlgorithm, VerificationError, VerificationMethod,
-    VerificationMethodResolver,
+    ControllerProvider, ProofPurpose, Referencable, ReferenceOrOwnedRef, SignatureAlgorithm,
+    VerificationError, VerificationMethod, VerificationMethodResolver,
 };
 use iref::Iri;
-use pin_project::pin_project;
-use ssi_core::futures::{RefFutureBinder, SelfRefFuture, UnboundedRefFuture};
-use std::{future::Future, marker::PhantomData, pin::Pin, task};
 
 /// Verifier.
 pub trait Verifier<M: Referencable>: VerificationMethodResolver<M> + ControllerProvider {
     /// Verify the given `signature`, signed using the given `algorithm`,
     /// against the input `signing`.
-    fn verify<'f, 'o: 'f, 'm: 'f, 's: 'f, A: SignatureAlgorithm<M>>(
+    async fn verify<'f, 'o: 'f, 'm: 'f, 's: 'f, A: SignatureAlgorithm<M>>(
         &'f self,
         algorithm: A,
         options: <A::Options as Referencable>::Reference<'o>,
@@ -21,148 +17,144 @@ pub trait Verifier<M: Referencable>: VerificationMethodResolver<M> + ControllerP
         proof_purpose: ProofPurpose,
         signing_bytes: &'f [u8],
         signature: <A::Signature as Referencable>::Reference<'s>,
-    ) -> Verify<'f, M, Self, A>
+    ) -> Result<bool, VerificationError>
     where
-        M: 'f + Referencable,
+        M: 'f + VerificationMethod,
     {
-        let resolution = self.resolve_verification_method(issuer, method_reference);
-
-        Verify {
-            verifier: self,
-            options: <A::Options as Referencable>::apply_covariance(options),
-            proof_purpose,
-            data: Some(VerifyData {
-                algorithm,
-                signature: <A::Signature as Referencable>::apply_covariance(signature),
-                signing_bytes,
-            }),
-            resolution,
-            check_purpose: None,
+        let method = self
+            .resolve_verification_method(issuer, method_reference)
+            .await?;
+        if let Some(controller_id) = method.controller() {
+            self.ensure_allows_verification_method(controller_id, method.id(), proof_purpose)
+                .await?;
         }
+        algorithm.verify(options, signature, method.as_reference(), signing_bytes)
     }
 }
 
-#[pin_project]
-pub struct Verify<'f, M: 'f + Referencable, V: 'f + ?Sized + Verifier<M>, A: SignatureAlgorithm<M>>
-where
-    A::Options: 'f,
-{
-    verifier: &'f V,
+impl<M: Referencable, T: VerificationMethodResolver<M> + ControllerProvider> Verifier<M> for T {}
 
-    options: <A::Options as Referencable>::Reference<'f>,
+// #[pin_project]
+// pub struct Verify<'f, M: 'f + Referencable, V: 'f + ?Sized + Verifier<M>, A: SignatureAlgorithm<M>>
+// where
+//     A::Options: 'f,
+// {
+//     verifier: &'f V,
 
-    proof_purpose: ProofPurpose,
+//     options: <A::Options as Referencable>::Reference<'f>,
 
-    data: Option<VerifyData<'f, A, A::Signature>>,
+//     proof_purpose: ProofPurpose,
 
-    #[pin]
-    resolution: V::ResolveVerificationMethod<'f>,
+//     data: Option<VerifyData<'f, A, A::Signature>>,
 
-    #[pin]
-    check_purpose: Option<SelfRefFuture<'f, UnboundedVerifyProofPurpose<M, V>>>,
-}
+//     #[pin]
+//     resolution: V::ResolveVerificationMethod<'f>,
 
-struct UnboundedVerifyProofPurpose<M, C: ?Sized>(PhantomData<(M, C)>);
+//     #[pin]
+//     check_purpose: Option<SelfRefFuture<'f, UnboundedVerifyProofPurpose<M, V>>>,
+// }
 
-impl<'max, M: 'max + Referencable, C: 'max + ?Sized + ControllerProvider> UnboundedRefFuture<'max>
-    for UnboundedVerifyProofPurpose<M, C>
-{
-    type Bound<'a> = VerifyProofPurpose<'a, M, C> where 'max: 'a;
+// struct UnboundedVerifyProofPurpose<M, C: ?Sized>(PhantomData<(M, C)>);
 
-    type Owned = Cow<'max, M>;
+// impl<'max, M: 'max + Referencable, C: 'max + ?Sized + ControllerProvider> UnboundedRefFuture<'max>
+//     for UnboundedVerifyProofPurpose<M, C>
+// {
+//     type Bound<'a> = VerifyProofPurpose<'a, M, C> where 'max: 'a;
 
-    type Output = Result<(), VerificationError>;
-}
+//     type Owned = Cow<'max, M>;
 
-struct SetupVerifyProofPurpose<'a, V: ?Sized> {
-    verifier: &'a V,
-    proof_purpose: ProofPurpose,
-}
+//     type Output = Result<(), VerificationError>;
+// }
 
-impl<'max, M: 'max + Referencable, C: 'max + ?Sized + ControllerProvider>
-    RefFutureBinder<'max, UnboundedVerifyProofPurpose<M, C>> for SetupVerifyProofPurpose<'max, C>
-where
-    M: VerificationMethod,
-{
-    fn bind<'a>(context: Self, method: &'a Cow<'max, M>) -> VerifyProofPurpose<'a, M, C>
-    where
-        'max: 'a,
-    {
-        match method.controller() {
-            Some(controller_id) => {
-                VerifyProofPurpose::Pending(context.verifier.ensure_allows_verification_method(
-                    controller_id,
-                    method.id(),
-                    context.proof_purpose,
-                ))
-            }
-            None => VerifyProofPurpose::Ok(PhantomData),
-        }
-    }
-}
+// struct SetupVerifyProofPurpose<'a, V: ?Sized> {
+//     verifier: &'a V,
+//     proof_purpose: ProofPurpose,
+// }
 
-struct VerifyData<'f, A, S: 'f + Referencable> {
-    algorithm: A,
+// impl<'max, M: 'max + Referencable, C: 'max + ?Sized + ControllerProvider>
+//     RefFutureBinder<'max, UnboundedVerifyProofPurpose<M, C>> for SetupVerifyProofPurpose<'max, C>
+// where
+//     M: VerificationMethod,
+// {
+//     fn bind<'a>(context: Self, method: &'a Cow<'max, M>) -> VerifyProofPurpose<'a, M, C>
+//     where
+//         'max: 'a,
+//     {
+//         match method.controller() {
+//             Some(controller_id) => {
+//                 VerifyProofPurpose::Pending(context.verifier.ensure_allows_verification_method(
+//                     controller_id,
+//                     method.id(),
+//                     context.proof_purpose,
+//                 ))
+//             }
+//             None => VerifyProofPurpose::Ok(PhantomData),
+//         }
+//     }
+// }
 
-    signature: S::Reference<'f>,
+// struct VerifyData<'f, A, S: 'f + Referencable> {
+//     algorithm: A,
 
-    signing_bytes: &'f [u8],
-}
+//     signature: S::Reference<'f>,
 
-#[pin_project(project = VerifyProofPurposeProj)]
-enum VerifyProofPurpose<'a, M: 'a + Referencable, V: 'a + ?Sized + ControllerProvider> {
-    Ok(PhantomData<M>),
-    Pending(#[pin] EnsureAllowsVerificationMethod<'a, V>),
-}
+//     signing_bytes: &'f [u8],
+// }
 
-impl<'a, M: 'a + Referencable, V: 'a + ?Sized + ControllerProvider> Future
-    for VerifyProofPurpose<'a, M, V>
-{
-    type Output = Result<(), VerificationError>;
+// #[pin_project(project = VerifyProofPurposeProj)]
+// enum VerifyProofPurpose<'a, M: 'a + Referencable, V: 'a + ?Sized + ControllerProvider> {
+//     Ok(PhantomData<M>),
+//     Pending(#[pin] EnsureAllowsVerificationMethod<'a, V>),
+// }
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        match self.project() {
-            VerifyProofPurposeProj::Ok(_) => task::Poll::Ready(Ok(())),
-            VerifyProofPurposeProj::Pending(f) => f.poll(cx),
-        }
-    }
-}
+// impl<'a, M: 'a + Referencable, V: 'a + ?Sized + ControllerProvider> Future
+//     for VerifyProofPurpose<'a, M, V>
+// {
+//     type Output = Result<(), VerificationError>;
 
-impl<'f, M: 'f + Referencable, V: 'f + ?Sized + Verifier<M>, A: SignatureAlgorithm<M>> Future
-    for Verify<'f, M, V, A>
-where
-    M: VerificationMethod,
-{
-    type Output = Result<bool, VerificationError>;
+//     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+//         match self.project() {
+//             VerifyProofPurposeProj::Ok(_) => task::Poll::Ready(Ok(())),
+//             VerifyProofPurposeProj::Pending(f) => f.poll(cx),
+//         }
+//     }
+// }
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let mut this = self.project();
+// impl<'f, M: 'f + Referencable, V: 'f + ?Sized + Verifier<M>, A: SignatureAlgorithm<M>> Future
+//     for Verify<'f, M, V, A>
+// where
+//     M: VerificationMethod,
+// {
+//     type Output = Result<bool, VerificationError>;
 
-        if this.check_purpose.is_none() {
-            match this.resolution.poll(cx) {
-                task::Poll::Pending => return task::Poll::Pending,
-                task::Poll::Ready(Ok(method)) => this.check_purpose.set(Some(SelfRefFuture::new(
-                    method,
-                    SetupVerifyProofPurpose {
-                        verifier: *this.verifier,
-                        proof_purpose: *this.proof_purpose,
-                    },
-                ))),
-                task::Poll::Ready(Err(e)) => return task::Poll::Ready(Err(e.into())),
-            }
-        }
+//     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+//         let mut this = self.project();
 
-        let check_purpose = this.check_purpose.as_pin_mut().unwrap();
-        check_purpose.poll(cx).map(|(check_result, method)| {
-            check_result.and_then(|()| {
-                let data = this.data.take().unwrap();
-                data.algorithm.verify(
-                    *this.options,
-                    data.signature,
-                    method.as_reference(),
-                    data.signing_bytes,
-                )
-            })
-        })
-    }
-}
+//         if this.check_purpose.is_none() {
+//             match this.resolution.poll(cx) {
+//                 task::Poll::Pending => return task::Poll::Pending,
+//                 task::Poll::Ready(Ok(method)) => this.check_purpose.set(Some(SelfRefFuture::new(
+//                     method,
+//                     SetupVerifyProofPurpose {
+//                         verifier: *this.verifier,
+//                         proof_purpose: *this.proof_purpose,
+//                     },
+//                 ))),
+//                 task::Poll::Ready(Err(e)) => return task::Poll::Ready(Err(e.into())),
+//             }
+//         }
+
+//         let check_purpose = this.check_purpose.as_pin_mut().unwrap();
+//         check_purpose.poll(cx).map(|(check_result, method)| {
+//             check_result.and_then(|()| {
+//                 let data = this.data.take().unwrap();
+//                 data.algorithm.verify(
+//                     *this.options,
+//                     data.signature,
+//                     method.as_reference(),
+//                     data.signing_bytes,
+//                 )
+//             })
+//         })
+//     }
+// }


### PR DESCRIPTION
This PR brings the `did-key` library up to date with the new `ssi` API. During this update I notices a few issues with the previous ssi implementation that have been fixed with the refactor:
  - Whenever a DID document generated with the `did:key` method contains a verification method of type `Ed25519VerificationKey2018`, the public key in the verification method is provided by the wrong attribute: `publicKeyJwk` instead of `publicKeyBase58`.
  - Similarly, `EcdsaSecp256r1VerificationKey2019` methods are generated with the `publicKeyJwk` attribute instead of `publicKeyMultibase`.
  - The  proof value generated by the `EcdsaSecp256r1Signature2019` cryptosuite is provided by the wrong attribute in the proof object: `jws` instead of `proofValue`. This is a more serious issue because fixing it means no loosing backward compatibility with VCs signed with the old faulty implementation of this cryptosuite.
 
## Bonus: removing ugly associated future types

While refactoring, I initially added some associated types in the new traits meant to represent the future of async functions in traits. Something like that:
```
trait MessageSigner {
  type Sign: Future<Output = Signature>;

  // this function is async.
  fn sign(&self, message: &[u8]) -> Self::Sign;
}
```

This was required because until version 1.75, rust did not support "real" async functions in traits (there was some possible workaround with the `async_trait` crate, but not offering enough flexibility). Now that version 1.75 is stable, I've been able to remove all the associated future types (and their often ugly implementations). The example above is reduced to:
```
trait MessageSigner {
  async fn sign(&self, message: &[u8]) -> Signature;
}
```