### PR TITLE
Refactor `web` DID method implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ members = [
   "did-tezos",
   "did-jwk",
   "did-key",
-  # "did-web",
+  "did-web",
   # "did-ethr",
   # "did-sol",
   "did-pkh",

--- a/did-key/Cargo.toml
+++ b/did-key/Cargo.toml
@@ -34,25 +34,15 @@ static-iref.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
 simple_asn1 = "^0.5.2"
-# ssi-jwk = { path = "../ssi-jwk", version = "0.1", default-features = false, features = ["ripemd-160"] }
-# ssi-crypto = { path = "../ssi-crypto", default-features = false, version = "0.1"}
-# async-trait = "0.1"
-# thiserror = "1.0"
-# multibase = "0.8"
 k256 = { version = "0.11", optional = true, features = ["ecdsa"] }
 p256 = { version = "0.11", optional = true, features = ["ecdsa"] }
-# serde_json = "1.0"
-# simple_asn1 = "^0.5.2"
 
 [dev-dependencies]
 ssi-top.workspace = true
-# ssi-vc = { path = "../ssi-vc" }
 ssi-vc-ldp.workspace = true
-# ssi-json-ld = { path = "../ssi-json-ld" }
 xsd-types.workspace = true
 linked-data.workspace = true
 serde = { workspace = true, features = ["derive"] }
 async-std = { version = "1.9", features = ["attributes"] }
-# serde_json = "1.0"
 rand_chacha.workspace = true
 rand_chacha_old = { package = "rand_chacha", version = "0.2" }

--- a/did-web/Cargo.toml
+++ b/did-web/Cargo.toml
@@ -12,23 +12,25 @@ homepage = "https://github.com/spruceid/ssi/tree/main/did-web/"
 documentation = "https://docs.rs/did-web/"
 
 [dependencies]
-ssi-dids = { path = "../ssi-dids", version = "0.1" }
-async-trait = "0.1"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+ssi-dids.workspace = true
+thiserror.workspace = true
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 http = "0.2"
-serde_json = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
 version = "0.11"
-features = ["json", "native-tls-vendored"]
+features = ["native-tls-vendored"]
 
 [dev-dependencies]
-ssi-jwk = { path = "../ssi-jwk", default-features = false }
-ssi-ldp = { path = "../ssi-ldp" }
-ssi-vc = { path = "../ssi-vc" }
-ssi-json-ld = { path = "../ssi-json-ld", default-features = false }
+ssi-top.workspace = true
+ssi-vc-ldp.workspace = true
+ssi-jwk.workspace = true
+linked-data.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+iref.workspace = true
+static-iref.workspace = true
+xsd-types.workspace = true
 tokio = { version = "1.0", features = ["macros"] }
-serde = { version = "1.0", features = ["derive"] }
-async-std = { version = "1.9", features = ["attributes"] }
 futures = "0.3"
 hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }

--- a/did-web/src/lib.rs
+++ b/did-web/src/lib.rs
@@ -1,18 +1,33 @@
-use async_trait::async_trait;
-
-use ssi_dids::did_resolve::{
-    DIDResolver, DocumentMetadata, ResolutionInputMetadata, ResolutionMetadata, ERROR_INVALID_DID,
-    ERROR_NOT_FOUND, TYPE_DID_LD_JSON,
+use http::header;
+use ssi_dids::{
+    document::representation::MediaType,
+    resolution::{self, DIDMethodResolver, Error, Output},
 };
-use ssi_dids::{DIDMethod, Document};
+
 pub const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 // For testing, enable handling requests at localhost.
 #[cfg(test)]
 use std::cell::RefCell;
+
 #[cfg(test)]
 thread_local! {
   static PROXY: RefCell<Option<String>> = RefCell::new(None);
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InternalError {
+    #[error("Error building HTTP client: {0}")]
+    Client(reqwest::Error),
+
+    #[error("Error sending HTTP request ({0}): {1}")]
+    Request(String, reqwest::Error),
+
+    #[error("Server error: {0}")]
+    Server(String),
+
+    #[error("Error reading HTTP response: {0}")]
+    Response(reqwest::Error),
 }
 
 /// did:web Method
@@ -20,14 +35,12 @@ thread_local! {
 /// [Specification](https://w3c-ccg.github.io/did-method-web/)
 pub struct DIDWeb;
 
-fn did_web_url(did: &str) -> Result<String, ResolutionMetadata> {
-    let mut parts = did.split(':').peekable();
-    let domain_name = match (parts.next(), parts.next(), parts.next()) {
-        (Some("did"), Some("web"), Some(domain_name)) => domain_name,
-        _ => {
-            return Err(ResolutionMetadata::from_error(ERROR_INVALID_DID));
-        }
-    };
+fn did_web_url(id: &str) -> Result<String, Error> {
+    let mut parts = id.split(':').peekable();
+    let domain_name = parts
+        .next()
+        .ok_or_else(|| Error::InvalidMethodSpecificId(id.to_owned()))?;
+
     // TODO:
     // - Validate domain name: alphanumeric, hyphen, dot. no IP address.
     // - Ensure domain name matches TLS certificate common name
@@ -37,74 +50,44 @@ fn did_web_url(did: &str) -> Result<String, ResolutionMetadata> {
         Some(_) => parts.collect::<Vec<&str>>().join("/"),
         None => ".well-known".to_string(),
     };
+
     // Use http for localhost, for testing purposes.
     let proto = if domain_name.starts_with("localhost") {
         "http"
     } else {
         "https"
     };
+
     #[allow(unused_mut)]
     let mut url = format!(
-        "{}://{}/{}/did.json",
-        proto,
-        domain_name.replacen("%3A", ":", 1),
-        path
+        "{proto}://{}/{path}/did.json",
+        domain_name.replacen("%3A", ":", 1)
     );
+
     #[cfg(test)]
     PROXY.with(|proxy| {
         if let Some(ref proxy) = *proxy.borrow() {
             url = proxy.clone() + &url;
         }
     });
+
     Ok(url)
 }
 
 /// <https://w3c-ccg.github.io/did-method-web/#read-resolve>
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl DIDResolver for DIDWeb {
-    async fn resolve(
-        &self,
-        did: &str,
-        input_metadata: &ResolutionInputMetadata,
-    ) -> (
-        ResolutionMetadata,
-        Option<Document>,
-        Option<DocumentMetadata>,
-    ) {
-        let (mut res_meta, doc_data, doc_meta_opt) =
-            self.resolve_representation(did, input_metadata).await;
-        let doc_opt = if doc_data.is_empty() {
-            None
-        } else {
-            match serde_json::from_slice(&doc_data) {
-                Ok(doc) => doc,
-                Err(err) => {
-                    return (
-                        ResolutionMetadata::from_error(
-                            &("JSON Error: ".to_string() + &err.to_string()),
-                        ),
-                        None,
-                        None,
-                    )
-                }
-            }
-        };
-        // https://www.w3.org/TR/did-core/#did-resolution-metadata
-        // contentType - "MUST NOT be present if the resolve function was called"
-        res_meta.content_type = None;
-        (res_meta, doc_opt, doc_meta_opt)
+impl DIDMethodResolver for DIDWeb {
+    fn method_name(&self) -> &str {
+        "web"
     }
 
-    async fn resolve_representation(
-        &self,
-        did: &str,
-        input_metadata: &ResolutionInputMetadata,
-    ) -> (ResolutionMetadata, Vec<u8>, Option<DocumentMetadata>) {
-        let url = match did_web_url(did) {
-            Err(meta) => return (meta, Vec::new(), None),
-            Ok(url) => url,
-        };
+    async fn resolve_method_representation<'a>(
+        &'a self,
+        method_specific_id: &'a str,
+        options: resolution::Options,
+    ) -> Result<Output<Vec<u8>>, Error> {
+        // let did = DIDBuf::new(format!("did:web:{method_specific_id}")).unwrap();
+
+        let url = did_web_url(method_specific_id)?;
         // TODO: https://w3c-ccg.github.io/did-method-web/#in-transit-security
 
         let mut headers = reqwest::header::HeaderMap::new();
@@ -114,106 +97,76 @@ impl DIDResolver for DIDWeb {
             reqwest::header::HeaderValue::from_static(USER_AGENT),
         );
 
-        let client = match reqwest::Client::builder().default_headers(headers).build() {
-            Ok(c) => c,
-            Err(err) => {
-                return (
-                    ResolutionMetadata::from_error(&format!("Error building HTTP client: {}", err)),
-                    Vec::new(),
-                    None,
-                )
-            }
-        };
-        let accept = input_metadata
-            .accept
-            .clone()
-            .unwrap_or_else(|| "application/json".to_string());
-        let resp = match client.get(&url).header("Accept", accept).send().await {
-            Ok(req) => req,
-            Err(err) => {
-                return (
-                    ResolutionMetadata::from_error(&format!(
-                        "Error sending HTTP request ({}): {}",
-                        url, err
-                    )),
-                    Vec::new(),
-                    None,
-                )
-            }
-        };
-        if let Err(err) = resp.error_for_status_ref() {
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .map_err(|e| Error::internal(InternalError::Client(e)))?;
+
+        let accept = options.accept.clone().unwrap_or(MediaType::Json);
+
+        let resp = client
+            .get(&url)
+            .header(header::ACCEPT, accept.to_string())
+            .send()
+            .await
+            .map_err(|e| Error::internal(InternalError::Request(url.to_owned(), e)))?;
+
+        resp.error_for_status_ref().map_err(|err| {
             if err.status() == Some(reqwest::StatusCode::NOT_FOUND) {
-                return (
-                    ResolutionMetadata::from_error(ERROR_NOT_FOUND),
-                    Vec::new(),
-                    Some(DocumentMetadata::default()),
-                );
+                Error::NotFound
+            } else {
+                Error::internal(InternalError::Server(err.to_string()))
             }
-            return (
-                ResolutionMetadata::from_error(&err.to_string()),
-                Vec::new(),
-                Some(DocumentMetadata::default()),
-            );
-        }
-        let doc_representation = match resp.bytes().await {
-            Ok(bytes) => bytes.to_vec(),
-            Err(err) => {
-                return (
-                    ResolutionMetadata::from_error(
-                        &("Error reading HTTP response: ".to_string() + &err.to_string()),
-                    ),
-                    Vec::new(),
-                    None,
-                )
-            }
-        };
+        })?;
+
+        let document = resp
+            .bytes()
+            .await
+            .map_err(|e| Error::internal(InternalError::Response(e)))?;
+
         // TODO: set document created/updated metadata from HTTP headers?
-        (
-            ResolutionMetadata {
-                error: None,
-                content_type: Some(TYPE_DID_LD_JSON.to_string()),
-                property_set: None,
-            },
-            doc_representation,
-            Some(DocumentMetadata::default()),
-        )
-    }
-}
-
-impl DIDMethod for DIDWeb {
-    fn name(&self) -> &'static str {
-        "web"
-    }
-
-    fn to_resolver(&self) -> &dyn DIDResolver {
-        self
+        Ok(Output {
+            document: document.into(),
+            document_metadata: ssi_dids::document::Metadata::default(),
+            metadata: resolution::Metadata::from_content_type(Some(MediaType::JsonLd.to_string())),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use iref::IriBuf;
+    use ssi_dids::{did, DIDResolver, DIDVerifier, Document};
+    use ssi_jwk::JWK;
+    use ssi_top::data_integrity::{AnyInputContext, AnySuite};
+    use ssi_vc_ldp::{
+        verification::method::{signer::SingleSecretSigner, ProofPurpose},
+        CryptographicSuiteInput, ProofConfiguration,
+    };
+    use static_iref::iri;
+
     use super::*;
 
-    #[async_std::test]
+    #[tokio::test]
     async fn parse_did_web() {
         // https://w3c-ccg.github.io/did-method-web/#example-3-creating-the-did
         assert_eq!(
-            did_web_url("did:web:w3c-ccg.github.io").unwrap(),
+            did_web_url(did!("did:web:w3c-ccg.github.io").method_specific_id()).unwrap(),
             "https://w3c-ccg.github.io/.well-known/did.json"
         );
         // https://w3c-ccg.github.io/did-method-web/#example-4-creating-the-did-with-optional-path
         assert_eq!(
-            did_web_url("did:web:w3c-ccg.github.io:user:alice").unwrap(),
+            did_web_url(did!("did:web:w3c-ccg.github.io:user:alice").method_specific_id()).unwrap(),
             "https://w3c-ccg.github.io/user/alice/did.json"
         );
         // https://w3c-ccg.github.io/did-method-web/#optional-path-considerations
         assert_eq!(
-            did_web_url("did:web:example.com:u:bob").unwrap(),
+            did_web_url(did!("did:web:example.com:u:bob").method_specific_id()).unwrap(),
             "https://example.com/u/bob/did.json"
         );
         // https://w3c-ccg.github.io/did-method-web/#example-creating-the-did-with-optional-path-and-port
         assert_eq!(
-            did_web_url("did:web:example.com%3A443:u:bob").unwrap(),
+            did_web_url(did!("did:web:example.com%3A443:u:bob").method_specific_id()).unwrap(),
             "https://example.com:443/u/bob/did.json"
         );
     }
@@ -226,12 +179,7 @@ mod tests {
          "id": "did:web:localhost#key1",
          "type": "Ed25519VerificationKey2018",
          "controller": "did:web:localhost",
-         "publicKeyJwk": {
-           "key_id": "ed25519-2020-10-18",
-           "kty": "OKP",
-           "crv": "Ed25519",
-           "x": "G80iskrv_nE69qbGLSpeOHJgmV4MKIzsy5l5iT6pCww"
-         }
+         "publicKeyBase58": "2sXRz2VfrpySNEL6xmXJWQg6iY94qwNp1qrJJFBuPWmH"
       }],
       "assertionMethod": ["did:web:localhost#key1"]
     }"#;
@@ -282,62 +230,97 @@ mod tests {
         PROXY.with(|proxy| {
             proxy.replace(Some(url));
         });
-        let (res_meta, doc_opt, _doc_meta) = DIDWeb
-            .resolve("did:web:localhost", &ResolutionInputMetadata::default())
-            .await;
-        assert_eq!(res_meta.error, None);
-        let doc_expected: Document = serde_json::from_str(DID_JSON).unwrap();
-        assert_eq!(doc_opt, Some(doc_expected));
+        let doc = DIDWeb.resolve(did!("did:web:localhost")).await.unwrap();
+        let doc_expected = Document::from_bytes(MediaType::JsonLd, DID_JSON.as_bytes()).unwrap();
+        assert_eq!(doc.document.document(), doc_expected.document());
         PROXY.with(|proxy| {
             proxy.replace(None);
         });
         shutdown().ok();
     }
 
+    #[derive(Clone, serde::Serialize, linked_data::Serialize)]
+    #[ld(prefix("cred" = "https://www.w3.org/2018/credentials#"))]
+    #[ld(type = "cred:VerifiableCredential")]
+    #[serde(rename_all = "camelCase")]
+    struct TestCredential {
+        #[ld("cred:issuer")]
+        issuer: IriBuf,
+
+        #[ld("cred:issuanceDate")]
+        issuance_date: xsd_types::DateTime,
+
+        #[ld("cred:credentialSubject")]
+        credential_subject: CredentialSubject,
+    }
+
+    #[derive(Clone, serde::Serialize, linked_data::Serialize)]
+    struct CredentialSubject {
+        #[ld(id)]
+        id: IriBuf,
+    }
+
     #[tokio::test]
     async fn credential_prove_verify_did_web() {
-        use ssi_jwk::JWK;
-        use ssi_ldp::LinkedDataProofOptions;
-        use ssi_vc::{Credential, Issuer, URI};
-        let vc_str = r###"{
-            "@context": "https://www.w3.org/2018/credentials/v1",
-            "type": ["VerifiableCredential"],
-            "issuer": "did:web:localhost",
-            "issuanceDate": "2021-01-26T16:57:27Z",
-            "credentialSubject": {
-                "id": "did:web:localhost"
-            }
-        }"###;
+        let didweb = DIDVerifier::new(DIDWeb);
+
         let (url, shutdown) = web_server().unwrap();
         PROXY.with(|proxy| {
             proxy.replace(Some(url));
         });
-        let mut vc: Credential = Credential::from_json_unsigned(vc_str).unwrap();
-        let key_str = include_str!("../../tests/ed25519-2020-10-18.json");
-        let key: JWK = serde_json::from_str(key_str).unwrap();
-        let issue_options = LinkedDataProofOptions {
-            verification_method: Some(URI::String("did:web:localhost#key1".to_string())),
-            ..Default::default()
+
+        let cred = TestCredential {
+            issuer: did!("did:web:localhost").to_owned().into(),
+            issuance_date: "2021-01-26T16:57:27Z".parse().unwrap(),
+            credential_subject: CredentialSubject {
+                id: did!("did:web:localhost").to_owned().into(),
+            },
         };
-        let mut context_loader = ssi_json_ld::ContextLoader::default();
-        let proof = vc
-            .generate_proof(&key, &issue_options, &DIDWeb, &mut context_loader)
+
+        let key: JWK = include_str!("../../tests/ed25519-2020-10-18.json")
+            .parse()
+            .unwrap();
+        let verification_method = iri!("did:web:localhost#key1").to_owned().into();
+        let suite = AnySuite::pick(&key, Some(&verification_method)).unwrap();
+        let issue_options = ProofConfiguration {
+            created: "2021-01-26T16:57:27Z".parse().unwrap(),
+            verification_method,
+            proof_purpose: ProofPurpose::Assertion,
+            options: Default::default(),
+        };
+        let signer = SingleSecretSigner::new(&didweb, key);
+        let vc = suite
+            .sign(cred, AnyInputContext::default(), &signer, issue_options)
             .await
             .unwrap();
-        println!("{}", serde_json::to_string_pretty(&proof).unwrap());
-        vc.add_proof(proof);
-        vc.validate().unwrap();
-        let verification_result = vc.verify(None, &DIDWeb, &mut context_loader).await;
-        println!("{:#?}", verification_result);
-        assert!(verification_result.errors.is_empty());
+
+        println!(
+            "proof: {}",
+            serde_json::to_string_pretty(vc.proof()).unwrap()
+        );
+        assert_eq!(vc.proof().signature().jws.as_ref().unwrap().as_str(), "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..BCvVb4jz-yVaTeoP24Wz0cOtiHKXCdPcmFQD_pxgsMU6aCAj1AIu3cqHyoViU93nPmzqMLswOAqZUlMyVnmzDw");
+        assert!(vc.verify(&didweb).await.unwrap().is_valid());
 
         // test that issuer property is used for verification
-        vc.issuer = Some(Issuer::URI(URI::String("did:example:bad".to_string())));
-        assert!(!vc
-            .verify(None, &DIDWeb, &mut context_loader)
+        let vc_bad_issuer = vc
+            .clone()
+            .async_try_map(|di, proof| async {
+                di.map(
+                    AnyInputContext::default(),
+                    proof.suite(),
+                    proof.configuration(),
+                    |mut cred| {
+                        cred.issuer = iri!("did:pkh:example:bad").to_owned();
+                        cred
+                    },
+                )
+                .await
+                .map(|di| (di, proof))
+            })
             .await
-            .errors
-            .is_empty());
+            .unwrap();
+        // It should fail.
+        assert!(vc_bad_issuer.verify(&didweb).await.unwrap().is_invalid());
 
         PROXY.with(|proxy| {
             proxy.replace(None);

--- a/ssi-dids/src/did.rs
+++ b/ssi-dids/src/did.rs
@@ -410,6 +410,7 @@ impl DID {
                 },
                 State::MethodSpecificId => match bytes.next() {
                     Some(b':') => state = State::MethodSpecificIdStartOrSeparator,
+                    Some(b'%') => state = State::MethodSpecificIdPct1,
                     Some(c) if is_id_char(c) => (),
                     c => break Ok((i, c)),
                 },
@@ -426,10 +427,11 @@ mod tests {
 
     #[test]
     fn parse_did_accept() {
-        let vectors: [&[u8]; 3] = [
+        let vectors: [&[u8]; 4] = [
             b"did:method:foo",
             b"did:a:b",
-            b"did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9"
+            b"did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9",
+            b"did:web:example.com%3A443:u:bob"
         ];
 
         for input in vectors {

--- a/ssi-dids/src/document/representation.rs
+++ b/ssi-dids/src/document/representation.rs
@@ -128,6 +128,30 @@ impl FromStr for MediaType {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidMediaType {
+    #[error(transparent)]
+    Unknown(Unknown),
+
+    #[error("invalid DID document media type")]
+    NotAString,
+}
+
+impl<'a> TryFrom<&'a [u8]> for MediaType {
+    type Error = InvalidMediaType;
+
+    fn try_from(s: &'a [u8]) -> Result<Self, Self::Error> {
+        match s {
+            b"application/did+json" => Ok(Self::Json),
+            b"application/did+ld+json" => Ok(Self::JsonLd),
+            unknown => match String::from_utf8(unknown.to_vec()) {
+                Ok(s) => Err(InvalidMediaType::Unknown(Unknown(s))),
+                Err(_) => Err(InvalidMediaType::NotAString),
+            },
+        }
+    }
+}
+
 /// Representation configuration.
 pub enum Options {
     Json,

--- a/ssi-dids/src/resolution.rs
+++ b/ssi-dids/src/resolution.rs
@@ -41,6 +41,9 @@ pub enum Error {
     #[error("DID representation `{0}` not supported")]
     RepresentationNotSupported(String),
 
+    #[error("invalid DID representation media type")]
+    InvalidRepresentationMediaType,
+
     #[error(transparent)]
     InvalidData(InvalidData),
 
@@ -55,12 +58,17 @@ pub enum Error {
 }
 
 impl Error {
+    pub fn internal<E: 'static + std::error::Error + Send>(error: E) -> Self {
+        Self::Internal(Box::new(error))
+    }
+
     pub fn kind(&self) -> ErrorKind {
         match self {
             Self::MethodNotSupported(_) => ErrorKind::MethodNotSupported,
             Self::NotFound => ErrorKind::NotFound,
             Self::NoRepresentation => ErrorKind::NoRepresentation,
             Self::UnknownRepresentation(_) => ErrorKind::UnknownRepresentation,
+            Self::InvalidRepresentationMediaType => ErrorKind::InvalidRepresentationMediaType,
             Self::RepresentationNotSupported(_) => ErrorKind::RepresentationNotSupported,
             Self::InvalidData(_) => ErrorKind::InvalidData,
             Self::InvalidMethodSpecificId(_) => ErrorKind::InvalidMethodSpecificId,
@@ -82,6 +90,7 @@ pub enum ErrorKind {
     NotFound,
     NoRepresentation,
     UnknownRepresentation,
+    InvalidRepresentationMediaType,
     RepresentationNotSupported,
     InvalidData,
     InvalidMethodSpecificId,

--- a/ssi-jwk/Cargo.toml
+++ b/ssi-jwk/Cargo.toml
@@ -64,7 +64,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 ssi-multicodec.workspace = true
 linked-data.workspace = true
-json-syntax = { workspace = true, features = ["serde"] }
+json-syntax = { workspace = true, features = ["serde", "canonicalize"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"], optional = true }


### PR DESCRIPTION
This PR brings the `did-web` library up to date with the new `ssi` API. There is nothing special with this refactor as this DID method is very simple, and tests are only using already tested cryptographic suites.