### PR TITLE
Prefer OUT_DIR for outputting the multicodec table

### DIFF
--- a/crates/multicodec/build.rs
+++ b/crates/multicodec/build.rs
@@ -1,8 +1,9 @@
-use std::{fs, io, io::Write, path::Path};
+use std::{env, fs, io, io::Write, path::Path};
 
 fn main() {
     println!("cargo:rerun-if-changed=src/table.csv");
-    if let Err(e) = generate_codecs("src/table.csv", "src/table.rs") {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    if let Err(e) = generate_codecs("src/table.csv", Path::new(&out_dir).join("table.rs")) {
         eprintln!("unable to generate codecs: {e}");
         std::process::exit(1);
     }

--- a/crates/multicodec/src/lib.rs
+++ b/crates/multicodec/src/lib.rs
@@ -2,10 +2,7 @@ use std::ops::Deref;
 
 pub use unsigned_varint::decode::Error;
 
-#[rustfmt::skip]
-mod table;
-
-pub use table::*;
+include!(concat!(env!("OUT_DIR"), "/table.rs"));
 
 /// Multi-encoded byte slice.
 pub struct MultiEncoded([u8]);


### PR DESCRIPTION
Some Rust build environments (e.g. [Crane](https://crane.dev/)) rely on build scripts using only OUT_DIR directory for producing build-time artifacts, erroring out otherwise.

This PR fixes the `ssi-multicodec` build failure in such cases.