### PR TITLE
Verifier simplification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ let jwt = CompactJWSString::from_string(
 // public key used to sign the JWT.
 // Here we use the example `ExampleDIDResolver` resolver, enabled with the
 // `example` feature.
-let vm_resolver = ExampleDIDResolver::default().with_default_options::<AnyJwkMethod>();
+let vm_resolver = ExampleDIDResolver::default().into_vm_resolver::<AnyJwkMethod>();
 
 // Verify the JWT.
 assert!(jwt.verify(&vm_resolver).await.expect("verification failed").is_ok())
@@ -89,7 +89,7 @@ let vc = ssi::claims::vc::v1::data_integrity::any_credential_from_json_str(
 
 // Setup a verification method resolver, in charge of retrieving the
 // public key used to sign the JWT.
-let vm_resolver = ExampleDIDResolver::default().with_default_options();
+let vm_resolver = ExampleDIDResolver::default().into_vm_resolver();
 
 assert!(vc.verify(&vm_resolver).await.expect("verification failed").is_ok());
 ```
@@ -133,7 +133,7 @@ let jwt = claims.sign(&key).await.expect("signature failed");
 
 // Create a verification method resolver, which will be in charge of
 // decoding the DID back into a public key.
-let vm_resolver = DIDJWK.with_default_options::<AnyJwkMethod>();
+let vm_resolver = DIDJWK.into_vm_resolver::<AnyJwkMethod>();
 
 // Verify the JWT.
 assert!(jwt.verify(&vm_resolver).await.expect("verification failed").is_ok());
@@ -181,7 +181,7 @@ let did = DIDJWK::generate_url(&key.to_public());
 
 // Create a verification method resolver, which will be in charge of
 // decoding the DID back into a public key.
-let vm_resolver = DIDJWK.with_default_options();
+let vm_resolver = DIDJWK.into_vm_resolver();
 
 // Create a signer from the secret key.
 // Here we use the simple `SingleSecretSigner` signer type which always uses

--- a/crates/claims/core/src/signature.rs
+++ b/crates/claims/core/src/signature.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
-use ssi_eip712::Eip712TypesEnvironment;
-use ssi_json_ld::ContextLoaderEnvironment;
+use ssi_eip712::Eip712TypesLoaderProvider;
+use ssi_json_ld::JsonLdLoaderProvider;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SignatureError {
@@ -73,7 +73,7 @@ impl Default for SignatureEnvironment {
     }
 }
 
-impl<JsonLdLoader, Eip712Loader> ContextLoaderEnvironment
+impl<JsonLdLoader, Eip712Loader> JsonLdLoaderProvider
     for SignatureEnvironment<JsonLdLoader, Eip712Loader>
 where
     JsonLdLoader: ssi_json_ld::Loader,
@@ -85,14 +85,14 @@ where
     }
 }
 
-impl<JsonLdLoader, Eip712Loader> Eip712TypesEnvironment
+impl<JsonLdLoader, Eip712Loader> Eip712TypesLoaderProvider
     for SignatureEnvironment<JsonLdLoader, Eip712Loader>
 where
-    Eip712Loader: ssi_eip712::TypesProvider,
+    Eip712Loader: ssi_eip712::TypesLoader,
 {
-    type Provider = Eip712Loader;
+    type Loader = Eip712Loader;
 
-    fn eip712_types(&self) -> &Self::Provider {
+    fn eip712_types(&self) -> &Self::Loader {
         &self.eip712_loader
     }
 }

--- a/crates/claims/core/src/verification/claims.rs
+++ b/crates/claims/core/src/verification/claims.rs
@@ -2,8 +2,8 @@ use chrono::{DateTime, Utc};
 use core::fmt;
 use std::borrow::Cow;
 
-pub use ssi_eip712::Eip712TypesEnvironment;
-pub use ssi_json_ld::ContextLoaderEnvironment;
+pub use ssi_eip712::Eip712TypesLoaderProvider;
+pub use ssi_json_ld::JsonLdLoaderProvider;
 
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum InvalidClaims {

--- a/crates/claims/core/src/verification/claims.rs
+++ b/crates/claims/core/src/verification/claims.rs
@@ -39,7 +39,7 @@ pub type ClaimsValidity = Result<(), InvalidClaims>;
 
 /// Claims that can be validated.
 ///
-/// Validation consists in verifying that the claims themselves are
+/// This consists in verifying that the claims themselves are
 /// consistent and valid with regard to the verification environment.
 /// For instance, checking that a credential's expiration date is not in the
 /// past, or the issue date not in the future.
@@ -48,128 +48,30 @@ pub type ClaimsValidity = Result<(), InvalidClaims>;
 ///
 /// The `validate` function is also provided with the proof, as some claim type
 /// require information from the proof to be validated.
-pub trait Validate<E, P> {
-    /// Validates the claims.
-    fn validate(&self, env: &E, proof: &P) -> ClaimsValidity;
+pub trait ValidateClaims<E, P = ()> {
+    fn validate_claims(&self, environment: &E, proof: &P) -> ClaimsValidity;
 }
 
-impl<E, P> Validate<E, P> for () {
-    fn validate(&self, _env: &E, _proof: &P) -> ClaimsValidity {
+impl<E, P> ValidateClaims<E, P> for () {
+    fn validate_claims(&self, _env: &E, _proof: &P) -> ClaimsValidity {
         Ok(())
     }
 }
 
-impl<E, P> Validate<E, P> for [u8] {
-    fn validate(&self, _env: &E, _proof: &P) -> ClaimsValidity {
+impl<E, P> ValidateClaims<E, P> for [u8] {
+    fn validate_claims(&self, _env: &E, _proof: &P) -> ClaimsValidity {
         Ok(())
     }
 }
 
-impl<E, P> Validate<E, P> for Vec<u8> {
-    fn validate(&self, _env: &E, _proof: &P) -> ClaimsValidity {
+impl<E, P> ValidateClaims<E, P> for Vec<u8> {
+    fn validate_claims(&self, _env: &E, _proof: &P) -> ClaimsValidity {
         Ok(())
     }
 }
 
-impl<'a, E, P, T: ?Sized + ToOwned + Validate<E, P>> Validate<E, P> for Cow<'a, T> {
-    fn validate(&self, _env: &E, _proof: &P) -> ClaimsValidity {
+impl<'a, E, P, T: ?Sized + ToOwned + ValidateClaims<E, P>> ValidateClaims<E, P> for Cow<'a, T> {
+    fn validate_claims(&self, _env: &E, _proof: &P) -> ClaimsValidity {
         Ok(())
-    }
-}
-
-/// Environment that provides date and time.
-///
-/// Used to check the validity period of given claims.
-pub trait DateTimeEnvironment {
-    /// Returns the current date and time.
-    fn date_time(&self) -> DateTime<Utc>;
-}
-
-impl DateTimeEnvironment for () {
-    fn date_time(&self) -> DateTime<Utc> {
-        Utc::now()
-    }
-}
-
-/// Verifiable claims with a preferred default verification environment.
-pub trait DefaultVerificationEnvironment {
-    type Environment: Default;
-}
-
-impl DefaultVerificationEnvironment for () {
-    type Environment = ();
-}
-
-impl DefaultVerificationEnvironment for [u8] {
-    type Environment = ();
-}
-
-impl DefaultVerificationEnvironment for Vec<u8> {
-    type Environment = ();
-}
-
-impl<'a> DefaultVerificationEnvironment for Cow<'a, [u8]> {
-    type Environment = ();
-}
-
-impl<'a, T: DefaultVerificationEnvironment> DefaultVerificationEnvironment for &'a T {
-    type Environment = T::Environment;
-}
-
-/// Verification environment.
-///
-/// This is a common environment implementation expected to work with most
-/// claims.
-///
-/// It is possible to define a custom environment type, as long it implements
-/// the accessor traits required for verification such as
-/// [`DateTimeEnvironment`].
-pub struct VerificationEnvironment<JsonLdLoader = ssi_json_ld::ContextLoader, Eip712Loader = ()> {
-    pub date_time: DateTime<Utc>,
-
-    pub json_ld_loader: JsonLdLoader,
-
-    pub eip712_loader: Eip712Loader,
-}
-
-impl Default for VerificationEnvironment {
-    fn default() -> Self {
-        Self {
-            date_time: Utc::now(),
-            json_ld_loader: ssi_json_ld::ContextLoader::default(),
-            eip712_loader: (),
-        }
-    }
-}
-
-impl<JsonLdLoader, Eip712Loader> DateTimeEnvironment
-    for VerificationEnvironment<JsonLdLoader, Eip712Loader>
-{
-    fn date_time(&self) -> DateTime<Utc> {
-        self.date_time
-    }
-}
-
-impl<JsonLdLoader, Eip712Loader> ContextLoaderEnvironment
-    for VerificationEnvironment<JsonLdLoader, Eip712Loader>
-where
-    JsonLdLoader: ssi_json_ld::Loader,
-{
-    type Loader = JsonLdLoader;
-
-    fn loader(&self) -> &Self::Loader {
-        &self.json_ld_loader
-    }
-}
-
-impl<JsonLdLoader, Eip712Loader> Eip712TypesEnvironment
-    for VerificationEnvironment<JsonLdLoader, Eip712Loader>
-where
-    Eip712Loader: ssi_eip712::TypesProvider,
-{
-    type Provider = Eip712Loader;
-
-    fn eip712_types(&self) -> &Self::Provider {
-        &self.eip712_loader
     }
 }

--- a/crates/claims/core/src/verification/mod.rs
+++ b/crates/claims/core/src/verification/mod.rs
@@ -20,6 +20,8 @@
 //!   - Proof validation: the claims verified against the proof using the
 //!     [`ValidateProof`] trait.
 mod claims;
+
+use chrono::{DateTime, Utc};
 pub use claims::*;
 mod proof;
 pub use proof::*;
@@ -34,37 +36,30 @@ pub trait VerifiableClaims {
     /// Proof type.
     type Proof;
 
+    /// The claims.
     fn claims(&self) -> &Self::Claims;
 
+    /// The proof.
     fn proof(&self) -> &Self::Proof;
 
-    /// Validates the claims and verify them against the proof.
+    /// Validates the claims and proof.
+    ///
+    /// The `verifier` argument is a environment providing all the resources
+    /// necessary for the validation of the claims and proof. This is highly
+    /// dependent on the type of claims/proof you want to verify, but in most
+    /// cases you can use the built-in [`Verifier`] type. This type provides the
+    /// most common required resources such as a public key resolver and
+    /// JSON-LD document loader.
     #[allow(async_fn_in_trait)]
-    async fn verify<V>(&self, verifier: &V) -> Result<Verification, ProofValidationError>
+    async fn verify<V>(&self, verifier: V) -> Result<Verification, ProofValidationError>
     where
-        Self: DefaultVerificationEnvironment,
-        Self::Claims: Validate<Self::Environment, Self::Proof>,
-        Self::Proof: ValidateProof<Self::Claims, Self::Environment, V>,
+        Self::Claims: ValidateClaims<V, Self::Proof>,
+        Self::Proof: ValidateProof<V, Self::Claims>,
     {
-        self.verify_with(verifier, Self::Environment::default())
-            .await
-    }
-
-    /// Validates the claims and verify them against the proof.
-    #[allow(async_fn_in_trait)]
-    async fn verify_with<V, E>(
-        &self,
-        verifier: &V,
-        env: E,
-    ) -> Result<Verification, ProofValidationError>
-    where
-        Self::Claims: Validate<E, Self::Proof>,
-        Self::Proof: ValidateProof<Self::Claims, E, V>,
-    {
-        match self.claims().validate(&env, self.proof()) {
+        match self.claims().validate_claims(&verifier, self.proof()) {
             Ok(_) => self
                 .proof()
-                .validate_proof(&env, self.claims(), verifier)
+                .validate_proof(&verifier, self.claims())
                 .await
                 .map(|r| r.map_err(Invalid::Proof)),
             Err(e) => {
@@ -97,4 +92,136 @@ pub enum Invalid {
 
     #[error("invalid proof: {0}")]
     Proof(#[from] InvalidProof),
+}
+
+/// Public key resolver environment.
+pub trait ResolverEnvironment {
+    /// Public key resolver.
+    type Resolver;
+
+    /// Returns a reference to the environment's public key resolver.
+    fn resolver(&self) -> &Self::Resolver;
+}
+
+impl<'a, E: ResolverEnvironment> ResolverEnvironment for &'a E {
+    type Resolver = E::Resolver;
+
+    fn resolver(&self) -> &Self::Resolver {
+        E::resolver(*self)
+    }
+}
+
+/// Environment that provides date and time.
+///
+/// Used to check the validity period of given claims.
+pub trait DateTimeEnvironment {
+    /// Returns the current date and time.
+    fn date_time(&self) -> DateTime<Utc>;
+}
+
+impl<'a, E: DateTimeEnvironment> DateTimeEnvironment for &'a E {
+    fn date_time(&self) -> DateTime<Utc> {
+        E::date_time(*self)
+    }
+}
+
+/// Default verifier.
+///
+/// The [`VerifiableClaims::verify`] function expects a verification environment
+/// (called the `verifier`) providing all the resources necessary for the
+/// validation of claims and signature.
+///
+/// Required resources depend on the actual type of claims and signature you
+/// want to validate, however we can identify a set of resources that are
+/// commonly required, namely:
+///  - A public key resolver,
+///  - a JSON-LD document loader,
+///  - an EIP-712 types definition loader,
+///  - the date and time.
+///
+/// This type defines an environment providing those resources. In most cases,
+/// this will be sufficient to verify all your secured claims.
+///
+/// The `from_resolver` constructor provides sensible defaults for the JSON-LD
+/// document loader, EIP-712 loader, date and time. You still need to provide
+/// public key resolver.
+#[derive(Debug, Clone, Copy)]
+pub struct Verifier<R, L1 = ssi_json_ld::ContextLoader, L2 = ()> {
+    /// Public key resolver.
+    pub resolver: R,
+
+    /// JSON-LD loader.
+    pub json_ld_loader: L1,
+
+    /// EIP-712 types loader.
+    pub eip712_types_loader: L2,
+
+    /// Date-time.
+    pub date_time: DateTime<Utc>,
+}
+
+impl<R> Verifier<R> {
+    pub fn from_resolver(resolver: R) -> Self {
+        Self {
+            resolver,
+            json_ld_loader: ssi_json_ld::ContextLoader::default(),
+            eip712_types_loader: (),
+            date_time: Utc::now(),
+        }
+    }
+}
+
+impl<R, L1, L2> Verifier<R, L1, L2> {
+    pub fn with_date_time(mut self, date_time: DateTime<Utc>) -> Self {
+        self.date_time = date_time;
+        self
+    }
+
+    pub fn with_json_ld_loader<L>(self, loader: L) -> Verifier<R, L, L2> {
+        Verifier {
+            resolver: self.resolver,
+            json_ld_loader: loader,
+            eip712_types_loader: self.eip712_types_loader,
+            date_time: self.date_time,
+        }
+    }
+
+    pub fn with_eip712_types_loader<L>(self, loader: L) -> Verifier<R, L1, L> {
+        Verifier {
+            resolver: self.resolver,
+            json_ld_loader: self.json_ld_loader,
+            eip712_types_loader: loader,
+            date_time: self.date_time,
+        }
+    }
+}
+
+impl<R, L1, L2> ResolverEnvironment for Verifier<R, L1, L2> {
+    type Resolver = R;
+
+    fn resolver(&self) -> &Self::Resolver {
+        &self.resolver
+    }
+}
+
+impl<R, L1: ssi_json_ld::Loader, L2> ContextLoaderEnvironment for Verifier<R, L1, L2> {
+    type Loader = L1;
+
+    fn loader(&self) -> &Self::Loader {
+        &self.json_ld_loader
+    }
+}
+
+impl<R, L1, L2: ssi_eip712::TypesProvider> Eip712TypesEnvironment for Verifier<R, L1, L2> {
+    type Provider = L2;
+
+    fn eip712_types(&self) -> &Self::Provider {
+        &self.eip712_types_loader
+    }
+}
+
+impl<R, L1, L2> DateTimeEnvironment for Verifier<R, L1, L2> {
+    fn date_time(&self) -> DateTime<Utc> {
+        self.date_time
+    }
 }

--- a/crates/claims/core/src/verification/mod.rs
+++ b/crates/claims/core/src/verification/mod.rs
@@ -25,6 +25,8 @@ use chrono::{DateTime, Utc};
 pub use claims::*;
 mod proof;
 pub use proof::*;
+mod parameters;
+pub use parameters::*;
 
 /// Verifiable Claims.
 ///
@@ -44,22 +46,30 @@ pub trait VerifiableClaims {
 
     /// Validates the claims and proof.
     ///
-    /// The `verifier` argument is a environment providing all the resources
-    /// necessary for the validation of the claims and proof. This is highly
-    /// dependent on the type of claims/proof you want to verify, but in most
-    /// cases you can use the built-in [`Verifier`] type. This type provides the
-    /// most common required resources such as a public key resolver and
-    /// JSON-LD document loader.
+    /// The `params` argument provides all the verification parameters required
+    /// to validate the claims and proof.
+    ///
+    /// # What verification parameters should I use?
+    ///
+    /// It really depends on the claims type `Self::Claims` and proof type
+    /// `Self::Proof`, but the [`VerificationParameters`] type is a good
+    /// starting point that should work most of the time.
+    ///
+    /// # Passing the parameters by reference
+    ///
+    /// If the validation traits are implemented for `P`, they will be
+    /// implemented for `&P` as well. This means the parameters can be passed
+    /// by move *or* by reference.
     #[allow(async_fn_in_trait)]
-    async fn verify<V>(&self, verifier: V) -> Result<Verification, ProofValidationError>
+    async fn verify<P>(&self, params: P) -> Result<Verification, ProofValidationError>
     where
-        Self::Claims: ValidateClaims<V, Self::Proof>,
-        Self::Proof: ValidateProof<V, Self::Claims>,
+        Self::Claims: ValidateClaims<P, Self::Proof>,
+        Self::Proof: ValidateProof<P, Self::Claims>,
     {
-        match self.claims().validate_claims(&verifier, self.proof()) {
+        match self.claims().validate_claims(&params, self.proof()) {
             Ok(_) => self
                 .proof()
-                .validate_proof(&verifier, self.claims())
+                .validate_proof(&params, self.claims())
                 .await
                 .map(|r| r.map_err(Invalid::Proof)),
             Err(e) => {
@@ -94,8 +104,8 @@ pub enum Invalid {
     Proof(#[from] InvalidProof),
 }
 
-/// Public key resolver environment.
-pub trait ResolverEnvironment {
+/// Type that provides a public key resolver.
+pub trait ResolverProvider {
     /// Public key resolver.
     type Resolver;
 
@@ -103,7 +113,7 @@ pub trait ResolverEnvironment {
     fn resolver(&self) -> &Self::Resolver;
 }
 
-impl<'a, E: ResolverEnvironment> ResolverEnvironment for &'a E {
+impl<'a, E: ResolverProvider> ResolverProvider for &'a E {
     type Resolver = E::Resolver;
 
     fn resolver(&self) -> &Self::Resolver {
@@ -111,117 +121,16 @@ impl<'a, E: ResolverEnvironment> ResolverEnvironment for &'a E {
     }
 }
 
-/// Environment that provides date and time.
+/// Type that provides date and time.
 ///
 /// Used to check the validity period of given claims.
-pub trait DateTimeEnvironment {
+pub trait DateTimeProvider {
     /// Returns the current date and time.
     fn date_time(&self) -> DateTime<Utc>;
 }
 
-impl<'a, E: DateTimeEnvironment> DateTimeEnvironment for &'a E {
+impl<'a, E: DateTimeProvider> DateTimeProvider for &'a E {
     fn date_time(&self) -> DateTime<Utc> {
         E::date_time(*self)
-    }
-}
-
-/// Default verifier.
-///
-/// The [`VerifiableClaims::verify`] function expects a verification environment
-/// (called the `verifier`) providing all the resources necessary for the
-/// validation of claims and signature.
-///
-/// Required resources depend on the actual type of claims and signature you
-/// want to validate, however we can identify a set of resources that are
-/// commonly required, namely:
-///  - A public key resolver,
-///  - a JSON-LD document loader,
-///  - an EIP-712 types definition loader,
-///  - the date and time.
-///
-/// This type defines an environment providing those resources. In most cases,
-/// this will be sufficient to verify all your secured claims.
-///
-/// The `from_resolver` constructor provides sensible defaults for the JSON-LD
-/// document loader, EIP-712 loader, date and time. You still need to provide
-/// public key resolver.
-#[derive(Debug, Clone, Copy)]
-pub struct Verifier<R, L1 = ssi_json_ld::ContextLoader, L2 = ()> {
-    /// Public key resolver.
-    pub resolver: R,
-
-    /// JSON-LD loader.
-    pub json_ld_loader: L1,
-
-    /// EIP-712 types loader.
-    pub eip712_types_loader: L2,
-
-    /// Date-time.
-    pub date_time: DateTime<Utc>,
-}
-
-impl<R> Verifier<R> {
-    pub fn from_resolver(resolver: R) -> Self {
-        Self {
-            resolver,
-            json_ld_loader: ssi_json_ld::ContextLoader::default(),
-            eip712_types_loader: (),
-            date_time: Utc::now(),
-        }
-    }
-}
-
-impl<R, L1, L2> Verifier<R, L1, L2> {
-    pub fn with_date_time(mut self, date_time: DateTime<Utc>) -> Self {
-        self.date_time = date_time;
-        self
-    }
-
-    pub fn with_json_ld_loader<L>(self, loader: L) -> Verifier<R, L, L2> {
-        Verifier {
-            resolver: self.resolver,
-            json_ld_loader: loader,
-            eip712_types_loader: self.eip712_types_loader,
-            date_time: self.date_time,
-        }
-    }
-
-    pub fn with_eip712_types_loader<L>(self, loader: L) -> Verifier<R, L1, L> {
-        Verifier {
-            resolver: self.resolver,
-            json_ld_loader: self.json_ld_loader,
-            eip712_types_loader: loader,
-            date_time: self.date_time,
-        }
-    }
-}
-
-impl<R, L1, L2> ResolverEnvironment for Verifier<R, L1, L2> {
-    type Resolver = R;
-
-    fn resolver(&self) -> &Self::Resolver {
-        &self.resolver
-    }
-}
-
-impl<R, L1: ssi_json_ld::Loader, L2> ContextLoaderEnvironment for Verifier<R, L1, L2> {
-    type Loader = L1;
-
-    fn loader(&self) -> &Self::Loader {
-        &self.json_ld_loader
-    }
-}
-
-impl<R, L1, L2: ssi_eip712::TypesProvider> Eip712TypesEnvironment for Verifier<R, L1, L2> {
-    type Provider = L2;
-
-    fn eip712_types(&self) -> &Self::Provider {
-        &self.eip712_types_loader
-    }
-}
-
-impl<R, L1, L2> DateTimeEnvironment for Verifier<R, L1, L2> {
-    fn date_time(&self) -> DateTime<Utc> {
-        self.date_time
     }
 }

--- a/crates/claims/core/src/verification/parameters.rs
+++ b/crates/claims/core/src/verification/parameters.rs
@@ -1,0 +1,102 @@
+use crate::{DateTimeProvider, ResolverProvider};
+use chrono::{DateTime, Utc};
+use ssi_eip712::Eip712TypesLoaderProvider;
+use ssi_json_ld::JsonLdLoaderProvider;
+
+/// Common verification parameters.
+///
+/// The [`VerifiableClaims::verify`] function expects a set of verification
+/// parameters necessary for the validation of claims and signature.
+///
+/// Required parameters depend on the actual type of claims and signature you
+/// want to validate, however we can identify a subset of parameters that are
+/// commonly required, namely:
+///  - A public key resolver,
+///  - a JSON-LD document loader,
+///  - an EIP-712 types definition loader,
+///  - the date and time.
+///
+/// This type provides this subset of parameters. In most cases, this will be
+/// sufficient to verify all your secured claims.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct VerificationParameters<R, L1 = ssi_json_ld::ContextLoader, L2 = ()> {
+    /// Public key resolver.
+    pub resolver: R,
+
+    /// JSON-LD loader.
+    pub json_ld_loader: L1,
+
+    /// EIP-712 types loader.
+    pub eip712_types_loader: L2,
+
+    /// Date-time.
+    pub date_time: DateTime<Utc>,
+}
+
+impl<R> VerificationParameters<R> {
+    pub fn from_resolver(resolver: R) -> Self {
+        Self {
+            resolver,
+            json_ld_loader: ssi_json_ld::ContextLoader::default(),
+            eip712_types_loader: (),
+            date_time: Utc::now(),
+        }
+    }
+}
+
+impl<R, L1, L2> VerificationParameters<R, L1, L2> {
+    pub fn with_date_time(mut self, date_time: DateTime<Utc>) -> Self {
+        self.date_time = date_time;
+        self
+    }
+
+    pub fn with_json_ld_loader<L>(self, loader: L) -> VerificationParameters<R, L, L2> {
+        VerificationParameters {
+            resolver: self.resolver,
+            json_ld_loader: loader,
+            eip712_types_loader: self.eip712_types_loader,
+            date_time: self.date_time,
+        }
+    }
+
+    pub fn with_eip712_types_loader<L>(self, loader: L) -> VerificationParameters<R, L1, L> {
+        VerificationParameters {
+            resolver: self.resolver,
+            json_ld_loader: self.json_ld_loader,
+            eip712_types_loader: loader,
+            date_time: self.date_time,
+        }
+    }
+}
+
+impl<R, L1, L2> ResolverProvider for VerificationParameters<R, L1, L2> {
+    type Resolver = R;
+
+    fn resolver(&self) -> &Self::Resolver {
+        &self.resolver
+    }
+}
+
+impl<R, L1: ssi_json_ld::Loader, L2> JsonLdLoaderProvider for VerificationParameters<R, L1, L2> {
+    type Loader = L1;
+
+    fn loader(&self) -> &Self::Loader {
+        &self.json_ld_loader
+    }
+}
+
+impl<R, L1, L2: ssi_eip712::TypesLoader> Eip712TypesLoaderProvider
+    for VerificationParameters<R, L1, L2>
+{
+    type Loader = L2;
+
+    fn eip712_types(&self) -> &Self::Loader {
+        &self.eip712_types_loader
+    }
+}
+
+impl<R, L1, L2> DateTimeProvider for VerificationParameters<R, L1, L2> {
+    fn date_time(&self) -> DateTime<Utc> {
+        self.date_time
+    }
+}

--- a/crates/claims/core/src/verification/parameters.rs
+++ b/crates/claims/core/src/verification/parameters.rs
@@ -30,7 +30,9 @@ pub struct VerificationParameters<R, L1 = ssi_json_ld::ContextLoader, L2 = ()> {
     pub eip712_types_loader: L2,
 
     /// Date-time.
-    pub date_time: DateTime<Utc>,
+    ///
+    /// If `None`, the current date time is used.
+    pub date_time: Option<DateTime<Utc>>,
 }
 
 impl<R> VerificationParameters<R> {
@@ -39,14 +41,14 @@ impl<R> VerificationParameters<R> {
             resolver,
             json_ld_loader: ssi_json_ld::ContextLoader::default(),
             eip712_types_loader: (),
-            date_time: Utc::now(),
+            date_time: None,
         }
     }
 }
 
 impl<R, L1, L2> VerificationParameters<R, L1, L2> {
     pub fn with_date_time(mut self, date_time: DateTime<Utc>) -> Self {
-        self.date_time = date_time;
+        self.date_time = Some(date_time);
         self
     }
 
@@ -97,6 +99,6 @@ impl<R, L1, L2: ssi_eip712::TypesLoader> Eip712TypesLoaderProvider
 
 impl<R, L1, L2> DateTimeProvider for VerificationParameters<R, L1, L2> {
     fn date_time(&self) -> DateTime<Utc> {
-        self.date_time
+        self.date_time.unwrap_or_else(Utc::now)
     }
 }

--- a/crates/claims/crates/data-integrity/core/src/canonicalization.rs
+++ b/crates/claims/crates/data-integrity/core/src/canonicalization.rs
@@ -1,7 +1,7 @@
 use digest::Digest;
 use std::marker::PhantomData;
 
-use ssi_json_ld::{ContextLoaderEnvironment, Expandable, JsonLdNodeObject};
+use ssi_json_ld::{Expandable, JsonLdLoaderProvider, JsonLdNodeObject};
 use ssi_rdf::{AnyLdEnvironment, LdEnvironment};
 
 use crate::{
@@ -30,7 +30,7 @@ impl<S, T, C> standard::TypedTransformationAlgorithm<S, T, C> for CanonicalizeCl
 where
     S: SerializeCryptographicSuite,
     T: JsonLdNodeObject + Expandable,
-    C: ContextLoaderEnvironment,
+    C: JsonLdLoaderProvider,
 {
     async fn transform(
         context: &C,

--- a/crates/claims/crates/data-integrity/core/src/document.rs
+++ b/crates/claims/crates/data-integrity/core/src/document.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::BTreeMap, hash::Hash};
 
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::Validate;
+use ssi_claims_core::ValidateClaims;
 use ssi_core::OneOrMany;
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, LinkedDataResource, LinkedDataSubject, Vocabulary};
@@ -72,8 +72,8 @@ impl JsonLdNodeObject for DataIntegrityDocument {
     }
 }
 
-impl<E, P> Validate<E, P> for DataIntegrityDocument {
-    fn validate(&self, _env: &E, _proof: &P) -> ssi_claims_core::ClaimsValidity {
+impl<E, P> ValidateClaims<E, P> for DataIntegrityDocument {
+    fn validate_claims(&self, _env: &E, _proof: &P) -> ssi_claims_core::ClaimsValidity {
         Ok(())
     }
 }

--- a/crates/claims/crates/data-integrity/core/src/lib.rs
+++ b/crates/claims/crates/data-integrity/core/src/lib.rs
@@ -18,7 +18,7 @@ use educe::Educe;
 pub use options::ProofOptions;
 pub use proof::*;
 use serde::Serialize;
-use ssi_claims_core::{DefaultVerificationEnvironment, VerifiableClaims, VerificationEnvironment};
+use ssi_claims_core::VerifiableClaims;
 pub use suite::{
     CloneCryptographicSuite, CryptographicSuite, DebugCryptographicSuite,
     DeserializeCryptographicSuite, SerializeCryptographicSuite, StandardCryptographicSuite,
@@ -72,8 +72,4 @@ impl<T, S: CryptographicSuite> VerifiableClaims for DataIntegrity<T, S> {
     fn proof(&self) -> &Self::Proof {
         &self.proofs
     }
-}
-
-impl<T, S: CryptographicSuite> DefaultVerificationEnvironment for DataIntegrity<T, S> {
-    type Environment = VerificationEnvironment;
 }

--- a/crates/claims/crates/data-integrity/core/src/lib.rs
+++ b/crates/claims/crates/data-integrity/core/src/lib.rs
@@ -18,7 +18,9 @@ use educe::Educe;
 pub use options::ProofOptions;
 pub use proof::*;
 use serde::Serialize;
-use ssi_claims_core::VerifiableClaims;
+use ssi_claims_core::{
+    ProofValidationError, ValidateClaims, ValidateProof, VerifiableClaims, Verification,
+};
 pub use suite::{
     CloneCryptographicSuite, CryptographicSuite, DebugCryptographicSuite,
     DeserializeCryptographicSuite, SerializeCryptographicSuite, StandardCryptographicSuite,
@@ -42,10 +44,54 @@ pub struct DataIntegrity<T, S: CryptographicSuite> {
 }
 
 impl<T, S: CryptographicSuite> DataIntegrity<T, S> {
+    /// Create new Data-Integrity-secured claims by providing the proofs.
     pub fn new(claims: T, proofs: Proofs<S>) -> Self {
         Self { claims, proofs }
     }
+
+    /// Verify the claims and proofs.
+    ///
+    /// The `params` argument provides all the verification parameters required
+    /// to validate the claims and proof.
+    ///
+    /// # What verification parameters should I use?
+    ///
+    /// It really depends on the claims type `T` and cryptosuite type `S`,
+    /// but the `ssi::claims::VerificationParameters` type is a good starting
+    /// point that should work most of the time.
+    ///
+    /// # Passing the parameters by reference
+    ///
+    /// If the validation traits are implemented for `P`, they will be
+    /// implemented for `&P` as well. This means the parameters can be passed
+    /// by move *or* by reference.
+    pub async fn verify<P>(&self, params: P) -> Result<Verification, ProofValidationError>
+    where
+        T: ValidateClaims<P, Proofs<S>>,
+        Proofs<S>: ValidateProof<P, T>,
+    {
+        VerifiableClaims::verify(self, params).await
+    }
 }
+
+// impl<T, S: CryptographicSuite> DataIntegrity<T, S>
+// where
+//     T: ValidateClaims<VerificationParameters, Proofs<S>>,
+//     Proofs<S>: ValidateProof<VerificationParameters, T>,
+// {
+//     /// Verify the claims and proofs with the default verification parameters.
+//     ///
+//     /// This function should be available for most claims and cryptosuite.
+//     /// If you need to customize the verification parameters, such as
+//     /// changing the verification date and time or the JSON-LD context loader,
+//     /// use the [`Self::verify_with`] method.
+//     ///
+//     /// See the [`VerificationParameters`] type for more information about the
+//     /// default verification parameters.
+//     pub async fn verify(&self) -> Result<Verification, ProofValidationError> {
+//         VerifiableClaims::verify(self, VerificationParameters::default()).await
+//     }
+// }
 
 impl<T, S: CryptographicSuite> Deref for DataIntegrity<T, S> {
     type Target = T;

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/expansion.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/expansion.rs
@@ -9,7 +9,7 @@ use rdf_types::{
 };
 use serde::Serialize;
 use ssi_json_ld::{
-    CompactJsonLd, ContextLoaderEnvironment, Expandable, ExpandedDocument, JsonLdError,
+    CompactJsonLd, Expandable, ExpandedDocument, JsonLdError, JsonLdLoaderProvider,
     JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader,
 };
 use ssi_rdf::{urdna2015, Interpretation, IntoNQuads, LdEnvironment};
@@ -31,7 +31,7 @@ impl<'a, S: CryptographicSuite> ProofConfigurationRef<'a, S> {
 
     pub async fn expand(
         self,
-        environment: &impl ContextLoaderEnvironment,
+        environment: &impl JsonLdLoaderProvider,
         document: &impl JsonLdNodeObject,
     ) -> Result<ExpandedProofConfiguration, ConfigurationExpansionError>
     where

--- a/crates/claims/crates/data-integrity/core/src/proof/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/mod.rs
@@ -218,18 +218,17 @@ impl<S: DebugCryptographicSuite> fmt::Debug for Proof<S> {
     }
 }
 
-impl<S: CryptographicSuite, T, E, V> ssi_claims_core::ValidateProof<T, E, V> for Proof<S>
+impl<S: CryptographicSuite, T, V> ssi_claims_core::ValidateProof<V, T> for Proof<S>
 where
-    S: CryptographicSuiteVerification<T, E, V>,
+    S: CryptographicSuiteVerification<T, V>,
 {
     async fn validate_proof<'a>(
         &'a self,
-        environment: &'a E,
-        claims: &'a T,
         verifier: &'a V,
+        claims: &'a T,
     ) -> Result<ProofValidity, ProofValidationError> {
         self.suite()
-            .verify_proof(environment, verifier, claims, self.borrowed())
+            .verify_proof(verifier, claims, self.borrowed())
             .await
     }
 }
@@ -325,17 +324,16 @@ impl<S: CryptographicSuite> From<Vec<Proof<S>>> for Proofs<S> {
     }
 }
 
-impl<S: CryptographicSuite, T, E, V> ssi_claims_core::ValidateProof<T, E, V> for Proofs<S>
+impl<S: CryptographicSuite, T, V> ssi_claims_core::ValidateProof<V, T> for Proofs<S>
 where
-    S: CryptographicSuiteVerification<T, E, V>,
+    S: CryptographicSuiteVerification<T, V>,
 {
     async fn validate_proof<'a>(
         &'a self,
-        environment: &'a E,
-        claims: &'a T,
         verifier: &'a V,
+        claims: &'a T,
     ) -> Result<ProofValidity, ProofValidationError> {
-        self.0.validate_proof(environment, claims, verifier).await
+        self.0.validate_proof(verifier, claims).await
     }
 }
 

--- a/crates/claims/crates/data-integrity/core/src/proof/prepared.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/prepared.rs
@@ -50,7 +50,7 @@ impl<T: CryptographicSuite> DerefMut for PreparedProof<T> {
     }
 }
 
-impl<T, S: CryptographicSuite, V> ssi_claims_core::ValidateProof<T, V> for PreparedProof<S>
+impl<T, S: CryptographicSuite, V> ssi_claims_core::ValidateProof<V, T> for PreparedProof<S>
 where
     S: CryptographicSuiteVerification<V>,
 {
@@ -163,7 +163,7 @@ impl<S: CryptographicSuite> ssi_claims_core::UnprepareProof for PreparedProofs<S
     }
 }
 
-impl<T, S: CryptographicSuiteVerification<V>, V> ssi_claims_core::ValidateProof<T, V>
+impl<T, S: CryptographicSuiteVerification<V>, V> ssi_claims_core::ValidateProof<V, T>
     for PreparedProofs<S>
 {
     async fn validate_proof<'a>(

--- a/crates/claims/crates/data-integrity/core/src/suite/standard/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/suite/standard/mod.rs
@@ -1,7 +1,7 @@
 //! Cryptographic suites.
 use std::borrow::Cow;
 
-use ssi_claims_core::{ProofValidationError, ProofValidity, SignatureError};
+use ssi_claims_core::{ProofValidationError, ProofValidity, ResolverEnvironment, SignatureError};
 use ssi_verification_methods_core::{Signer, VerificationMethodResolver, VerificationMethodSet};
 
 use crate::{CryptographicSuite, ProofConfigurationRef, ProofRef, TypeRef};
@@ -140,22 +140,24 @@ where
     }
 }
 
-impl<S: StandardCryptographicSuite, C, E, V> CryptographicSuiteVerification<C, E, V> for S
+impl<S: StandardCryptographicSuite, C, V> CryptographicSuiteVerification<C, V> for S
 where
-    V: VerificationMethodResolver<Method = S::VerificationMethod>,
-    S::Transformation: TypedTransformationAlgorithm<Self, C, E>,
+    V: ResolverEnvironment,
+    V::Resolver: VerificationMethodResolver<Method = S::VerificationMethod>,
+    S::Transformation: TypedTransformationAlgorithm<Self, C, V>,
     S::SignatureAlgorithm: VerificationAlgorithm<S>,
 {
     async fn verify_proof(
         &self,
-        context: &E,
         verifier: &V,
         claims: &C,
         proof: ProofRef<'_, Self>,
     ) -> Result<ProofValidity, ProofValidationError> {
         let proof_configuration = proof.configuration();
 
-        let transformed = self.transform(context, claims, proof_configuration).await?;
+        let transformed = self
+            .transform(verifier, claims, proof_configuration)
+            .await?;
 
         let hashed = self.hash(transformed, proof_configuration)?;
 
@@ -165,6 +167,7 @@ where
 
         // Resolve the verification method.
         let method = verifier
+            .resolver()
             .resolve_verification_method_with(None, Some(proof.verification_method), options)
             .await?;
 

--- a/crates/claims/crates/data-integrity/core/src/suite/standard/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/suite/standard/mod.rs
@@ -1,7 +1,7 @@
 //! Cryptographic suites.
 use std::borrow::Cow;
 
-use ssi_claims_core::{ProofValidationError, ProofValidity, ResolverEnvironment, SignatureError};
+use ssi_claims_core::{ProofValidationError, ProofValidity, ResolverProvider, SignatureError};
 use ssi_verification_methods_core::{Signer, VerificationMethodResolver, VerificationMethodSet};
 
 use crate::{CryptographicSuite, ProofConfigurationRef, ProofRef, TypeRef};
@@ -142,7 +142,7 @@ where
 
 impl<S: StandardCryptographicSuite, C, V> CryptographicSuiteVerification<C, V> for S
 where
-    V: ResolverEnvironment,
+    V: ResolverProvider,
     V::Resolver: VerificationMethodResolver<Method = S::VerificationMethod>,
     S::Transformation: TypedTransformationAlgorithm<Self, C, V>,
     S::SignatureAlgorithm: VerificationAlgorithm<S>,

--- a/crates/claims/crates/data-integrity/core/src/suite/verification.rs
+++ b/crates/claims/crates/data-integrity/core/src/suite/verification.rs
@@ -2,11 +2,10 @@ use super::CryptographicSuite;
 use crate::ProofRef;
 use ssi_claims_core::{ProofValidationError, ProofValidity};
 
-pub trait CryptographicSuiteVerification<T, C, V>: CryptographicSuite {
+pub trait CryptographicSuiteVerification<T, V>: CryptographicSuite {
     #[allow(async_fn_in_trait)]
     async fn verify_proof(
         &self,
-        context: &C,
         verifier: &V,
         claims: &T,
         proof: ProofRef<'_, Self>,

--- a/crates/claims/crates/data-integrity/src/any/macros.rs
+++ b/crates/claims/crates/data-integrity/src/any/macros.rs
@@ -169,18 +169,15 @@ macro_rules! crypto_suites {
         }
 
         #[allow(unused_variables)]
-        impl<T, C, F> ssi_data_integrity_core::suite::CryptographicSuiteVerification<T, C, F> for AnySuite
+        impl<T, V> ssi_data_integrity_core::suite::CryptographicSuiteVerification<T, V> for AnySuite
         where
-            C: ssi_json_ld::ContextLoaderEnvironment
-                + ssi_eip712::Eip712TypesEnvironment,
             T: serde::Serialize + ssi_json_ld::Expandable + ssi_json_ld::JsonLdNodeObject,
-            //
-            F: ssi_verification_methods::VerificationMethodResolver<Method = ssi_verification_methods::AnyMethod>,
+            V: ssi_claims_core::ResolverEnvironment + ssi_json_ld::ContextLoaderEnvironment + ssi_eip712::Eip712TypesEnvironment,
+            V::Resolver: ssi_verification_methods::VerificationMethodResolver<Method = ssi_verification_methods::AnyMethod>,
         {
             async fn verify_proof(
                 &self,
-                environment: &C,
-                verifier: &F,
+                verifier: &V,
                 claims: &T,
                 proof: ssi_data_integrity_core::ProofRef<'_, Self>,
             ) -> Result<ssi_claims_core::ProofValidity, ssi_claims_core::ProofValidationError> {
@@ -188,11 +185,14 @@ macro_rules! crypto_suites {
                     $(
                         $(#[cfg($($t)*)])?
                         Self::$name => {
-                            let verifier = crate::AnyResolver::<_, <ssi_data_integrity_suites::$name as ssi_data_integrity_core::suite::CryptographicSuite>::VerificationMethod>::new(verifier);
+                            let verifier = AnyVerifier {
+                                resolver: crate::AnyResolver::<_, <ssi_data_integrity_suites::$name as ssi_data_integrity_core::suite::CryptographicSuite>::VerificationMethod>::new(verifier.resolver()),
+                                json_ld_loader: verifier.loader(),
+                                eip712_loader: verifier.eip712_types()
+                            };
 
-                            <ssi_data_integrity_suites::$name as ssi_data_integrity_core::suite::CryptographicSuiteVerification<_, _, _>>::verify_proof(
+                            <ssi_data_integrity_suites::$name as ssi_data_integrity_core::suite::CryptographicSuiteVerification<_, _>>::verify_proof(
                                 &ssi_data_integrity_suites::$name,
-                                environment,
                                 &verifier,
                                 claims,
                                 Self::project_proof(proof)

--- a/crates/claims/crates/data-integrity/src/any/macros.rs
+++ b/crates/claims/crates/data-integrity/src/any/macros.rs
@@ -128,8 +128,8 @@ macro_rules! crypto_suites {
         #[allow(unused_variables)]
         impl<T, C, R, S> ssi_data_integrity_core::suite::CryptographicSuiteSigning<T, C, R, S> for AnySuite
         where
-            C: ssi_json_ld::ContextLoaderEnvironment
-                + ssi_eip712::Eip712TypesEnvironment,
+            C: ssi_json_ld::JsonLdLoaderProvider
+                + ssi_eip712::Eip712TypesLoaderProvider,
             T: serde::Serialize + ssi_json_ld::Expandable + ssi_json_ld::JsonLdNodeObject,
             //
             R: ssi_verification_methods::VerificationMethodResolver<Method = ssi_verification_methods::AnyMethod>,
@@ -172,7 +172,7 @@ macro_rules! crypto_suites {
         impl<T, V> ssi_data_integrity_core::suite::CryptographicSuiteVerification<T, V> for AnySuite
         where
             T: serde::Serialize + ssi_json_ld::Expandable + ssi_json_ld::JsonLdNodeObject,
-            V: ssi_claims_core::ResolverEnvironment + ssi_json_ld::ContextLoaderEnvironment + ssi_eip712::Eip712TypesEnvironment,
+            V: ssi_claims_core::ResolverProvider + ssi_json_ld::JsonLdLoaderProvider + ssi_eip712::Eip712TypesLoaderProvider,
             V::Resolver: ssi_verification_methods::VerificationMethodResolver<Method = ssi_verification_methods::AnyMethod>,
         {
             async fn verify_proof(

--- a/crates/claims/crates/data-integrity/src/any/suite/mod.rs
+++ b/crates/claims/crates/data-integrity/src/any/suite/mod.rs
@@ -1,7 +1,7 @@
 mod unknown;
-use ssi_claims_core::ResolverEnvironment;
-use ssi_eip712::Eip712TypesEnvironment;
-use ssi_json_ld::ContextLoaderEnvironment;
+use ssi_claims_core::ResolverProvider;
+use ssi_eip712::Eip712TypesLoaderProvider;
+use ssi_json_ld::JsonLdLoaderProvider;
 pub use unknown::*;
 
 use crate::{macros, AnyResolver};
@@ -147,7 +147,7 @@ pub struct AnyVerifier<R, M, L1, L2> {
     eip712_loader: L2,
 }
 
-impl<R, M, L1, L2> ResolverEnvironment for AnyVerifier<R, M, L1, L2> {
+impl<R, M, L1, L2> ResolverProvider for AnyVerifier<R, M, L1, L2> {
     type Resolver = AnyResolver<R, M>;
 
     fn resolver(&self) -> &Self::Resolver {
@@ -155,7 +155,7 @@ impl<R, M, L1, L2> ResolverEnvironment for AnyVerifier<R, M, L1, L2> {
     }
 }
 
-impl<R, M, L1: ssi_json_ld::Loader, L2> ContextLoaderEnvironment for AnyVerifier<R, M, L1, L2> {
+impl<R, M, L1: ssi_json_ld::Loader, L2> JsonLdLoaderProvider for AnyVerifier<R, M, L1, L2> {
     type Loader = L1;
 
     fn loader(&self) -> &Self::Loader {
@@ -163,10 +163,12 @@ impl<R, M, L1: ssi_json_ld::Loader, L2> ContextLoaderEnvironment for AnyVerifier
     }
 }
 
-impl<R, M, L1, L2: ssi_eip712::TypesProvider> Eip712TypesEnvironment for AnyVerifier<R, M, L1, L2> {
-    type Provider = L2;
+impl<R, M, L1, L2: ssi_eip712::TypesLoader> Eip712TypesLoaderProvider
+    for AnyVerifier<R, M, L1, L2>
+{
+    type Loader = L2;
 
-    fn eip712_types(&self) -> &Self::Provider {
+    fn eip712_types(&self) -> &Self::Loader {
         &self.eip712_loader
     }
 }

--- a/crates/claims/crates/data-integrity/src/any/suite/mod.rs
+++ b/crates/claims/crates/data-integrity/src/any/suite/mod.rs
@@ -1,7 +1,10 @@
 mod unknown;
+use ssi_claims_core::ResolverEnvironment;
+use ssi_eip712::Eip712TypesEnvironment;
+use ssi_json_ld::ContextLoaderEnvironment;
 pub use unknown::*;
 
-use crate::macros;
+use crate::{macros, AnyResolver};
 
 mod pick;
 
@@ -135,5 +138,35 @@ impl AnyProofOptions {
             Self::EthereumEip712Signature2021v0_1(o) => o.eip712.as_mut(),
             _ => None,
         }
+    }
+}
+
+pub struct AnyVerifier<R, M, L1, L2> {
+    resolver: AnyResolver<R, M>,
+    json_ld_loader: L1,
+    eip712_loader: L2,
+}
+
+impl<R, M, L1, L2> ResolverEnvironment for AnyVerifier<R, M, L1, L2> {
+    type Resolver = AnyResolver<R, M>;
+
+    fn resolver(&self) -> &Self::Resolver {
+        &self.resolver
+    }
+}
+
+impl<R, M, L1: ssi_json_ld::Loader, L2> ContextLoaderEnvironment for AnyVerifier<R, M, L1, L2> {
+    type Loader = L1;
+
+    fn loader(&self) -> &Self::Loader {
+        &self.json_ld_loader
+    }
+}
+
+impl<R, M, L1, L2: ssi_eip712::TypesProvider> Eip712TypesEnvironment for AnyVerifier<R, M, L1, L2> {
+    type Provider = L2;
+
+    fn eip712_types(&self) -> &Self::Provider {
+        &self.eip712_loader
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/eip712_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/eip712_signature_2021.rs
@@ -12,7 +12,7 @@ use ssi_data_integrity_core::{
     },
     CryptographicSuite, ProofConfigurationRef, StandardCryptographicSuite, TypeRef,
 };
-use ssi_json_ld::{ContextLoaderEnvironment, Expandable, JsonLdNodeObject};
+use ssi_json_ld::{Expandable, JsonLdLoaderProvider, JsonLdNodeObject};
 use ssi_rdf::{AnyLdEnvironment, LdEnvironment, NQuadsStatement};
 use ssi_verification_methods::{
     ecdsa_secp_256k1_recovery_method_2020, ecdsa_secp_256k1_verification_key_2019,
@@ -106,7 +106,7 @@ impl TransformationAlgorithm<Eip712Signature2021> for Eip712Transformation {
 impl<T, C> TypedTransformationAlgorithm<Eip712Signature2021, T, C> for Eip712Transformation
 where
     T: Expandable + JsonLdNodeObject,
-    C: ContextLoaderEnvironment,
+    C: JsonLdLoaderProvider,
 {
     async fn transform(
         context: &C,

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ethereum_eip712_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ethereum_eip712_signature_2021.rs
@@ -15,7 +15,7 @@ use ssi_data_integrity_core::{
     CryptographicSuite, ProofConfigurationRef, ProofRef, SerializeCryptographicSuite,
     StandardCryptographicSuite, TypeRef,
 };
-use ssi_eip712::{Eip712TypesEnvironment, TypesProvider, Value};
+use ssi_eip712::{Eip712TypesLoaderProvider, TypesLoader, Value};
 use ssi_jwk::algorithm::{AlgorithmError, AnyESKeccakK};
 use ssi_verification_methods::{
     ecdsa_secp_256k1_recovery_method_2020, ecdsa_secp_256k1_verification_key_2019,
@@ -269,7 +269,7 @@ where
     S: SerializeCryptographicSuite,
     S::ProofOptions: AnyEip712Options,
     T: Serialize,
-    C: Eip712TypesEnvironment,
+    C: Eip712TypesLoaderProvider,
 {
     async fn transform(
         context: &C,

--- a/crates/claims/crates/jws/src/compact/bytes.rs
+++ b/crates/claims/crates/jws/src/compact/bytes.rs
@@ -1,8 +1,7 @@
-use crate::{
-    DecodeError, DecodedJWS, DecodedSigningBytes, Header, InvalidHeader, JWSVerifier, JWS,
-};
+use crate::{DecodeError, DecodedJWS, DecodedSigningBytes, Header, InvalidHeader, JWS};
 pub use base64::DecodeError as Base64DecodeError;
-use ssi_claims_core::{ProofValidationError, VerifiableClaims, Verification};
+use ssi_claims_core::{ProofValidationError, ResolverEnvironment, VerifiableClaims, Verification};
+use ssi_jwk::JWKResolver;
 use std::{borrow::Cow, ops::Deref};
 
 /// JWS in compact serialized form.
@@ -165,10 +164,11 @@ impl CompactJWS {
     /// To perform a more precise verification, first decode the JWS with]
     /// [`Self::to_decoded`], then parse the payload manually before using
     /// [`ssi_claims_core::Verifiable`] to actually perform the verification.
-    pub async fn verify(
-        &self,
-        verifier: &impl JWSVerifier,
-    ) -> Result<Verification, ProofValidationError> {
+    pub async fn verify<V>(&self, verifier: V) -> Result<Verification, ProofValidationError>
+    where
+        V: ResolverEnvironment,
+        V::Resolver: JWKResolver,
+    {
         let jws = self.to_decoded().unwrap();
         jws.verify(verifier).await
     }

--- a/crates/claims/crates/jws/src/verification.rs
+++ b/crates/claims/crates/jws/src/verification.rs
@@ -1,9 +1,9 @@
 use crate::{verify_bytes, DecodedJWS, DecodedSigningBytes, Error, Header};
 use ssi_claims_core::{
-    ClaimsValidity, DefaultVerificationEnvironment, InvalidProof, ProofValidationError,
-    ProofValidity, Validate, ValidateProof, VerifiableClaims,
+    ClaimsValidity, InvalidProof, ProofValidationError, ProofValidity, ResolverEnvironment,
+    ValidateClaims, ValidateProof, VerifiableClaims,
 };
-use ssi_jwk::{Algorithm, JWK};
+use ssi_jwk::JWKResolver;
 use std::{
     borrow::{Borrow, Cow},
     ops::Deref,
@@ -25,71 +25,12 @@ impl<'a, E, T: ?Sized + ToOwned + ValidateJWSHeader<E>> ValidateJWSHeader<E> for
     }
 }
 
-impl<E, T: Validate<E, JWSSignature> + ValidateJWSHeader<E>> Validate<E, JWSSignature>
+impl<E, T: ValidateClaims<E, JWSSignature> + ValidateJWSHeader<E>> ValidateClaims<E, JWSSignature>
     for DecodedSigningBytes<T>
 {
-    fn validate(&self, env: &E, proof: &JWSSignature) -> ClaimsValidity {
+    fn validate_claims(&self, env: &E, signature: &JWSSignature) -> ClaimsValidity {
         self.payload.validate_jws_header(env, &self.header)?;
-        self.payload.validate(env, proof)
-    }
-}
-
-/// JWS verifier.
-///
-/// Any type that can fetch a JWK using the `kid` parameter of a JWS JOSE
-/// header.
-pub trait JWSVerifier {
-    /// Fetches a JWK by id.
-    ///
-    /// The key identifier is optional since the key may be known in advance.
-    #[allow(async_fn_in_trait)]
-    async fn fetch_public_jwk(
-        &self,
-        key_id: Option<&str>,
-    ) -> Result<Cow<JWK>, ProofValidationError>;
-
-    #[allow(async_fn_in_trait)]
-    async fn verify(
-        &self,
-        signing_bytes: &[u8],
-        signature: &[u8],
-        key_id: Option<&str>,
-        algorithm: Algorithm,
-    ) -> Result<ProofValidity, ProofValidationError> {
-        let key = self.fetch_public_jwk(key_id).await?;
-        match verify_bytes(algorithm, signing_bytes, &key, signature) {
-            Ok(()) => Ok(Ok(())),
-            Err(Error::InvalidSignature) => Ok(Err(InvalidProof::Signature)),
-            Err(_) => Err(ProofValidationError::InvalidSignature),
-        }
-    }
-}
-
-impl<'a, T: JWSVerifier> JWSVerifier for &'a T {
-    async fn fetch_public_jwk(
-        &self,
-        key_id: Option<&str>,
-    ) -> Result<Cow<JWK>, ProofValidationError> {
-        T::fetch_public_jwk(*self, key_id).await
-    }
-
-    async fn verify(
-        &self,
-        signing_bytes: &[u8],
-        signature: &[u8],
-        key_id: Option<&str>,
-        algorithm: Algorithm,
-    ) -> Result<ProofValidity, ProofValidationError> {
-        T::verify(*self, signing_bytes, signature, key_id, algorithm).await
-    }
-}
-
-impl JWSVerifier for JWK {
-    async fn fetch_public_jwk(
-        &self,
-        _key_id: Option<&str>,
-    ) -> Result<Cow<JWK>, ProofValidationError> {
-        Ok(Cow::Borrowed(self))
+        self.payload.validate_claims(env, signature)
     }
 }
 
@@ -151,27 +92,24 @@ impl<T> VerifiableClaims for DecodedJWS<T> {
     }
 }
 
-impl<T: DefaultVerificationEnvironment> DefaultVerificationEnvironment for DecodedJWS<T> {
-    type Environment = ();
-}
-
-impl<T, E, V> ValidateProof<DecodedSigningBytes<T>, E, V> for JWSSignature
+impl<V, T> ValidateProof<V, DecodedSigningBytes<T>> for JWSSignature
 where
-    V: JWSVerifier,
+    V: ResolverEnvironment,
+    V::Resolver: JWKResolver,
 {
     async fn validate_proof<'a>(
         &'a self,
-        _environment: &'a E,
-        claims: &'a DecodedSigningBytes<T>,
         verifier: &'a V,
+        claims: &'a DecodedSigningBytes<T>,
     ) -> Result<ProofValidity, ProofValidationError> {
-        verifier
-            .verify(
-                &claims.bytes,
-                &self.0,
-                claims.header.key_id.as_deref(),
-                claims.header.algorithm,
-            )
-            .await
+        let key = verifier
+            .resolver()
+            .fetch_public_jwk(claims.header.key_id.as_deref())
+            .await?;
+        match verify_bytes(claims.header.algorithm, &claims.bytes, &key, &self.0) {
+            Ok(()) => Ok(Ok(())),
+            Err(Error::InvalidSignature) => Ok(Err(InvalidProof::Signature)),
+            Err(_) => Err(ProofValidationError::InvalidSignature),
+        }
     }
 }

--- a/crates/claims/crates/jws/src/verification.rs
+++ b/crates/claims/crates/jws/src/verification.rs
@@ -1,6 +1,6 @@
 use crate::{verify_bytes, DecodedJWS, DecodedSigningBytes, Error, Header};
 use ssi_claims_core::{
-    ClaimsValidity, InvalidProof, ProofValidationError, ProofValidity, ResolverEnvironment,
+    ClaimsValidity, InvalidProof, ProofValidationError, ProofValidity, ResolverProvider,
     ValidateClaims, ValidateProof, VerifiableClaims,
 };
 use ssi_jwk::JWKResolver;
@@ -94,7 +94,7 @@ impl<T> VerifiableClaims for DecodedJWS<T> {
 
 impl<V, T> ValidateProof<V, DecodedSigningBytes<T>> for JWSSignature
 where
-    V: ResolverEnvironment,
+    V: ResolverProvider,
     V::Resolver: JWKResolver,
 {
     async fn validate_proof<'a>(

--- a/crates/claims/crates/jwt/src/claims/any.rs
+++ b/crates/claims/crates/jwt/src/claims/any.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, ValidateClaims};
 
 use crate::{Claim, ClaimSet};
 
@@ -77,7 +77,7 @@ impl ClaimSet for AnyClaims {
 
 impl<E, P> ValidateClaims<E, P> for AnyClaims
 where
-    E: DateTimeEnvironment,
+    E: DateTimeProvider,
 {
     fn validate_claims(&self, env: &E, _proof: &P) -> ClaimsValidity {
         ClaimSet::validate_registered_claims(self, env)

--- a/crates/claims/crates/jwt/src/claims/any.rs
+++ b/crates/claims/crates/jwt/src/claims/any.rs
@@ -1,8 +1,6 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
-use ssi_claims_core::{
-    ClaimsValidity, DateTimeEnvironment, DefaultVerificationEnvironment, Validate,
-};
+use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
 
 use crate::{Claim, ClaimSet};
 
@@ -77,15 +75,11 @@ impl ClaimSet for AnyClaims {
     }
 }
 
-impl<E, P> Validate<E, P> for AnyClaims
+impl<E, P> ValidateClaims<E, P> for AnyClaims
 where
     E: DateTimeEnvironment,
 {
-    fn validate(&self, env: &E, _proof: &P) -> ClaimsValidity {
+    fn validate_claims(&self, env: &E, _proof: &P) -> ClaimsValidity {
         ClaimSet::validate_registered_claims(self, env)
     }
-}
-
-impl DefaultVerificationEnvironment for AnyClaims {
-    type Environment = ();
 }

--- a/crates/claims/crates/jwt/src/claims/mixed/mod.rs
+++ b/crates/claims/crates/jwt/src/claims/mixed/mod.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, ValidateClaims};
 use ssi_jws::{JWSPayload, ValidateJWSHeader};
 use std::borrow::Cow;
 
@@ -83,7 +83,7 @@ impl<T, E> ValidateJWSHeader<E> for JWTClaims<T> {
 
 impl<P, T: ClaimSet + ValidateClaims<E, P>, E> ValidateClaims<E, P> for JWTClaims<T>
 where
-    E: DateTimeEnvironment,
+    E: DateTimeProvider,
 {
     fn validate_claims(&self, env: &E, proof: &P) -> ClaimsValidity {
         self.registered.validate_claims(env, proof)?;

--- a/crates/claims/crates/jwt/src/claims/mixed/mod.rs
+++ b/crates/claims/crates/jwt/src/claims/mixed/mod.rs
@@ -1,7 +1,5 @@
 use serde::Serialize;
-use ssi_claims_core::{
-    ClaimsValidity, DateTimeEnvironment, DefaultVerificationEnvironment, Validate,
-};
+use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
 use ssi_jws::{JWSPayload, ValidateJWSHeader};
 use std::borrow::Cow;
 
@@ -83,19 +81,12 @@ impl<T, E> ValidateJWSHeader<E> for JWTClaims<T> {
     }
 }
 
-impl<T: ClaimSet + Validate<E, P>, E, P> Validate<E, P> for JWTClaims<T>
+impl<P, T: ClaimSet + ValidateClaims<E, P>, E> ValidateClaims<E, P> for JWTClaims<T>
 where
     E: DateTimeEnvironment,
 {
-    fn validate(&self, env: &E, proof: &P) -> ClaimsValidity {
-        Validate::<E, P>::validate(&self.registered, env, proof)?;
-        self.private.validate(env, proof)
+    fn validate_claims(&self, env: &E, proof: &P) -> ClaimsValidity {
+        self.registered.validate_claims(env, proof)?;
+        self.private.validate_claims(env, proof)
     }
-}
-
-impl<T: DefaultVerificationEnvironment> DefaultVerificationEnvironment for JWTClaims<T>
-where
-    T::Environment: DateTimeEnvironment,
-{
-    type Environment = T::Environment;
 }

--- a/crates/claims/crates/jwt/src/claims/mod.rs
+++ b/crates/claims/crates/jwt/src/claims/mod.rs
@@ -11,7 +11,7 @@ pub use matching::*;
 mod any;
 pub use any::*;
 use serde::{de::DeserializeOwned, Serialize};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, InvalidClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, InvalidClaims};
 
 /// JWT claim.
 pub trait Claim: 'static + Clone + Serialize + DeserializeOwned {
@@ -32,7 +32,7 @@ pub trait ClaimSet {
 
     fn validate_registered_claims<E>(&self, env: &E) -> ClaimsValidity
     where
-        E: DateTimeEnvironment,
+        E: DateTimeProvider,
     {
         let now = env.date_time();
 

--- a/crates/claims/crates/jwt/src/claims/registered.rs
+++ b/crates/claims/crates/jwt/src/claims/registered.rs
@@ -1,6 +1,6 @@
 use super::{Claim, JWTClaims};
 use crate::{CastClaim, ClaimSet, NumericDate, StringOrURI};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, ValidateClaims};
 use ssi_core::OneOrMany;
 use ssi_jws::JWSPayload;
 use std::{borrow::Cow, collections::BTreeMap};
@@ -87,7 +87,7 @@ impl JWSPayload for RegisteredClaims {
 
 impl<E, P> ValidateClaims<E, P> for RegisteredClaims
 where
-    E: DateTimeEnvironment,
+    E: DateTimeProvider,
 {
     fn validate_claims(&self, env: &E, _proof: &P) -> ClaimsValidity {
         ClaimSet::validate_registered_claims(self, env)

--- a/crates/claims/crates/jwt/src/claims/registered.rs
+++ b/crates/claims/crates/jwt/src/claims/registered.rs
@@ -1,6 +1,6 @@
 use super::{Claim, JWTClaims};
 use crate::{CastClaim, ClaimSet, NumericDate, StringOrURI};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, Validate};
+use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
 use ssi_core::OneOrMany;
 use ssi_jws::JWSPayload;
 use std::{borrow::Cow, collections::BTreeMap};
@@ -85,11 +85,11 @@ impl JWSPayload for RegisteredClaims {
     }
 }
 
-impl<E, P> Validate<E, P> for RegisteredClaims
+impl<E, P> ValidateClaims<E, P> for RegisteredClaims
 where
     E: DateTimeEnvironment,
 {
-    fn validate(&self, env: &E, _proof: &P) -> ClaimsValidity {
+    fn validate_claims(&self, env: &E, _proof: &P) -> ClaimsValidity {
         ClaimSet::validate_registered_claims(self, env)
     }
 }

--- a/crates/claims/crates/jwt/src/decoding.rs
+++ b/crates/claims/crates/jwt/src/decoding.rs
@@ -1,8 +1,11 @@
 use serde::de::DeserializeOwned;
-use ssi_claims_core::{ProofValidationError, VerifiableClaims, Verification};
+use ssi_claims_core::{
+    DateTimeEnvironment, ProofValidationError, ResolverEnvironment, VerifiableClaims, Verification,
+};
+use ssi_jwk::JWKResolver;
 use ssi_jws::{
     CompactJWS, CompactJWSBuf, CompactJWSStr, CompactJWSString, DecodeError as JWSDecodeError,
-    DecodedJWS, JWSVerifier,
+    DecodedJWS,
 };
 
 use crate::{AnyClaims, JWTClaims};
@@ -41,10 +44,11 @@ pub trait ToDecodedJWT {
     ///
     /// This check the signature and the validity of registered claims.
     #[allow(async_fn_in_trait)]
-    async fn verify_jwt(
-        &self,
-        verifier: &impl JWSVerifier,
-    ) -> Result<Verification, ProofValidationError> {
+    async fn verify_jwt<V>(&self, verifier: V) -> Result<Verification, ProofValidationError>
+    where
+        V: ResolverEnvironment + DateTimeEnvironment,
+        V::Resolver: JWKResolver,
+    {
         self.to_decoded_jwt()?.verify(verifier).await
     }
 }

--- a/crates/claims/crates/jwt/src/decoding.rs
+++ b/crates/claims/crates/jwt/src/decoding.rs
@@ -1,7 +1,5 @@
 use serde::de::DeserializeOwned;
-use ssi_claims_core::{
-    DateTimeEnvironment, ProofValidationError, ResolverEnvironment, VerifiableClaims, Verification,
-};
+use ssi_claims_core::{DateTimeProvider, ProofValidationError, ResolverProvider, Verification};
 use ssi_jwk::JWKResolver;
 use ssi_jws::{
     CompactJWS, CompactJWSBuf, CompactJWSStr, CompactJWSString, DecodeError as JWSDecodeError,
@@ -44,9 +42,9 @@ pub trait ToDecodedJWT {
     ///
     /// This check the signature and the validity of registered claims.
     #[allow(async_fn_in_trait)]
-    async fn verify_jwt<V>(&self, verifier: V) -> Result<Verification, ProofValidationError>
+    async fn verify_jwt<V>(&self, verifier: &V) -> Result<Verification, ProofValidationError>
     where
-        V: ResolverEnvironment + DateTimeEnvironment,
+        V: ResolverProvider + DateTimeProvider,
         V::Resolver: JWKResolver,
     {
         self.to_decoded_jwt()?.verify(verifier).await

--- a/crates/claims/crates/status/Cargo.toml
+++ b/crates/claims/crates/status/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/ssi-token-status-list/"
 
 [dependencies]
 ssi-claims-core.workspace = true
+ssi-jwk.workspace = true
 ssi-jwt.workspace = true
 ssi-jws.workspace = true
 ssi-vc.workspace = true
@@ -31,7 +32,6 @@ flate2 = "1.0.28"
 
 [dev-dependencies]
 ssi-jws = { workspace = true, features = ["secp256r1"] }
-ssi-jwk.workspace = true
 ssi-dids.workspace = true
 ssi-data-integrity = { workspace = true, features = ["w3c"] }
 tokio = { version = "1.0", features = ["macros", "rt"] }

--- a/crates/claims/crates/status/Cargo.toml
+++ b/crates/claims/crates/status/Cargo.toml
@@ -31,7 +31,7 @@ parking_lot = "0.12.1"
 flate2 = "1.0.28"
 
 [dev-dependencies]
-ssi-jws = { workspace = true, features = ["secp256r1"] }
+ssi-jwk = { workspace = true, features = ["secp256r1"] }
 ssi-dids.workspace = true
 ssi-data-integrity = { workspace = true, features = ["w3c"] }
 tokio = { version = "1.0", features = ["macros", "rt"] }

--- a/crates/claims/crates/status/examples/status_list.rs
+++ b/crates/claims/crates/status/examples/status_list.rs
@@ -16,7 +16,7 @@
 use clap::{Parser, Subcommand};
 use core::fmt;
 use iref::UriBuf;
-use ssi_claims_core::Verifier;
+use ssi_claims_core::VerificationParameters;
 use ssi_data_integrity::{AnySuite, ProofOptions};
 use ssi_dids::{VerificationMethodDIDResolver, DIDJWK};
 use ssi_jwk::JWK;
@@ -119,7 +119,9 @@ impl Command {
                     Err(e) => return Err(Error::ReadFile(source, e)),
                 };
 
-                let verifier = Verifier::from_resolver(VerificationMethodDIDResolver::new(DIDJWK));
+                let verifier = VerificationParameters::from_resolver(
+                    VerificationMethodDIDResolver::new(DIDJWK),
+                );
                 let status_list = AnyStatusMap::from_bytes_with(
                     &bytes,
                     &media_type,

--- a/crates/claims/crates/status/examples/status_list.rs
+++ b/crates/claims/crates/status/examples/status_list.rs
@@ -16,6 +16,7 @@
 use clap::{Parser, Subcommand};
 use core::fmt;
 use iref::UriBuf;
+use ssi_claims_core::Verifier;
 use ssi_data_integrity::{AnySuite, ProofOptions};
 use ssi_dids::{VerificationMethodDIDResolver, DIDJWK};
 use ssi_jwk::JWK;
@@ -118,7 +119,7 @@ impl Command {
                     Err(e) => return Err(Error::ReadFile(source, e)),
                 };
 
-                let verifier = VerificationMethodDIDResolver::new(DIDJWK);
+                let verifier = Verifier::from_resolver(VerificationMethodDIDResolver::new(DIDJWK));
                 let status_list = AnyStatusMap::from_bytes_with(
                     &bytes,
                     &media_type,

--- a/crates/claims/crates/status/examples/status_list_client.rs
+++ b/crates/claims/crates/status/examples/status_list_client.rs
@@ -24,6 +24,7 @@
 //! ```
 use clap::Parser;
 use core::fmt;
+use ssi_claims_core::Verifier;
 use ssi_dids::{VerificationMethodDIDResolver, DIDJWK};
 use ssi_status::{
     any::{AnyEntrySet, AnyStatusMap},
@@ -95,7 +96,7 @@ async fn run(args: Args) -> Result<(), Error> {
         Err(e) => return Err(Error::ReadFile(input, e)),
     };
 
-    let verifier = VerificationMethodDIDResolver::new(DIDJWK);
+    let verifier = Verifier::from_resolver(VerificationMethodDIDResolver::new(DIDJWK));
 
     let entry_set = AnyEntrySet::from_bytes(&bytes, &args.media_type, &verifier)
         .await

--- a/crates/claims/crates/status/examples/status_list_client.rs
+++ b/crates/claims/crates/status/examples/status_list_client.rs
@@ -24,7 +24,7 @@
 //! ```
 use clap::Parser;
 use core::fmt;
-use ssi_claims_core::Verifier;
+use ssi_claims_core::VerificationParameters;
 use ssi_dids::{VerificationMethodDIDResolver, DIDJWK};
 use ssi_status::{
     any::{AnyEntrySet, AnyStatusMap},
@@ -96,7 +96,8 @@ async fn run(args: Args) -> Result<(), Error> {
         Err(e) => return Err(Error::ReadFile(input, e)),
     };
 
-    let verifier = Verifier::from_resolver(VerificationMethodDIDResolver::new(DIDJWK));
+    let verifier =
+        VerificationParameters::from_resolver(VerificationMethodDIDResolver::new(DIDJWK));
 
     let entry_set = AnyEntrySet::from_bytes(&bytes, &args.media_type, &verifier)
         .await

--- a/crates/claims/crates/status/examples/status_list_server.rs
+++ b/crates/claims/crates/status/examples/status_list_server.rs
@@ -22,6 +22,7 @@ use hyper::{
     Request, Response,
 };
 use hyper_util::rt::TokioIo;
+use ssi_claims_core::Verifier;
 use ssi_dids::{VerificationMethodDIDResolver, DIDJWK};
 use ssi_status::{any::AnyStatusMap, FromBytes, FromBytesOptions};
 use std::{
@@ -77,7 +78,7 @@ async fn run(args: Args) -> Result<(), Error> {
         Err(e) => return Err(Error::ReadFile(input, e)),
     };
 
-    let verifier = VerificationMethodDIDResolver::new(DIDJWK);
+    let verifier = Verifier::from_resolver(VerificationMethodDIDResolver::new(DIDJWK));
 
     let status_list = AnyStatusMap::from_bytes_with(
         &bytes,

--- a/crates/claims/crates/status/examples/status_list_server.rs
+++ b/crates/claims/crates/status/examples/status_list_server.rs
@@ -22,7 +22,7 @@ use hyper::{
     Request, Response,
 };
 use hyper_util::rt::TokioIo;
-use ssi_claims_core::Verifier;
+use ssi_claims_core::VerificationParameters;
 use ssi_dids::{VerificationMethodDIDResolver, DIDJWK};
 use ssi_status::{any::AnyStatusMap, FromBytes, FromBytesOptions};
 use std::{
@@ -78,7 +78,8 @@ async fn run(args: Args) -> Result<(), Error> {
         Err(e) => return Err(Error::ReadFile(input, e)),
     };
 
-    let verifier = Verifier::from_resolver(VerificationMethodDIDResolver::new(DIDJWK));
+    let verifier =
+        VerificationParameters::from_resolver(VerificationMethodDIDResolver::new(DIDJWK));
 
     let status_list = AnyStatusMap::from_bytes_with(
         &bytes,

--- a/crates/claims/crates/status/src/impl/any.rs
+++ b/crates/claims/crates/status/src/impl/any.rs
@@ -1,7 +1,8 @@
 use iref::Uri;
-use ssi_claims_core::{ValidateProof, VerificationEnvironment};
-use ssi_data_integrity::AnyProofs;
-use ssi_jws::JWSVerifier;
+use ssi_claims_core::{DateTimeEnvironment, Eip712TypesEnvironment, ResolverEnvironment};
+use ssi_json_ld::ContextLoaderEnvironment;
+use ssi_jwk::JWKResolver;
+use ssi_verification_methods::{AnyMethod, VerificationMethodResolver};
 
 use crate::{
     bitstream_status_list::{
@@ -41,8 +42,11 @@ pub enum FromBytesError {
 
 impl<V> FromBytes<V> for AnyStatusMap
 where
-    V: JWSVerifier,
-    AnyProofs: ValidateProof<BitstringStatusListCredential, VerificationEnvironment, V>,
+    V: ResolverEnvironment
+        + DateTimeEnvironment
+        + ContextLoaderEnvironment
+        + Eip712TypesEnvironment,
+    V::Resolver: JWKResolver + VerificationMethodResolver<Method = AnyMethod>,
 {
     type Error = FromBytesError;
 
@@ -178,8 +182,11 @@ pub enum AnyEntrySet {
 
 impl<V> FromBytes<V> for AnyEntrySet
 where
-    V: JWSVerifier,
-    AnyProofs: ValidateProof<BitstringStatusListEntrySetCredential, VerificationEnvironment, V>,
+    V: ResolverEnvironment
+        + DateTimeEnvironment
+        + ContextLoaderEnvironment
+        + Eip712TypesEnvironment,
+    V::Resolver: JWKResolver + VerificationMethodResolver<Method = AnyMethod>,
 {
     type Error = EntrySetFromBytesError;
 

--- a/crates/claims/crates/status/src/impl/token_status_list/json.rs
+++ b/crates/claims/crates/status/src/impl/token_status_list/json.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use flate2::Compression;
 use iref::UriBuf;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{DefaultVerificationEnvironment, Validate};
+use ssi_claims_core::ValidateClaims;
 use ssi_jws::ValidateJWSHeader;
 use ssi_jwt::{match_claim_type, AnyClaims, Claim, ClaimSet, IssuedAt, Issuer, JWTClaims, Subject};
 
@@ -137,8 +137,8 @@ impl ClaimSet for StatusListJwtPrivateClaims {
     }
 }
 
-impl<E, P> Validate<E, P> for StatusListJwtPrivateClaims {
-    fn validate(&self, _env: &E, _proof: &P) -> ssi_claims_core::ClaimsValidity {
+impl<E, P> ValidateClaims<E, P> for StatusListJwtPrivateClaims {
+    fn validate_claims(&self, _env: &E, _proof: &P) -> ssi_claims_core::ClaimsValidity {
         Ok(())
     }
 }
@@ -151,10 +151,6 @@ impl<E> ValidateJWSHeader<E> for StatusListJwtPrivateClaims {
     ) -> ssi_claims_core::ClaimsValidity {
         Ok(())
     }
-}
-
-impl DefaultVerificationEnvironment for StatusListJwtPrivateClaims {
-    type Environment = ();
 }
 
 /// Time to live JWT claim.

--- a/crates/claims/crates/status/src/impl/token_status_list/mod.rs
+++ b/crates/claims/crates/status/src/impl/token_status_list/mod.rs
@@ -11,6 +11,7 @@
 use flate2::{bufread::ZlibDecoder, write::ZlibEncoder, Compression};
 use iref::Uri;
 use serde::Serialize;
+use ssi_claims_core::{DateTimeEnvironment, ResolverEnvironment};
 use std::{
     io::{self, Read, Write},
     time::Duration,
@@ -20,7 +21,8 @@ pub mod cbor;
 pub mod json;
 
 pub use json::StatusListJwt;
-use ssi_jws::{CompactJWS, InvalidCompactJWS, JWSVerifier};
+use ssi_jwk::JWKResolver;
+use ssi_jws::{CompactJWS, InvalidCompactJWS};
 use ssi_jwt::{ClaimSet, JWTClaims, ToDecodedJWT};
 
 use crate::{
@@ -92,7 +94,11 @@ pub enum FromBytesError {
     Rejected(#[from] ssi_claims_core::Invalid),
 }
 
-impl<V: JWSVerifier> FromBytes<V> for StatusListToken {
+impl<V> FromBytes<V> for StatusListToken
+where
+    V: ResolverEnvironment + DateTimeEnvironment,
+    V::Resolver: JWKResolver,
+{
     type Error = FromBytesError;
 
     async fn from_bytes_with(
@@ -487,7 +493,11 @@ pub enum AnyStatusListEntrySet {
     Json(json::Status),
 }
 
-impl<V: JWSVerifier> FromBytes<V> for AnyStatusListEntrySet {
+impl<V> FromBytes<V> for AnyStatusListEntrySet
+where
+    V: ResolverEnvironment + DateTimeEnvironment,
+    V::Resolver: JWKResolver,
+{
     type Error = EntrySetFromBytesError;
 
     async fn from_bytes_with(

--- a/crates/claims/crates/status/src/impl/token_status_list/mod.rs
+++ b/crates/claims/crates/status/src/impl/token_status_list/mod.rs
@@ -11,7 +11,7 @@
 use flate2::{bufread::ZlibDecoder, write::ZlibEncoder, Compression};
 use iref::Uri;
 use serde::Serialize;
-use ssi_claims_core::{DateTimeEnvironment, ResolverEnvironment};
+use ssi_claims_core::{DateTimeProvider, ResolverProvider};
 use std::{
     io::{self, Read, Write},
     time::Duration,
@@ -96,7 +96,7 @@ pub enum FromBytesError {
 
 impl<V> FromBytes<V> for StatusListToken
 where
-    V: ResolverEnvironment + DateTimeEnvironment,
+    V: ResolverProvider + DateTimeProvider,
     V::Resolver: JWKResolver,
 {
     type Error = FromBytesError;
@@ -109,7 +109,6 @@ where
     ) -> Result<Self, Self::Error> {
         match media_type {
             "statuslist+jwt" => {
-                use ssi_claims_core::VerifiableClaims;
                 let jwt = CompactJWS::new(bytes)
                     .map_err(InvalidCompactJWS::into_owned)?
                     .to_decoded_custom_jwt::<json::StatusListJwtPrivateClaims>()?;
@@ -495,7 +494,7 @@ pub enum AnyStatusListEntrySet {
 
 impl<V> FromBytes<V> for AnyStatusListEntrySet
 where
-    V: ResolverEnvironment + DateTimeEnvironment,
+    V: ResolverProvider + DateTimeProvider,
     V::Resolver: JWKResolver,
 {
     type Error = EntrySetFromBytesError;
@@ -517,7 +516,6 @@ where
                 ))
             }
             "application/jwt" => {
-                use ssi_claims_core::VerifiableClaims;
                 let jwt = CompactJWS::new(bytes)
                     .map_err(InvalidCompactJWS::into_owned)?
                     .to_decoded_jwt()?;

--- a/crates/claims/crates/status/src/lib.rs
+++ b/crates/claims/crates/status/src/lib.rs
@@ -31,7 +31,7 @@ pub trait FromBytes<V>: Sized {
     async fn from_bytes_with(
         bytes: &[u8],
         media_type: &str,
-        verifier: &V,
+        verification_params: &V,
         options: FromBytesOptions,
     ) -> Result<Self, Self::Error>;
 

--- a/crates/claims/crates/vc/examples/sign.rs
+++ b/crates/claims/crates/vc/examples/sign.rs
@@ -3,7 +3,7 @@
 use iref::{Iri, IriBuf, Uri, UriBuf};
 use linked_data::{LinkedDataResource, LinkedDataSubject};
 use rand_chacha::rand_core::SeedableRng;
-use ssi_claims_core::VerifiableClaims;
+use ssi_claims_core::{VerifiableClaims, Verifier};
 use ssi_data_integrity::{suites::Ed25519Signature2020, CryptographicSuite, ProofOptions};
 use ssi_json_ld::{Expandable, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, VocabularyMut};
@@ -50,11 +50,11 @@ impl ssi_json_ld::JsonLdNodeObject for Credential {
     }
 }
 
-impl<E, P> ssi_claims_core::Validate<E, P> for Credential
+impl<E, P> ssi_claims_core::ValidateClaims<E, P> for Credential
 where
     E: ssi_claims_core::DateTimeEnvironment,
 {
-    fn validate(&self, env: &E, _proof: &P) -> ssi_claims_core::ClaimsValidity {
+    fn validate_claims(&self, env: &E, _proof: &P) -> ssi_claims_core::ClaimsValidity {
         ssi_vc::v1::Credential::validate_credential(self, env)
     }
 }
@@ -173,7 +173,7 @@ async fn main() {
 
     // Verify the generated verifiable credential.
     verifiable_credential
-        .verify(&keyring)
+        .verify(Verifier::from_resolver(keyring))
         .await
         .expect("verification failed")
         .expect("invalid proof");

--- a/crates/claims/crates/vc/examples/sign.rs
+++ b/crates/claims/crates/vc/examples/sign.rs
@@ -3,7 +3,7 @@
 use iref::{Iri, IriBuf, Uri, UriBuf};
 use linked_data::{LinkedDataResource, LinkedDataSubject};
 use rand_chacha::rand_core::SeedableRng;
-use ssi_claims_core::{VerifiableClaims, Verifier};
+use ssi_claims_core::VerificationParameters;
 use ssi_data_integrity::{suites::Ed25519Signature2020, CryptographicSuite, ProofOptions};
 use ssi_json_ld::{Expandable, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, VocabularyMut};
@@ -52,7 +52,7 @@ impl ssi_json_ld::JsonLdNodeObject for Credential {
 
 impl<E, P> ssi_claims_core::ValidateClaims<E, P> for Credential
 where
-    E: ssi_claims_core::DateTimeEnvironment,
+    E: ssi_claims_core::DateTimeProvider,
 {
     fn validate_claims(&self, env: &E, _proof: &P) -> ssi_claims_core::ClaimsValidity {
         ssi_vc::v1::Credential::validate_credential(self, env)
@@ -173,7 +173,7 @@ async fn main() {
 
     // Verify the generated verifiable credential.
     verifiable_credential
-        .verify(Verifier::from_resolver(keyring))
+        .verify(VerificationParameters::from_resolver(keyring))
         .await
         .expect("verification failed")
         .expect("invalid proof");

--- a/crates/claims/crates/vc/src/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/syntax/credential.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, hash::Hash};
 use iref::Uri;
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, Validate};
+use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, LinkedDataResource, LinkedDataSubject, Vocabulary};
 
@@ -52,14 +52,14 @@ impl<S, C, T> JsonLdNodeObject for AnySpecializedJsonCredential<S, C, T> {
     }
 }
 
-impl<S, C, T, E, P> Validate<E, P> for AnySpecializedJsonCredential<S, C, T>
+impl<S, C, T, E, P> ValidateClaims<E, P> for AnySpecializedJsonCredential<S, C, T>
 where
     E: DateTimeEnvironment,
 {
-    fn validate(&self, env: &E, proof: &P) -> ClaimsValidity {
+    fn validate_claims(&self, env: &E, proof: &P) -> ClaimsValidity {
         match self {
-            Self::V1(c) => c.validate(env, proof),
-            Self::V2(c) => c.validate(env, proof),
+            Self::V1(c) => c.validate_claims(env, proof),
+            Self::V2(c) => c.validate_claims(env, proof),
         }
     }
 }

--- a/crates/claims/crates/vc/src/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/syntax/credential.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, hash::Hash};
 use iref::Uri;
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, LinkedDataResource, LinkedDataSubject, Vocabulary};
 
@@ -54,7 +54,7 @@ impl<S, C, T> JsonLdNodeObject for AnySpecializedJsonCredential<S, C, T> {
 
 impl<S, C, T, E, P> ValidateClaims<E, P> for AnySpecializedJsonCredential<S, C, T>
 where
-    E: DateTimeEnvironment,
+    E: DateTimeProvider,
 {
     fn validate_claims(&self, env: &E, proof: &P) -> ClaimsValidity {
         match self {

--- a/crates/claims/crates/vc/src/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/syntax/presentation.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, hash::Hash};
 
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, Validate};
+use ssi_claims_core::{ClaimsValidity, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, LinkedDataResource, LinkedDataSubject, Vocabulary};
 
@@ -34,11 +34,11 @@ impl<C1, C2> JsonLdNodeObject for AnyJsonPresentation<C1, C2> {
     }
 }
 
-impl<C1, C2, E, P> Validate<E, P> for AnyJsonPresentation<C1, C2> {
-    fn validate(&self, env: &E, proof: &P) -> ClaimsValidity {
+impl<C1, C2, E, P> ValidateClaims<E, P> for AnyJsonPresentation<C1, C2> {
+    fn validate_claims(&self, env: &E, proof: &P) -> ClaimsValidity {
         match self {
-            Self::V1(p) => Validate::<E, P>::validate(p, env, proof),
-            Self::V2(p) => Validate::<E, P>::validate(p, env, proof),
+            Self::V1(p) => p.validate_claims(env, proof),
+            Self::V2(p) => p.validate_claims(env, proof),
         }
     }
 }

--- a/crates/claims/crates/vc/src/v1/data_model/credential.rs
+++ b/crates/claims/crates/vc/src/v1/data_model/credential.rs
@@ -1,5 +1,5 @@
 use iref::{Iri, Uri};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, InvalidClaims, VerifiableClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, InvalidClaims, VerifiableClaims};
 use ssi_data_integrity::{CryptographicSuite, DataIntegrity};
 use static_iref::iri;
 use xsd_types::DateTime;
@@ -132,7 +132,7 @@ pub trait Credential {
     /// verified.
     fn validate_credential<E>(&self, env: &E) -> ClaimsValidity
     where
-        E: DateTimeEnvironment,
+        E: DateTimeProvider,
     {
         let now = env.date_time();
 

--- a/crates/claims/crates/vc/src/v1/revocation/v2020.rs
+++ b/crates/claims/crates/vc/src/v1/revocation/v2020.rs
@@ -5,7 +5,7 @@ use bitvec::prelude::Lsb0;
 use bitvec::vec::BitVec;
 use iref::UriBuf;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{VerifiableClaims, Verifier};
+use ssi_claims_core::VerificationParameters;
 use ssi_data_integrity::AnyDataIntegrity;
 use ssi_json_ld::REVOCATION_LIST_2020_V1_CONTEXT;
 use ssi_verification_methods::{AnyMethod, VerificationMethodResolver};
@@ -153,8 +153,8 @@ impl CredentialStatus for RevocationList2020Status {
             )));
         }
 
-        let verifier = Verifier::from_resolver(resolver);
-        let vc_result = revocation_list_credential.verify(verifier).await?;
+        let params = VerificationParameters::from_resolver(resolver);
+        let vc_result = revocation_list_credential.verify(&params).await?;
 
         if let Err(e) = vc_result {
             return Ok(StatusCheck::Invalid(Reason::CredentialVerification(e)));

--- a/crates/claims/crates/vc/src/v1/revocation/v2020.rs
+++ b/crates/claims/crates/vc/src/v1/revocation/v2020.rs
@@ -5,7 +5,7 @@ use bitvec::prelude::Lsb0;
 use bitvec::vec::BitVec;
 use iref::UriBuf;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::VerifiableClaims;
+use ssi_claims_core::{VerifiableClaims, Verifier};
 use ssi_data_integrity::AnyDataIntegrity;
 use ssi_json_ld::REVOCATION_LIST_2020_V1_CONTEXT;
 use ssi_verification_methods::{AnyMethod, VerificationMethodResolver};
@@ -153,7 +153,8 @@ impl CredentialStatus for RevocationList2020Status {
             )));
         }
 
-        let vc_result = revocation_list_credential.verify(resolver).await?;
+        let verifier = Verifier::from_resolver(resolver);
+        let vc_result = revocation_list_credential.verify(verifier).await?;
 
         if let Err(e) = vc_result {
             return Ok(StatusCheck::Invalid(Reason::CredentialVerification(e)));

--- a/crates/claims/crates/vc/src/v1/revocation/v2021.rs
+++ b/crates/claims/crates/vc/src/v1/revocation/v2021.rs
@@ -5,7 +5,7 @@ use bitvec::prelude::Lsb0;
 use bitvec::vec::BitVec;
 use iref::UriBuf;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{VerifiableClaims, Verifier};
+use ssi_claims_core::VerificationParameters;
 use ssi_data_integrity::AnyDataIntegrity;
 use ssi_json_ld::STATUS_LIST_2021_V1_CONTEXT;
 use ssi_verification_methods::{AnyMethod, VerificationMethodResolver};
@@ -178,8 +178,8 @@ impl CredentialStatus for StatusList2021Entry {
             )));
         }
 
-        let verifier = Verifier::from_resolver(resolver);
-        let vc_result = status_list_credential.verify(verifier).await?;
+        let params = VerificationParameters::from_resolver(resolver);
+        let vc_result = status_list_credential.verify(params).await?;
 
         if let Err(e) = vc_result {
             return Ok(StatusCheck::Invalid(Reason::CredentialVerification(e)));

--- a/crates/claims/crates/vc/src/v1/revocation/v2021.rs
+++ b/crates/claims/crates/vc/src/v1/revocation/v2021.rs
@@ -5,7 +5,7 @@ use bitvec::prelude::Lsb0;
 use bitvec::vec::BitVec;
 use iref::UriBuf;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::VerifiableClaims;
+use ssi_claims_core::{VerifiableClaims, Verifier};
 use ssi_data_integrity::AnyDataIntegrity;
 use ssi_json_ld::STATUS_LIST_2021_V1_CONTEXT;
 use ssi_verification_methods::{AnyMethod, VerificationMethodResolver};
@@ -178,7 +178,8 @@ impl CredentialStatus for StatusList2021Entry {
             )));
         }
 
-        let vc_result = status_list_credential.verify(resolver).await?;
+        let verifier = Verifier::from_resolver(resolver);
+        let vc_result = status_list_credential.verify(verifier).await?;
 
         if let Err(e) = vc_result {
             return Ok(StatusCheck::Invalid(Reason::CredentialVerification(e)));

--- a/crates/claims/crates/vc/src/v1/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/credential.rs
@@ -2,7 +2,7 @@ use iref::{Uri, UriBuf};
 use linked_data::{LinkedDataResource, LinkedDataSubject};
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment};
 use std::{borrow::Cow, collections::BTreeMap, hash::Hash};
@@ -171,7 +171,7 @@ impl<S, C, T> JsonLdNodeObject for SpecializedJsonCredential<S, C, T> {
 
 impl<S, C, T, E, P> ValidateClaims<E, P> for SpecializedJsonCredential<S, C, T>
 where
-    E: DateTimeEnvironment,
+    E: DateTimeProvider,
 {
     fn validate_claims(&self, env: &E, _proof: &P) -> ClaimsValidity {
         crate::v1::Credential::validate_credential(self, env)

--- a/crates/claims/crates/vc/src/v1/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/credential.rs
@@ -2,7 +2,7 @@ use iref::{Uri, UriBuf};
 use linked_data::{LinkedDataResource, LinkedDataSubject};
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, Validate};
+use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment};
 use std::{borrow::Cow, collections::BTreeMap, hash::Hash};
@@ -169,11 +169,11 @@ impl<S, C, T> JsonLdNodeObject for SpecializedJsonCredential<S, C, T> {
     }
 }
 
-impl<S, C, T, E, P> Validate<E, P> for SpecializedJsonCredential<S, C, T>
+impl<S, C, T, E, P> ValidateClaims<E, P> for SpecializedJsonCredential<S, C, T>
 where
     E: DateTimeEnvironment,
 {
-    fn validate(&self, env: &E, _proof: &P) -> ClaimsValidity {
+    fn validate_claims(&self, env: &E, _proof: &P) -> ClaimsValidity {
         crate::v1::Credential::validate_credential(self, env)
     }
 }

--- a/crates/claims/crates/vc/src/v1/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/presentation.rs
@@ -6,7 +6,7 @@ use iref::{Uri, UriBuf};
 use linked_data::{LinkedDataResource, LinkedDataSubject};
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, Validate};
+use ssi_claims_core::{ClaimsValidity, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment};
 
@@ -105,8 +105,8 @@ impl<C> JsonLdNodeObject for JsonPresentation<C> {
     }
 }
 
-impl<C, E, P> Validate<E, P> for JsonPresentation<C> {
-    fn validate(&self, _: &E, _: &P) -> ClaimsValidity {
+impl<C, E, P> ValidateClaims<E, P> for JsonPresentation<C> {
+    fn validate_claims(&self, _: &E, _: &P) -> ClaimsValidity {
         Ok(())
     }
 }

--- a/crates/claims/crates/vc/src/v2/data_model/credential.rs
+++ b/crates/claims/crates/vc/src/v2/data_model/credential.rs
@@ -1,5 +1,5 @@
 use iref::Uri;
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, InvalidClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, InvalidClaims};
 use xsd_types::DateTimeStamp;
 
 use super::{InternationalString, RelatedResource};
@@ -193,7 +193,7 @@ pub trait Credential: MaybeIdentified {
     /// verified.
     fn validate_credential<E>(&self, env: &E) -> ClaimsValidity
     where
-        E: DateTimeEnvironment,
+        E: DateTimeProvider,
     {
         let now = env.date_time();
 

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -8,7 +8,7 @@ use crate::syntax::{
 use iref::{Uri, UriBuf};
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
+use ssi_claims_core::{ClaimsValidity, DateTimeProvider, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, LinkedDataResource, LinkedDataSubject};
 use xsd_types::DateTimeStamp;
@@ -154,7 +154,7 @@ impl<S, C, T> JsonLdNodeObject for SpecializedJsonCredential<S, C, T> {
 
 impl<S, C, T, E, P> ValidateClaims<E, P> for SpecializedJsonCredential<S, C, T>
 where
-    E: DateTimeEnvironment,
+    E: DateTimeProvider,
 {
     fn validate_claims(&self, env: &E, _proof: &P) -> ClaimsValidity {
         crate::v2::Credential::validate_credential(self, env)

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -8,7 +8,7 @@ use crate::syntax::{
 use iref::{Uri, UriBuf};
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, Validate};
+use ssi_claims_core::{ClaimsValidity, DateTimeEnvironment, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, LinkedDataResource, LinkedDataSubject};
 use xsd_types::DateTimeStamp;
@@ -152,11 +152,11 @@ impl<S, C, T> JsonLdNodeObject for SpecializedJsonCredential<S, C, T> {
     }
 }
 
-impl<S, C, T, E, P> Validate<E, P> for SpecializedJsonCredential<S, C, T>
+impl<S, C, T, E, P> ValidateClaims<E, P> for SpecializedJsonCredential<S, C, T>
 where
     E: DateTimeEnvironment,
 {
-    fn validate(&self, env: &E, _proof: &P) -> ClaimsValidity {
+    fn validate_claims(&self, env: &E, _proof: &P) -> ClaimsValidity {
         crate::v2::Credential::validate_credential(self, env)
     }
 }

--- a/crates/claims/crates/vc/src/v2/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/presentation.rs
@@ -5,7 +5,7 @@ use crate::v2::{Context, Credential};
 use iref::{Uri, UriBuf};
 use rdf_types::VocabularyMut;
 use serde::{Deserialize, Serialize};
-use ssi_claims_core::{ClaimsValidity, Validate};
+use ssi_claims_core::{ClaimsValidity, ValidateClaims};
 use ssi_json_ld::{JsonLdError, JsonLdNodeObject, JsonLdObject, JsonLdTypes, Loader};
 use ssi_rdf::{Interpretation, LdEnvironment, LinkedDataResource, LinkedDataSubject};
 
@@ -102,8 +102,8 @@ impl<C> JsonLdNodeObject for JsonPresentation<C> {
     }
 }
 
-impl<C, E, P> Validate<E, P> for JsonPresentation<C> {
-    fn validate(&self, _: &E, _: &P) -> ClaimsValidity {
+impl<C, E, P> ValidateClaims<E, P> for JsonPresentation<C> {
+    fn validate_claims(&self, _: &E, _: &P) -> ClaimsValidity {
         Ok(())
     }
 }

--- a/crates/dids/core/src/method_resolver.rs
+++ b/crates/dids/core/src/method_resolver.rs
@@ -3,8 +3,7 @@ use std::{borrow::Cow, marker::PhantomData};
 use crate::{document::Document, resolution, DIDResolver, DID, DIDURL};
 use iref::Iri;
 use ssi_claims_core::ProofValidationError;
-use ssi_jwk::JWK;
-use ssi_jws::JWSVerifier;
+use ssi_jwk::{JWKResolver, JWK};
 use ssi_verification_methods_core::{
     ControllerError, ControllerProvider, GenericVerificationMethod, InvalidVerificationMethod,
     MaybeJwkVerificationMethod, ProofPurposes, ReferenceOrOwnedRef, VerificationMethod,
@@ -151,7 +150,7 @@ where
     }
 }
 
-impl<T: DIDResolver, M> JWSVerifier for VerificationMethodDIDResolver<T, M>
+impl<T: DIDResolver, M> JWKResolver for VerificationMethodDIDResolver<T, M>
 where
     M: MaybeJwkVerificationMethod
         + TryFrom<GenericVerificationMethod, Error = InvalidVerificationMethod>,

--- a/crates/dids/core/src/method_resolver.rs
+++ b/crates/dids/core/src/method_resolver.rs
@@ -16,6 +16,12 @@ pub struct VerificationMethodDIDResolver<T, M> {
     method: PhantomData<M>,
 }
 
+impl<T: Default, M> Default for VerificationMethodDIDResolver<T, M> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
 impl<T, M> VerificationMethodDIDResolver<T, M> {
     pub fn new(resolver: T) -> Self {
         Self {

--- a/crates/dids/core/src/resolution.rs
+++ b/crates/dids/core/src/resolution.rs
@@ -273,14 +273,27 @@ pub trait DIDResolver {
         self.dereference_with(did_url, Options::default()).await
     }
 
-    fn with_options<M>(self, options: Options) -> VerificationMethodDIDResolver<Self, M>
+    /// Turns this DID resolver into a verification method resolver.
+    ///
+    /// To resolve a verification method, the output resolver will first
+    /// resolve the DID using the given `options` then pull the referenced
+    /// method from the DID document.
+    fn into_vm_resolver_with<M>(self, options: Options) -> VerificationMethodDIDResolver<Self, M>
     where
         Self: Sized,
     {
         VerificationMethodDIDResolver::new_with_options(self, options)
     }
 
-    fn with_default_options<M>(self) -> VerificationMethodDIDResolver<Self, M>
+    /// Turns this DID resolver into a verification method resolver.
+    ///
+    /// To resolve a verification method, the output resolver will first
+    /// resolve the DID then pull the referenced method from the DID document.
+    ///
+    /// This is equivalent to calling
+    /// [`into_vm_resolver_with`](DIDResolver::into_vm_resolver_with)
+    /// with the default options.
+    fn into_vm_resolver<M>(self) -> VerificationMethodDIDResolver<Self, M>
     where
         Self: Sized,
     {

--- a/crates/dids/methods/ethr/src/lib.rs
+++ b/crates/dids/methods/ethr/src/lib.rs
@@ -473,7 +473,7 @@ mod tests {
     }
 
     async fn credential_prove_verify_did_ethr2(eip712: bool) {
-        let didethr = DIDEthr.with_default_options();
+        let didethr = DIDEthr.into_vm_resolver();
         let verifier = Verifier::from_resolver(&didethr);
         let key: JWK = serde_json::from_value(json!({
             "alg": "ES256K-R",
@@ -592,7 +592,7 @@ mod tests {
 
     #[tokio::test]
     async fn credential_verify_eip712vm() {
-        let didethr = DIDEthr.with_default_options();
+        let didethr = DIDEthr.into_vm_resolver();
         let vc = ssi_claims::vc::v1::data_integrity::any_credential_from_json_str(include_str!(
             "../tests/vc.jsonld"
         ))

--- a/crates/dids/methods/ethr/src/lib.rs
+++ b/crates/dids/methods/ethr/src/lib.rs
@@ -381,7 +381,7 @@ mod tests {
             ProofOptions,
         },
         vc::v1::{JsonCredential, JsonPresentation},
-        VerifiableClaims, Verifier,
+        VerificationParameters,
     };
     use ssi_dids_core::{did, DIDResolver};
     use ssi_jwk::JWK;
@@ -474,7 +474,7 @@ mod tests {
 
     async fn credential_prove_verify_did_ethr2(eip712: bool) {
         let didethr = DIDEthr.into_vm_resolver();
-        let verifier = Verifier::from_resolver(&didethr);
+        let verifier = VerificationParameters::from_resolver(&didethr);
         let key: JWK = serde_json::from_value(json!({
             "alg": "ES256K-R",
             "kty": "EC",
@@ -599,7 +599,7 @@ mod tests {
         .unwrap();
         // eprintln!("vc {:?}", vc);
         assert!(vc
-            .verify(Verifier::from_resolver(didethr))
+            .verify(VerificationParameters::from_resolver(didethr))
             .await
             .unwrap()
             .is_ok())

--- a/crates/dids/methods/ethr/src/lib.rs
+++ b/crates/dids/methods/ethr/src/lib.rs
@@ -381,7 +381,7 @@ mod tests {
             ProofOptions,
         },
         vc::v1::{JsonCredential, JsonPresentation},
-        VerifiableClaims,
+        VerifiableClaims, Verifier,
     };
     use ssi_dids_core::{did, DIDResolver};
     use ssi_jwk::JWK;
@@ -474,6 +474,7 @@ mod tests {
 
     async fn credential_prove_verify_did_ethr2(eip712: bool) {
         let didethr = DIDEthr.with_default_options();
+        let verifier = Verifier::from_resolver(&didethr);
         let key: JWK = serde_json::from_value(json!({
             "alg": "ES256K-R",
             "kty": "EC",
@@ -525,14 +526,14 @@ mod tests {
         } else {
             assert_eq!(vc.proofs.first().unwrap().signature.as_ref(), "eyJhbGciOiJFUzI1NkstUiIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..nwNfIHhCQlI-j58zgqwJgX2irGJNP8hqLis-xS16hMwzs3OuvjqzZIHlwvdzDMPopUA_Oq7M7Iql2LNe0B22oQE");
         }
-        assert!(vc.verify(&didethr).await.unwrap().is_ok());
+        assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
 
         // It should fail.
-        assert!(vc_bad_issuer.verify(&didethr).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
 
         // Check that proof JWK must match proof verificationMethod
         let wrong_key = JWK::generate_secp256k1().unwrap();
@@ -551,7 +552,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(vc_wrong_key.verify(&didethr).await.unwrap().is_err());
+        assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
 
         // Make it into a VP
         let presentation = JsonPresentation::new(
@@ -573,12 +574,12 @@ mod tests {
             .unwrap();
 
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
-        assert!(vp.verify(&didethr).await.unwrap().is_ok());
+        assert!(vp.verify(&verifier).await.unwrap().is_ok());
 
         // Mess with proof signature to make verify fail.
         let mut vp_fuzzed = vp.clone();
         vp_fuzzed.proofs.first_mut().unwrap().signature.alter();
-        let vp_fuzzed_result = vp_fuzzed.verify(&didethr).await;
+        let vp_fuzzed_result = vp_fuzzed.verify(&verifier).await;
         assert!(vp_fuzzed_result.is_err() || vp_fuzzed_result.is_ok_and(|v| v.is_err()));
 
         // test that holder is verified
@@ -586,7 +587,7 @@ mod tests {
         vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned().into());
 
         // It should fail.
-        assert!(vp_bad_holder.verify(&didethr).await.unwrap().is_err());
+        assert!(vp_bad_holder.verify(&verifier).await.unwrap().is_err());
     }
 
     #[tokio::test]
@@ -597,6 +598,10 @@ mod tests {
         ))
         .unwrap();
         // eprintln!("vc {:?}", vc);
-        assert!(vc.verify(&didethr).await.unwrap().is_ok())
+        assert!(vc
+            .verify(Verifier::from_resolver(didethr))
+            .await
+            .unwrap()
+            .is_ok())
     }
 }

--- a/crates/dids/methods/key/src/lib.rs
+++ b/crates/dids/methods/key/src/lib.rs
@@ -448,21 +448,19 @@ mod tests {
     use resolution::Parameters;
     use ssi_claims::{
         data_integrity::{AnyInputSuiteOptions, AnySuite},
-        jws::JWSVerifier,
         vc::v1::JsonCredential,
-        VerifiableClaims,
+        VerifiableClaims, Verifier,
     };
     use ssi_data_integrity::{CryptographicSuite, ProofOptions as SuiteOptions};
     use ssi_dids_core::{
         did, resolution::Options, DIDResolver, VerificationMethodDIDResolver, DIDURL,
     };
+    use ssi_jwk::JWKResolver;
     use ssi_verification_methods::AnyMethod;
     use ssi_verification_methods_core::{ProofPurpose, ReferenceOrOwned, SingleSecretSigner};
     use static_iref::uri;
 
     use super::*;
-    // use ssi_dids_core::did_resolve::{dereference, Content, DereferencingInputMetadata};
-    // use ssi_dids_core::Resource;
 
     #[async_std::test]
     async fn from_did_key() {
@@ -650,6 +648,7 @@ mod tests {
     #[async_std::test]
     async fn credential_prove_verify_did_key_ed25519() {
         let didkey = VerificationMethodDIDResolver::new(DIDKey);
+        let verifier = Verifier::from_resolver(&didkey);
 
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(2);
         let key = JWK::generate_ed25519_from(&mut rng).unwrap();
@@ -689,20 +688,21 @@ mod tests {
             serde_json::to_string_pretty(&vc.proofs).unwrap()
         );
         assert_eq!(vc.proofs.first().unwrap().signature.as_ref(), "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..o4SzDo1RBQqdK49OPdmfVRVh68xCTNEmb7hq39IVqISkelld6t6Aatg4PCXKpopIXmX8RCCF4BwrO8ERg1YFBg");
-        assert!(vc.verify(&didkey).await.unwrap().is_ok());
+        assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
         // test that issuer is verified
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
 
         // It should fail.
-        assert!(vc_bad_issuer.verify(&didkey).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
     }
 
     #[async_std::test]
     #[cfg(feature = "secp256k1")]
     async fn credential_prove_verify_did_key_secp256k1() {
         let didkey = VerificationMethodDIDResolver::new(DIDKey);
+        let verifier = Verifier::from_resolver(&didkey);
 
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(2);
         let key = JWK::generate_secp256k1_from(&mut rng).unwrap();
@@ -742,20 +742,21 @@ mod tests {
             serde_json::to_string_pretty(&vc.proofs).unwrap()
         );
         assert_eq!(vc.proofs.first().unwrap().signature.as_ref(), "eyJhbGciOiJFUzI1NksiLCJjcml0IjpbImI2NCJdLCJiNjQiOmZhbHNlfQ..jTUkFd_eYI72Y8j2OS5LRLhlc3gZn-gVsb76soi3FuJ5gWrbOb0W2CW6D-sjEsCuLkvSOfYd8Y8hB9pyeeZ2TQ");
-        assert!(vc.verify(&didkey).await.unwrap().is_ok());
+        assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
         // test that issuer is verified
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
 
         // It should fail.
-        assert!(vc_bad_issuer.verify(&didkey).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(verifier).await.unwrap().is_err());
     }
 
     #[async_std::test]
     #[cfg(feature = "secp256r1")]
     async fn credential_prove_verify_did_key_p256() {
         let didkey = VerificationMethodDIDResolver::new(DIDKey);
+        let verifier = Verifier::from_resolver(&didkey);
 
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(2);
         let key = JWK::generate_p256_from(&mut rng);
@@ -794,14 +795,14 @@ mod tests {
             "proof: {}",
             serde_json::to_string_pretty(&vc.proofs).unwrap()
         );
-        assert!(vc.verify(&didkey).await.unwrap().is_ok());
+        assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
         // test that issuer is verified
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
 
         // It should fail.
-        assert!(vc_bad_issuer.verify(&didkey).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(verifier).await.unwrap().is_err());
     }
 
     async fn fetch_jwk(jwk: JWK) {

--- a/crates/dids/methods/key/src/lib.rs
+++ b/crates/dids/methods/key/src/lib.rs
@@ -449,7 +449,7 @@ mod tests {
     use ssi_claims::{
         data_integrity::{AnyInputSuiteOptions, AnySuite},
         vc::v1::JsonCredential,
-        VerifiableClaims, Verifier,
+        VerificationParameters,
     };
     use ssi_data_integrity::{CryptographicSuite, ProofOptions as SuiteOptions};
     use ssi_dids_core::{
@@ -648,7 +648,7 @@ mod tests {
     #[async_std::test]
     async fn credential_prove_verify_did_key_ed25519() {
         let didkey = VerificationMethodDIDResolver::new(DIDKey);
-        let verifier = Verifier::from_resolver(&didkey);
+        let params = VerificationParameters::from_resolver(&didkey);
 
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(2);
         let key = JWK::generate_ed25519_from(&mut rng).unwrap();
@@ -688,21 +688,21 @@ mod tests {
             serde_json::to_string_pretty(&vc.proofs).unwrap()
         );
         assert_eq!(vc.proofs.first().unwrap().signature.as_ref(), "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..o4SzDo1RBQqdK49OPdmfVRVh68xCTNEmb7hq39IVqISkelld6t6Aatg4PCXKpopIXmX8RCCF4BwrO8ERg1YFBg");
-        assert!(vc.verify(&verifier).await.unwrap().is_ok());
+        assert!(vc.verify(&params).await.unwrap().is_ok());
 
         // test that issuer is verified
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
 
         // It should fail.
-        assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(&params).await.unwrap().is_err());
     }
 
     #[async_std::test]
     #[cfg(feature = "secp256k1")]
     async fn credential_prove_verify_did_key_secp256k1() {
         let didkey = VerificationMethodDIDResolver::new(DIDKey);
-        let verifier = Verifier::from_resolver(&didkey);
+        let params = VerificationParameters::from_resolver(&didkey);
 
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(2);
         let key = JWK::generate_secp256k1_from(&mut rng).unwrap();
@@ -742,21 +742,21 @@ mod tests {
             serde_json::to_string_pretty(&vc.proofs).unwrap()
         );
         assert_eq!(vc.proofs.first().unwrap().signature.as_ref(), "eyJhbGciOiJFUzI1NksiLCJjcml0IjpbImI2NCJdLCJiNjQiOmZhbHNlfQ..jTUkFd_eYI72Y8j2OS5LRLhlc3gZn-gVsb76soi3FuJ5gWrbOb0W2CW6D-sjEsCuLkvSOfYd8Y8hB9pyeeZ2TQ");
-        assert!(vc.verify(&verifier).await.unwrap().is_ok());
+        assert!(vc.verify(&params).await.unwrap().is_ok());
 
         // test that issuer is verified
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
 
         // It should fail.
-        assert!(vc_bad_issuer.verify(verifier).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(params).await.unwrap().is_err());
     }
 
     #[async_std::test]
     #[cfg(feature = "secp256r1")]
     async fn credential_prove_verify_did_key_p256() {
         let didkey = VerificationMethodDIDResolver::new(DIDKey);
-        let verifier = Verifier::from_resolver(&didkey);
+        let params = VerificationParameters::from_resolver(&didkey);
 
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(2);
         let key = JWK::generate_p256_from(&mut rng);
@@ -795,14 +795,14 @@ mod tests {
             "proof: {}",
             serde_json::to_string_pretty(&vc.proofs).unwrap()
         );
-        assert!(vc.verify(&verifier).await.unwrap().is_ok());
+        assert!(vc.verify(&params).await.unwrap().is_ok());
 
         // test that issuer is verified
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
 
         // It should fail.
-        assert!(vc_bad_issuer.verify(verifier).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(params).await.unwrap().is_err());
     }
 
     async fn fetch_jwk(jwk: JWK) {

--- a/crates/dids/methods/pkh/src/lib.rs
+++ b/crates/dids/methods/pkh/src/lib.rs
@@ -747,7 +747,7 @@ impl DIDPKH {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ssi_claims::VerifiableClaims;
+    use ssi_claims::{VerifiableClaims, Verifier};
     use ssi_dids_core::{did, resolution::ErrorKind, DIDResolver, VerificationMethodDIDResolver};
 
     #[cfg(all(feature = "eip", feature = "tezos"))]
@@ -956,11 +956,13 @@ mod tests {
                 signing::AlterSignature, AnyInputSuiteOptions, CryptographicSuite, ProofOptions,
             },
             vc::v1::{JsonCredential, JsonPresentation},
+            Verifier,
         };
         use ssi_verification_methods_core::{ProofPurpose, SingleSecretSigner};
         use static_iref::uri;
 
         let didpkh = VerificationMethodDIDResolver::new(DIDPKH);
+        let verifier = Verifier::from_resolver(&didpkh);
 
         // use ssi_vc::{Credential, Issuer, LinkedDataProofOptions, URI};
         let did = DIDPKH::generate(&key, type_).unwrap();
@@ -1004,14 +1006,14 @@ mod tests {
             .await
             .unwrap();
         println!("VC: {}", serde_json::to_string_pretty(&vc).unwrap());
-        assert!(vc.verify(&didpkh).await.unwrap().is_ok());
+        assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
         // Test that issuer property is used for verification.
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
 
         // It should fail.
-        assert!(vc_bad_issuer.verify(&didpkh).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
 
         // Check that proof JWK must match proof verificationMethod
         let wrong_signer = SingleSecretSigner::new(wrong_key.clone()).into_local();
@@ -1019,12 +1021,12 @@ mod tests {
             .sign(cred, &didpkh, &wrong_signer, issue_options)
             .await
             .unwrap();
-        assert!(vc_wrong_key.verify(&didpkh).await.unwrap().is_err());
+        assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
 
         // Mess with proof signature to make verify fail.
         let mut vc_fuzzed = vc.clone();
         vc_fuzzed.proofs.first_mut().unwrap().signature.alter();
-        let vc_fuzzed_result = vc_fuzzed.verify(&didpkh).await;
+        let vc_fuzzed_result = vc_fuzzed.verify(&verifier).await;
         assert!(vc_fuzzed_result.is_err() || vc_fuzzed_result.is_ok_and(|v| v.is_err()));
 
         // Make it into a VP.
@@ -1054,12 +1056,12 @@ mod tests {
             .unwrap();
 
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
-        assert!(vp.verify(&didpkh).await.unwrap().is_ok());
+        assert!(vp.verify(&verifier).await.unwrap().is_ok());
 
         // Mess with proof signature to make verify fail.
         let mut vp_fuzzed = vp.clone();
         vp_fuzzed.proofs.first_mut().unwrap().signature.alter();
-        let vp_fuzzed_result = vp_fuzzed.verify(&didpkh).await;
+        let vp_fuzzed_result = vp_fuzzed.verify(&verifier).await;
         assert!(vp_fuzzed_result.is_err() || vp_fuzzed_result.is_ok_and(|v| v.is_err()));
 
         // Test that holder is verified.
@@ -1067,7 +1069,7 @@ mod tests {
         vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned().into());
 
         // It should fail.
-        assert!(vp_bad_holder.verify(&didpkh).await.unwrap().is_err());
+        assert!(vp_bad_holder.verify(&verifier).await.unwrap().is_err());
     }
 
     #[cfg(all(feature = "eip", feature = "tezos"))]
@@ -1084,11 +1086,13 @@ mod tests {
                 signing::AlterSignature, AnyInputSuiteOptions, CryptographicSuite, ProofOptions,
             },
             vc::v1::{JsonCredential, JsonPresentation},
+            Verifier,
         };
         use ssi_verification_methods_core::{ProofPurpose, SingleSecretSigner};
         use static_iref::uri;
 
         let didpkh = VerificationMethodDIDResolver::new(DIDPKH);
+        let verifier = Verifier::from_resolver(&didpkh);
         let did = DIDPKH::generate(&key, type_).unwrap();
 
         eprintln!("did: {}", did);
@@ -1119,12 +1123,12 @@ mod tests {
             .await
             .unwrap();
         println!("VC: {}", serde_json::to_string_pretty(&vc).unwrap());
-        assert!(vc.verify(&didpkh).await.unwrap().is_ok());
+        assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
-        assert!(!vc_bad_issuer.verify(&didpkh).await.unwrap().is_ok());
+        assert!(!vc_bad_issuer.verify(&verifier).await.unwrap().is_ok());
 
         // Check that proof JWK must match proof verificationMethod.
         let wrong_signer = SingleSecretSigner::new(wrong_key.clone()).into_local();
@@ -1132,12 +1136,12 @@ mod tests {
             .sign(cred, &didpkh, &wrong_signer, issue_options)
             .await
             .unwrap();
-        assert!(vc_wrong_key.verify(&didpkh).await.unwrap().is_err());
+        assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
 
         // Mess with proof signature to make verify fail
         let mut vc_fuzzed = vc.clone();
         vc_fuzzed.proofs.first_mut().unwrap().signature.alter();
-        let vc_fuzzed_result = vc_fuzzed.verify(&didpkh).await;
+        let vc_fuzzed_result = vc_fuzzed.verify(&verifier).await;
         assert!(vc_fuzzed_result.is_err() || vc_fuzzed_result.is_ok_and(|v| v.is_err()));
 
         // Make it into a VP
@@ -1160,19 +1164,19 @@ mod tests {
             .unwrap();
 
         println!("VP: {}", serde_json::to_string_pretty(&vp).unwrap());
-        assert!(vp.verify(&didpkh).await.unwrap().is_ok());
+        assert!(vp.verify(&verifier).await.unwrap().is_ok());
 
         // Mess with proof signature to make verify fail.
         let mut vp_fuzzed = vp.clone();
         vp_fuzzed.proofs.first_mut().unwrap().signature.alter();
-        let vp_fuzzed_result = vp_fuzzed.verify(&didpkh).await;
+        let vp_fuzzed_result = vp_fuzzed.verify(&verifier).await;
         assert!(vp_fuzzed_result.is_err() || vp_fuzzed_result.is_ok_and(|v| v.is_err()));
 
         // Test that holder is verified.
         let mut vp_bad_holder = vp.clone();
         vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned().into());
         // It should fail.
-        assert!(vp_bad_holder.verify(&didpkh).await.unwrap().is_err());
+        assert!(vp_bad_holder.verify(&verifier).await.unwrap().is_err());
     }
 
     // fn sign_tezos(prep: &ssi_ldp::ProofPreparation, algorithm: Algorithm, key: &JWK) -> String {
@@ -1506,7 +1510,8 @@ mod tests {
         let vc = ssi_claims::vc::v1::data_integrity::any_credential_from_json_str(vc_str).unwrap();
 
         let didpkh = VerificationMethodDIDResolver::new(DIDPKH);
-        let verification_result = vc.verify(&didpkh).await.unwrap();
+        let verifier = Verifier::from_resolver(&didpkh);
+        let verification_result = vc.verify(&verifier).await.unwrap();
         assert!(verification_result.is_ok());
 
         // // assert_eq!(verification_result.warnings.len(), num_warnings); // TODO warnings
@@ -1545,7 +1550,7 @@ mod tests {
             }
         }
 
-        let verification_result = bad_vc.verify(&didpkh).await.unwrap();
+        let verification_result = bad_vc.verify(verifier).await.unwrap();
         assert!(verification_result.is_err());
     }
 

--- a/crates/dids/methods/tz/tests/did.rs
+++ b/crates/dids/methods/tz/tests/did.rs
@@ -8,7 +8,7 @@ use ssi_claims::{
         ProofOptions as SuiteOptions,
     },
     vc::v1::{JsonCredential, JsonPresentation},
-    VerifiableClaims,
+    VerifiableClaims, Verifier,
 };
 use ssi_dids_core::{did, resolution::Options, DIDResolver, VerificationMethodDIDResolver};
 use ssi_jwk::JWK;
@@ -215,6 +215,7 @@ async fn credential_prove_verify_did_tz1() {
     let didtz = VerificationMethodDIDResolver::new(DIDTz::new(Some(
         UriBuf::new(mock_server.uri().into_bytes()).unwrap(),
     )));
+    let verifier = Verifier::from_resolver(&didtz);
 
     let did = did!("did:tz:delphinet:tz1WvvbEGpBXGeTVbLiR6DYBe1izmgiYuZbq").to_owned();
     let vc = DataIntegrity::new(
@@ -265,7 +266,7 @@ async fn credential_prove_verify_did_tz1() {
     )
     .await
     .unwrap();
-    assert!(vc_wrong_key.verify(&didtz).await.unwrap().is_err());
+    assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
 
     let vp = DataIntegrity::new(
         JsonPresentation::new(
@@ -301,7 +302,7 @@ async fn credential_prove_verify_did_tz1() {
         vp1.proofs.first_mut().unwrap().signature.jws
     ))
     .unwrap();
-    assert!(vp1.verify(&didtz).await.is_err());
+    assert!(vp1.verify(&verifier).await.is_err());
 
     // test that holder is verified
     let mut _vp2 = vp.clone();
@@ -332,6 +333,7 @@ async fn credential_prove_verify_did_tz2() {
     );
 
     let didtz = VerificationMethodDIDResolver::new(DIDTZ);
+    let verifier = Verifier::from_resolver(&didtz);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     let vc_issue_options = SuiteOptions::new(
@@ -348,12 +350,12 @@ async fn credential_prove_verify_did_tz2() {
         .await
         .unwrap();
     println!("{}", serde_json::to_string_pretty(&vc.proofs).unwrap());
-    assert!(vc.verify(&didtz).await.unwrap().is_ok());
+    assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
     // Test that issuer property is used for verification.
     let mut vc_bad_issuer = vc.clone();
     vc_bad_issuer.issuer = uri!("did:example:bad").to_owned().into();
-    assert!(vc_bad_issuer.verify(&didtz).await.unwrap().is_err());
+    assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
 
     // Check that proof JWK must match proof verificationMethod
     let wrong_signer =
@@ -373,7 +375,7 @@ async fn credential_prove_verify_did_tz2() {
         )
         .await
         .unwrap();
-    assert!(vc_wrong_key.verify(&didtz).await.unwrap().is_err());
+    assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
 
     let presentation = JsonPresentation::new(
         Some(uri!("http://example.org/presentations/3731").to_owned()),
@@ -395,17 +397,17 @@ async fn credential_prove_verify_did_tz2() {
         .await
         .unwrap();
     println!("VP: {}", serde_json::to_string_pretty(&vp.proofs).unwrap());
-    assert!(vp.verify(&didtz).await.unwrap().is_ok());
+    assert!(vp.verify(&verifier).await.unwrap().is_ok());
 
     // mess with the VP proof to make verify fail
     let mut vp1 = vp.clone();
     vp1.proofs.first_mut().unwrap().signature.alter();
-    assert!(vp1.verify(&didtz).await.is_err());
+    assert!(vp1.verify(&verifier).await.is_err());
 
     // test that holder is verified
     let mut vp2 = vp.clone();
     vp2.holder = Some(did!("did:example:bad").to_owned().into());
-    assert!(vp2.verify(&didtz).await.unwrap().is_err());
+    assert!(vp2.verify(&verifier).await.unwrap().is_err());
 }
 
 #[tokio::test]
@@ -427,6 +429,7 @@ async fn credential_prove_verify_did_tz3() {
     );
 
     let didtz = VerificationMethodDIDResolver::new(DIDTZ);
+    let verifier = Verifier::from_resolver(&didtz);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     let vc_issue_options = SuiteOptions::new(
@@ -446,12 +449,12 @@ async fn credential_prove_verify_did_tz3() {
         .await
         .unwrap();
     println!("{}", serde_json::to_string_pretty(&vc.proofs).unwrap());
-    assert!(vc.verify(&didtz).await.unwrap().is_ok());
+    assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
     // Test that issuer property is used for verification.
     let mut vc_bad_issuer = vc.clone();
     vc_bad_issuer.issuer = uri!("did:example:bad").to_owned().into();
-    assert!(vc_bad_issuer.verify(&didtz).await.unwrap().is_err());
+    assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
 
     // Check that proof JWK must match proof verificationMethod
     let wrong_signer = SingleSecretSigner::new(JWK::generate_p256_from(&mut rng)).into_local();
@@ -470,7 +473,7 @@ async fn credential_prove_verify_did_tz3() {
         )
         .await
         .unwrap();
-    assert!(vc_wrong_key.verify(&didtz).await.unwrap().is_err());
+    assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
 
     let presentation = JsonPresentation::new(
         Some(uri!("http://example.org/presentations/3731").to_owned()),
@@ -494,15 +497,15 @@ async fn credential_prove_verify_did_tz3() {
         .await
         .unwrap();
     println!("VP: {}", serde_json::to_string_pretty(&vp.proofs).unwrap());
-    assert!(vp.verify(&didtz).await.unwrap().is_ok());
+    assert!(vp.verify(&verifier).await.unwrap().is_ok());
 
     // mess with the VP proof to make verify fail
     let mut vp1 = vp.clone();
     vp1.proofs.first_mut().unwrap().signature.alter();
-    assert!(vp1.verify(&didtz).await.is_err());
+    assert!(vp1.verify(&verifier).await.is_err());
 
     // test that holder is verified
     let mut vp2 = vp.clone();
     vp2.holder = Some(did!("did:example:bad").to_owned().into());
-    assert!(vp2.verify(&didtz).await.unwrap().is_err());
+    assert!(vp2.verify(verifier).await.unwrap().is_err());
 }

--- a/crates/dids/methods/tz/tests/did.rs
+++ b/crates/dids/methods/tz/tests/did.rs
@@ -8,7 +8,7 @@ use ssi_claims::{
         ProofOptions as SuiteOptions,
     },
     vc::v1::{JsonCredential, JsonPresentation},
-    VerifiableClaims, Verifier,
+    VerificationParameters,
 };
 use ssi_dids_core::{did, resolution::Options, DIDResolver, VerificationMethodDIDResolver};
 use ssi_jwk::JWK;
@@ -215,7 +215,7 @@ async fn credential_prove_verify_did_tz1() {
     let didtz = VerificationMethodDIDResolver::new(DIDTz::new(Some(
         UriBuf::new(mock_server.uri().into_bytes()).unwrap(),
     )));
-    let verifier = Verifier::from_resolver(&didtz);
+    let params = VerificationParameters::from_resolver(&didtz);
 
     let did = did!("did:tz:delphinet:tz1WvvbEGpBXGeTVbLiR6DYBe1izmgiYuZbq").to_owned();
     let vc = DataIntegrity::new(
@@ -266,7 +266,7 @@ async fn credential_prove_verify_did_tz1() {
     )
     .await
     .unwrap();
-    assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
+    assert!(vc_wrong_key.verify(&params).await.unwrap().is_err());
 
     let vp = DataIntegrity::new(
         JsonPresentation::new(
@@ -302,7 +302,7 @@ async fn credential_prove_verify_did_tz1() {
         vp1.proofs.first_mut().unwrap().signature.jws
     ))
     .unwrap();
-    assert!(vp1.verify(&verifier).await.is_err());
+    assert!(vp1.verify(&params).await.is_err());
 
     // test that holder is verified
     let mut _vp2 = vp.clone();
@@ -333,7 +333,7 @@ async fn credential_prove_verify_did_tz2() {
     );
 
     let didtz = VerificationMethodDIDResolver::new(DIDTZ);
-    let verifier = Verifier::from_resolver(&didtz);
+    let params = VerificationParameters::from_resolver(&didtz);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     let vc_issue_options = SuiteOptions::new(
@@ -350,12 +350,12 @@ async fn credential_prove_verify_did_tz2() {
         .await
         .unwrap();
     println!("{}", serde_json::to_string_pretty(&vc.proofs).unwrap());
-    assert!(vc.verify(&verifier).await.unwrap().is_ok());
+    assert!(vc.verify(&params).await.unwrap().is_ok());
 
     // Test that issuer property is used for verification.
     let mut vc_bad_issuer = vc.clone();
     vc_bad_issuer.issuer = uri!("did:example:bad").to_owned().into();
-    assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
+    assert!(vc_bad_issuer.verify(&params).await.unwrap().is_err());
 
     // Check that proof JWK must match proof verificationMethod
     let wrong_signer =
@@ -375,7 +375,7 @@ async fn credential_prove_verify_did_tz2() {
         )
         .await
         .unwrap();
-    assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
+    assert!(vc_wrong_key.verify(&params).await.unwrap().is_err());
 
     let presentation = JsonPresentation::new(
         Some(uri!("http://example.org/presentations/3731").to_owned()),
@@ -397,17 +397,17 @@ async fn credential_prove_verify_did_tz2() {
         .await
         .unwrap();
     println!("VP: {}", serde_json::to_string_pretty(&vp.proofs).unwrap());
-    assert!(vp.verify(&verifier).await.unwrap().is_ok());
+    assert!(vp.verify(&params).await.unwrap().is_ok());
 
     // mess with the VP proof to make verify fail
     let mut vp1 = vp.clone();
     vp1.proofs.first_mut().unwrap().signature.alter();
-    assert!(vp1.verify(&verifier).await.is_err());
+    assert!(vp1.verify(&params).await.is_err());
 
     // test that holder is verified
     let mut vp2 = vp.clone();
     vp2.holder = Some(did!("did:example:bad").to_owned().into());
-    assert!(vp2.verify(&verifier).await.unwrap().is_err());
+    assert!(vp2.verify(&params).await.unwrap().is_err());
 }
 
 #[tokio::test]
@@ -429,7 +429,7 @@ async fn credential_prove_verify_did_tz3() {
     );
 
     let didtz = VerificationMethodDIDResolver::new(DIDTZ);
-    let verifier = Verifier::from_resolver(&didtz);
+    let params = VerificationParameters::from_resolver(&didtz);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     let vc_issue_options = SuiteOptions::new(
@@ -449,12 +449,12 @@ async fn credential_prove_verify_did_tz3() {
         .await
         .unwrap();
     println!("{}", serde_json::to_string_pretty(&vc.proofs).unwrap());
-    assert!(vc.verify(&verifier).await.unwrap().is_ok());
+    assert!(vc.verify(&params).await.unwrap().is_ok());
 
     // Test that issuer property is used for verification.
     let mut vc_bad_issuer = vc.clone();
     vc_bad_issuer.issuer = uri!("did:example:bad").to_owned().into();
-    assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
+    assert!(vc_bad_issuer.verify(&params).await.unwrap().is_err());
 
     // Check that proof JWK must match proof verificationMethod
     let wrong_signer = SingleSecretSigner::new(JWK::generate_p256_from(&mut rng)).into_local();
@@ -473,7 +473,7 @@ async fn credential_prove_verify_did_tz3() {
         )
         .await
         .unwrap();
-    assert!(vc_wrong_key.verify(&verifier).await.unwrap().is_err());
+    assert!(vc_wrong_key.verify(&params).await.unwrap().is_err());
 
     let presentation = JsonPresentation::new(
         Some(uri!("http://example.org/presentations/3731").to_owned()),
@@ -497,15 +497,15 @@ async fn credential_prove_verify_did_tz3() {
         .await
         .unwrap();
     println!("VP: {}", serde_json::to_string_pretty(&vp.proofs).unwrap());
-    assert!(vp.verify(&verifier).await.unwrap().is_ok());
+    assert!(vp.verify(&params).await.unwrap().is_ok());
 
     // mess with the VP proof to make verify fail
     let mut vp1 = vp.clone();
     vp1.proofs.first_mut().unwrap().signature.alter();
-    assert!(vp1.verify(&verifier).await.is_err());
+    assert!(vp1.verify(&params).await.is_err());
 
     // test that holder is verified
     let mut vp2 = vp.clone();
     vp2.holder = Some(did!("did:example:bad").to_owned().into());
-    assert!(vp2.verify(verifier).await.unwrap().is_err());
+    assert!(vp2.verify(params).await.unwrap().is_err());
 }

--- a/crates/dids/methods/web/src/lib.rs
+++ b/crates/dids/methods/web/src/lib.rs
@@ -139,7 +139,7 @@ mod tests {
     use ssi_claims::{
         data_integrity::{AnySuite, CryptographicSuite, ProofOptions},
         vc::v1::JsonCredential,
-        VerifiableClaims, Verifier,
+        VerificationParameters,
     };
     use ssi_dids_core::{did, DIDResolver, Document, VerificationMethodDIDResolver};
     use ssi_jwk::JWK;
@@ -243,7 +243,7 @@ mod tests {
     #[tokio::test]
     async fn credential_prove_verify_did_web() {
         let didweb = VerificationMethodDIDResolver::new(DIDWeb);
-        let verifier = Verifier::from_resolver(&didweb);
+        let params = VerificationParameters::from_resolver(&didweb);
 
         let (url, shutdown) = web_server().unwrap();
         PROXY.with(|proxy| {
@@ -281,13 +281,13 @@ mod tests {
             serde_json::to_string_pretty(&vc.proofs).unwrap()
         );
         assert_eq!(vc.proofs.first().unwrap().signature.as_ref(), "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..BCvVb4jz-yVaTeoP24Wz0cOtiHKXCdPcmFQD_pxgsMU6aCAj1AIu3cqHyoViU93nPmzqMLswOAqZUlMyVnmzDw");
-        assert!(vc.verify(&verifier).await.unwrap().is_ok());
+        assert!(vc.verify(&params).await.unwrap().is_ok());
 
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
         // It should fail.
-        assert!(vc_bad_issuer.verify(verifier).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(params).await.unwrap().is_err());
 
         PROXY.with(|proxy| {
             proxy.replace(None);

--- a/crates/dids/methods/web/src/lib.rs
+++ b/crates/dids/methods/web/src/lib.rs
@@ -139,7 +139,7 @@ mod tests {
     use ssi_claims::{
         data_integrity::{AnySuite, CryptographicSuite, ProofOptions},
         vc::v1::JsonCredential,
-        VerifiableClaims,
+        VerifiableClaims, Verifier,
     };
     use ssi_dids_core::{did, DIDResolver, Document, VerificationMethodDIDResolver};
     use ssi_jwk::JWK;
@@ -243,6 +243,7 @@ mod tests {
     #[tokio::test]
     async fn credential_prove_verify_did_web() {
         let didweb = VerificationMethodDIDResolver::new(DIDWeb);
+        let verifier = Verifier::from_resolver(&didweb);
 
         let (url, shutdown) = web_server().unwrap();
         PROXY.with(|proxy| {
@@ -280,13 +281,13 @@ mod tests {
             serde_json::to_string_pretty(&vc.proofs).unwrap()
         );
         assert_eq!(vc.proofs.first().unwrap().signature.as_ref(), "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..BCvVb4jz-yVaTeoP24Wz0cOtiHKXCdPcmFQD_pxgsMU6aCAj1AIu3cqHyoViU93nPmzqMLswOAqZUlMyVnmzDw");
-        assert!(vc.verify(&didweb).await.unwrap().is_ok());
+        assert!(vc.verify(&verifier).await.unwrap().is_ok());
 
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
         // It should fail.
-        assert!(vc_bad_issuer.verify(&didweb).await.unwrap().is_err());
+        assert!(vc_bad_issuer.verify(verifier).await.unwrap().is_err());
 
         PROXY.with(|proxy| {
             proxy.replace(None);

--- a/crates/eip712/src/ty.rs
+++ b/crates/eip712/src/ty.rs
@@ -40,10 +40,24 @@ impl TypesProvider for () {
     }
 }
 
+impl<'a, T: TypesProvider> TypesProvider for &'a T {
+    async fn fetch_types(&self, uri: &Uri) -> Result<Types, TypesFetchError> {
+        T::fetch_types(*self, uri).await
+    }
+}
+
 pub trait Eip712TypesEnvironment {
     type Provider: TypesProvider;
 
     fn eip712_types(&self) -> &Self::Provider;
+}
+
+impl<'a, E: Eip712TypesEnvironment> Eip712TypesEnvironment for &'a E {
+    type Provider = E::Provider;
+
+    fn eip712_types(&self) -> &Self::Provider {
+        E::eip712_types(*self)
+    }
 }
 
 /// EIP-712 types

--- a/crates/eip712/src/ty.rs
+++ b/crates/eip712/src/ty.rs
@@ -22,7 +22,7 @@ pub enum TypesFetchError {
 ///
 /// A default implementation is provided for the `()` type that always return
 /// `TypesFetchError::Unsupported`.
-pub trait TypesProvider {
+pub trait TypesLoader {
     /// Fetches the type definitions located behind the given `uri`.
     ///
     /// This is an asynchronous function returning a `Self::Fetch` future that
@@ -34,28 +34,28 @@ pub trait TypesProvider {
 
 /// Simple EIP712 loader implementation that always return
 /// `TypesFetchError::Unsupported`.
-impl TypesProvider for () {
+impl TypesLoader for () {
     async fn fetch_types(&self, _uri: &Uri) -> Result<Types, TypesFetchError> {
         Err(TypesFetchError::Unsupported)
     }
 }
 
-impl<'a, T: TypesProvider> TypesProvider for &'a T {
+impl<'a, T: TypesLoader> TypesLoader for &'a T {
     async fn fetch_types(&self, uri: &Uri) -> Result<Types, TypesFetchError> {
         T::fetch_types(*self, uri).await
     }
 }
 
-pub trait Eip712TypesEnvironment {
-    type Provider: TypesProvider;
+pub trait Eip712TypesLoaderProvider {
+    type Loader: TypesLoader;
 
-    fn eip712_types(&self) -> &Self::Provider;
+    fn eip712_types(&self) -> &Self::Loader;
 }
 
-impl<'a, E: Eip712TypesEnvironment> Eip712TypesEnvironment for &'a E {
-    type Provider = E::Provider;
+impl<'a, E: Eip712TypesLoaderProvider> Eip712TypesLoaderProvider for &'a E {
+    type Loader = E::Loader;
 
-    fn eip712_types(&self) -> &Self::Provider {
+    fn eip712_types(&self) -> &Self::Loader {
         E::eip712_types(*self)
     }
 }

--- a/crates/json-ld/Cargo.toml
+++ b/crates/json-ld/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/ssi-json-ld/"
 [dependencies]
 thiserror.workspace = true
 async-std = { version = "1.9", features = ["attributes"] }
-json-ld = { version = "0.19.1", features = ["serde"] }
+json-ld = { version = "0.19.2", features = ["serde"] }
 iref.workspace = true
 static-iref.workspace = true
 rdf-types.workspace = true

--- a/crates/json-ld/src/lib.rs
+++ b/crates/json-ld/src/lib.rs
@@ -24,6 +24,14 @@ pub trait ContextLoaderEnvironment {
     fn loader(&self) -> &Self::Loader;
 }
 
+impl<'a, E: ContextLoaderEnvironment> ContextLoaderEnvironment for &'a E {
+    type Loader = E::Loader;
+
+    fn loader(&self) -> &Self::Loader {
+        E::loader(*self)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum JsonLdError {
     #[error("expansion error: {0}")]

--- a/crates/json-ld/src/lib.rs
+++ b/crates/json-ld/src/lib.rs
@@ -17,14 +17,14 @@ use ssi_rdf::{
     VocabularyMut,
 };
 
-/// Environment that provides a JSON-LD context loader.
-pub trait ContextLoaderEnvironment {
+/// Type that provides a JSON-LD document loader.
+pub trait JsonLdLoaderProvider {
     type Loader: json_ld::Loader;
 
     fn loader(&self) -> &Self::Loader;
 }
 
-impl<'a, E: ContextLoaderEnvironment> ContextLoaderEnvironment for &'a E {
+impl<'a, E: JsonLdLoaderProvider> JsonLdLoaderProvider for &'a E {
     type Loader = E::Loader;
 
     fn loader(&self) -> &Self::Loader {

--- a/crates/jwk/Cargo.toml
+++ b/crates/jwk/Cargo.toml
@@ -43,6 +43,7 @@ tezos = ["blake2b_simd", "secp256k1", "secp256r1", "bs58"]
 ring = ["dep:ring"]
 
 [dependencies]
+ssi-claims-core.workspace = true
 num-bigint = "0.4"
 simple_asn1 = "^0.5.2"
 zeroize = { version = "1.5", features = ["zeroize_derive"] }

--- a/crates/jwk/src/lib.rs
+++ b/crates/jwk/src/lib.rs
@@ -7,12 +7,15 @@ use ssi_multicodec::MultiEncoded;
 use std::result::Result;
 use std::{convert::TryFrom, str::FromStr};
 use zeroize::Zeroize;
+
 pub mod error;
 pub use error::Error;
 
 pub mod algorithm;
-
 pub use algorithm::Algorithm;
+
+mod resolver;
+pub use resolver::*;
 
 #[cfg(feature = "ripemd-160")]
 pub mod ripemd160;

--- a/crates/jwk/src/resolver.rs
+++ b/crates/jwk/src/resolver.rs
@@ -1,0 +1,53 @@
+use std::borrow::Cow;
+
+use crate::JWK;
+use ssi_claims_core::{
+    chrono::{DateTime, Utc},
+    DateTimeEnvironment, ProofValidationError, ResolverEnvironment,
+};
+
+/// JWK resolver.
+///
+/// Any type that can fetch a JWK from its identifier.
+pub trait JWKResolver {
+    /// Fetches a JWK by id.
+    ///
+    /// The key identifier is optional since the key may be known in advance.
+    #[allow(async_fn_in_trait)]
+    async fn fetch_public_jwk(
+        &self,
+        key_id: Option<&str>,
+    ) -> Result<Cow<JWK>, ProofValidationError>;
+}
+
+impl<'a, T: JWKResolver> JWKResolver for &'a T {
+    async fn fetch_public_jwk(
+        &self,
+        key_id: Option<&str>,
+    ) -> Result<Cow<JWK>, ProofValidationError> {
+        T::fetch_public_jwk(*self, key_id).await
+    }
+}
+
+impl JWKResolver for JWK {
+    async fn fetch_public_jwk(
+        &self,
+        _key_id: Option<&str>,
+    ) -> Result<Cow<JWK>, ProofValidationError> {
+        Ok(Cow::Borrowed(self))
+    }
+}
+
+impl ResolverEnvironment for JWK {
+    type Resolver = Self;
+
+    fn resolver(&self) -> &Self::Resolver {
+        self
+    }
+}
+
+impl DateTimeEnvironment for JWK {
+    fn date_time(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}

--- a/crates/jwk/src/resolver.rs
+++ b/crates/jwk/src/resolver.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use crate::JWK;
 use ssi_claims_core::{
     chrono::{DateTime, Utc},
-    DateTimeEnvironment, ProofValidationError, ResolverEnvironment,
+    DateTimeProvider, ProofValidationError, ResolverProvider,
 };
 
 /// JWK resolver.
@@ -38,7 +38,7 @@ impl JWKResolver for JWK {
     }
 }
 
-impl ResolverEnvironment for JWK {
+impl ResolverProvider for JWK {
     type Resolver = Self;
 
     fn resolver(&self) -> &Self::Resolver {
@@ -46,7 +46,7 @@ impl ResolverEnvironment for JWK {
     }
 }
 
-impl DateTimeEnvironment for JWK {
+impl DateTimeProvider for JWK {
     fn date_time(&self) -> DateTime<Utc> {
         Utc::now()
     }

--- a/crates/zcap-ld/Cargo.toml
+++ b/crates/zcap-ld/Cargo.toml
@@ -24,6 +24,7 @@ ssi-rdf.workspace = true
 ssi-json-ld.workspace = true
 ssi-claims.workspace = true
 ssi-verification-methods.workspace = true
+ssi-eip712.workspace = true
 
 [dev-dependencies]
 async-std = { version = "1.9", features = ["attributes"] }

--- a/crates/zcap-ld/src/lib.rs
+++ b/crates/zcap-ld/src/lib.rs
@@ -205,7 +205,7 @@ pub struct InvocationVerifier<'a, C, S, R, L1 = ssi_json_ld::ContextLoader, L2 =
     pub resolver: R,
     pub json_ld_loader: L1,
     pub eip712_types_loader: L2,
-    pub date_time: DateTime<Utc>,
+    pub date_time: Option<DateTime<Utc>>,
     pub delegation: &'a Delegation<C, S>,
 }
 
@@ -247,7 +247,7 @@ impl<'v, 'a, R, L1, L2, C, S> InvocationVerifier<'a, C, S, &'v R, &'v L1, &'v L2
 
 impl<'a, C, S, R, L1, L2> DateTimeProvider for InvocationVerifier<'a, C, S, R, L1, L2> {
     fn date_time(&self) -> DateTime<Utc> {
-        self.date_time
+        self.date_time.unwrap_or_else(Utc::now)
     }
 }
 

--- a/examples/issue-revocation-list.rs
+++ b/examples/issue-revocation-list.rs
@@ -11,6 +11,7 @@ use ssi::{
     jwk::JWK,
     verification_methods::SingleSecretSigner,
 };
+use ssi_claims::Verifier;
 use ssi_dids::DIDResolver;
 use static_iref::{iri, uri};
 
@@ -22,6 +23,7 @@ async fn main() {
 
     // DID resolver.
     let resolver = ssi::dids::example::ExampleDIDResolver::default().with_default_options();
+    let verifier = Verifier::from_resolver(&resolver);
 
     let mut rl = RevocationList2020::default();
     rl.set_status(1, true).unwrap();
@@ -39,7 +41,7 @@ async fn main() {
     let suite = AnySuite::pick(&key, params.verification_method.as_ref()).unwrap();
     let vc = suite.sign(rl_vc, &resolver, &signer, params).await.unwrap();
 
-    assert!(vc.verify(&resolver).await.unwrap().is_ok());
+    assert!(vc.verify(verifier).await.unwrap().is_ok());
 
     let stdout_writer = std::io::BufWriter::new(std::io::stdout());
     serde_json::to_writer_pretty(stdout_writer, &vc).unwrap();

--- a/examples/issue-revocation-list.rs
+++ b/examples/issue-revocation-list.rs
@@ -22,7 +22,7 @@ async fn main() {
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     // DID resolver.
-    let resolver = ssi::dids::example::ExampleDIDResolver::default().with_default_options();
+    let resolver = ssi::dids::example::ExampleDIDResolver::default().into_vm_resolver();
     let verifier = Verifier::from_resolver(&resolver);
 
     let mut rl = RevocationList2020::default();

--- a/examples/issue-revocation-list.rs
+++ b/examples/issue-revocation-list.rs
@@ -6,12 +6,11 @@ use ssi::{
         vc::v1::revocation::{
             RevocationList2020, RevocationList2020Credential, RevocationList2020Subject,
         },
-        VerifiableClaims,
     },
     jwk::JWK,
     verification_methods::SingleSecretSigner,
 };
-use ssi_claims::Verifier;
+use ssi_claims::VerificationParameters;
 use ssi_dids::DIDResolver;
 use static_iref::{iri, uri};
 
@@ -23,7 +22,7 @@ async fn main() {
 
     // DID resolver.
     let resolver = ssi::dids::example::ExampleDIDResolver::default().into_vm_resolver();
-    let verifier = Verifier::from_resolver(&resolver);
+    let params = VerificationParameters::from_resolver(&resolver);
 
     let mut rl = RevocationList2020::default();
     rl.set_status(1, true).unwrap();
@@ -36,12 +35,14 @@ async fn main() {
 
     let verification_method = iri!("did:example:foo#key1").into();
 
-    let params = ProofOptions::from_method_and_options(verification_method, Default::default());
+    let options = ProofOptions::from_method_and_options(verification_method, Default::default());
+    let suite = AnySuite::pick(&key, options.verification_method.as_ref()).unwrap();
+    let vc = suite
+        .sign(rl_vc, &resolver, &signer, options)
+        .await
+        .unwrap();
 
-    let suite = AnySuite::pick(&key, params.verification_method.as_ref()).unwrap();
-    let vc = suite.sign(rl_vc, &resolver, &signer, params).await.unwrap();
-
-    assert!(vc.verify(verifier).await.unwrap().is_ok());
+    assert!(vc.verify(params).await.unwrap().is_ok());
 
     let stdout_writer = std::io::BufWriter::new(std::io::stdout());
     serde_json::to_writer_pretty(stdout_writer, &vc).unwrap();

--- a/examples/issue-status-list.rs
+++ b/examples/issue-status-list.rs
@@ -4,12 +4,11 @@ use ssi::{
     claims::{
         data_integrity::{AnySuite, CryptographicSuite, ProofOptions},
         vc::v1::revocation::{StatusList2021, StatusList2021Credential, StatusList2021Subject},
-        VerifiableClaims,
     },
     jwk::JWK,
     verification_methods::SingleSecretSigner,
 };
-use ssi_claims::Verifier;
+use ssi_claims::VerificationParameters;
 use ssi_dids::DIDResolver;
 use static_iref::{iri, uri};
 
@@ -21,7 +20,7 @@ async fn main() {
 
     // DID resolver.
     let resolver = ssi::dids::example::ExampleDIDResolver::default().into_vm_resolver();
-    let verifier = Verifier::from_resolver(&resolver);
+    let params = VerificationParameters::from_resolver(&resolver);
 
     let mut rl = StatusList2021::new(131072).unwrap();
     rl.set_status(1, true).unwrap();
@@ -34,12 +33,14 @@ async fn main() {
 
     let verification_method = iri!("did:example:12345#key1").into();
 
-    let params = ProofOptions::from_method_and_options(verification_method, Default::default());
+    let options = ProofOptions::from_method_and_options(verification_method, Default::default());
+    let suite = AnySuite::pick(&key, options.verification_method.as_ref()).unwrap();
+    let vc = suite
+        .sign(rl_vc, &resolver, &signer, options)
+        .await
+        .unwrap();
 
-    let suite = AnySuite::pick(&key, params.verification_method.as_ref()).unwrap();
-    let vc = suite.sign(rl_vc, &resolver, &signer, params).await.unwrap();
-
-    assert!(vc.verify(verifier).await.unwrap().is_ok());
+    assert!(vc.verify(params).await.unwrap().is_ok());
 
     let stdout_writer = std::io::BufWriter::new(std::io::stdout());
     serde_json::to_writer_pretty(stdout_writer, &vc).unwrap();

--- a/examples/issue-status-list.rs
+++ b/examples/issue-status-list.rs
@@ -9,6 +9,7 @@ use ssi::{
     jwk::JWK,
     verification_methods::SingleSecretSigner,
 };
+use ssi_claims::Verifier;
 use ssi_dids::DIDResolver;
 use static_iref::{iri, uri};
 
@@ -20,6 +21,7 @@ async fn main() {
 
     // DID resolver.
     let resolver = ssi::dids::example::ExampleDIDResolver::default().with_default_options();
+    let verifier = Verifier::from_resolver(&resolver);
 
     let mut rl = StatusList2021::new(131072).unwrap();
     rl.set_status(1, true).unwrap();
@@ -37,7 +39,7 @@ async fn main() {
     let suite = AnySuite::pick(&key, params.verification_method.as_ref()).unwrap();
     let vc = suite.sign(rl_vc, &resolver, &signer, params).await.unwrap();
 
-    assert!(vc.verify(&resolver).await.unwrap().is_ok());
+    assert!(vc.verify(verifier).await.unwrap().is_ok());
 
     let stdout_writer = std::io::BufWriter::new(std::io::stdout());
     serde_json::to_writer_pretty(stdout_writer, &vc).unwrap();

--- a/examples/issue-status-list.rs
+++ b/examples/issue-status-list.rs
@@ -20,7 +20,7 @@ async fn main() {
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     // DID resolver.
-    let resolver = ssi::dids::example::ExampleDIDResolver::default().with_default_options();
+    let resolver = ssi::dids::example::ExampleDIDResolver::default().into_vm_resolver();
     let verifier = Verifier::from_resolver(&resolver);
 
     let mut rl = StatusList2021::new(131072).unwrap();

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -43,8 +43,8 @@ async fn issue(proof_format: &str) {
             let vc = suite.sign(vc, &resolver, &signer, options).await.unwrap();
 
             let result = vc.verify(params).await.expect("verification failed");
-            if result.is_err() {
-                panic!("verify failed");
+            if let Err(e) = result {
+                panic!("verify failed: {e}");
             }
 
             let stdout_writer = std::io::BufWriter::new(std::io::stdout());
@@ -54,8 +54,8 @@ async fn issue(proof_format: &str) {
             let jwt = vc.to_jwt_claims().unwrap().sign(&key).await.unwrap();
 
             let result = jwt.verify(params).await.expect("verification failed");
-            if result.is_err() {
-                panic!("verify failed");
+            if let Err(e) = result {
+                panic!("verify failed: {e}");
             }
 
             print!("{}", jwt);

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -17,7 +17,7 @@ async fn issue(proof_format: &str) {
     let key_str = include_str!("../tests/rsa2048-2020-08-25.json");
     let mut key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     key.key_id = Some("did:example:foo#key1".to_string());
-    let resolver = ssi::dids::example::ExampleDIDResolver::default().with_default_options();
+    let resolver = ssi::dids::example::ExampleDIDResolver::default().into_vm_resolver();
     let verifier = Verifier::from_resolver(&resolver);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 

--- a/examples/issue.rs
+++ b/examples/issue.rs
@@ -7,7 +7,7 @@ use ssi_claims::{
     data_integrity::{AnySuite, CryptographicSuite, ProofOptions},
     jws::JWSPayload,
     vc::v1::ToJwtClaims,
-    VerifiableClaims,
+    VerifiableClaims, Verifier,
 };
 use ssi_dids::DIDResolver;
 use ssi_verification_methods::SingleSecretSigner;
@@ -18,6 +18,7 @@ async fn issue(proof_format: &str) {
     let mut key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     key.key_id = Some("did:example:foo#key1".to_string());
     let resolver = ssi::dids::example::ExampleDIDResolver::default().with_default_options();
+    let verifier = Verifier::from_resolver(&resolver);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     let vc: ssi::claims::vc::v1::SpecializedJsonCredential = serde_json::from_value(json!({
@@ -41,7 +42,7 @@ async fn issue(proof_format: &str) {
             let suite = AnySuite::pick(&key, params.verification_method.as_ref()).unwrap();
             let vc = suite.sign(vc, &resolver, &signer, params).await.unwrap();
 
-            let result = vc.verify(&resolver).await.expect("verification failed");
+            let result = vc.verify(verifier).await.expect("verification failed");
             if result.is_err() {
                 panic!("verify failed");
             }
@@ -52,7 +53,7 @@ async fn issue(proof_format: &str) {
         "jwt" => {
             let jwt = vc.to_jwt_claims().unwrap().sign(&key).await.unwrap();
 
-            let result = jwt.verify(&resolver).await.expect("verification failed");
+            let result = jwt.verify(verifier).await.expect("verification failed");
             if result.is_err() {
                 panic!("verify failed");
             }

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -20,7 +20,7 @@ use ssi::{
 use ssi_claims::{
     data_integrity::AnyDataIntegrity,
     vc::{v1::ToJwtClaims, AnyJsonCredential},
-    Verifier
+    Verifier,
 };
 use ssi_dids::DIDResolver;
 use static_iref::{iri, uri};

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -50,7 +50,7 @@ async fn verify(proof_format_in: &str, proof_format_out: &str, input_vc: &str) {
     let key_str = include_str!("../tests/ed25519-2020-10-18.json");
     let mut key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     key.key_id = Some("did:example:foo#key2".to_string());
-    let resolver = ssi::dids::example::ExampleDIDResolver::default().with_default_options();
+    let resolver = ssi::dids::example::ExampleDIDResolver::default().into_vm_resolver();
     let verifier = Verifier::from_resolver(&resolver);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -13,14 +13,13 @@ use ssi::{
     claims::{
         data_integrity::{AnySuite, CryptographicSuite, ProofOptions},
         jws::{CompactJWSString, JWSPayload},
-        VerifiableClaims,
     },
     verification_methods::{ProofPurpose, SingleSecretSigner},
 };
 use ssi_claims::{
     data_integrity::AnyDataIntegrity,
     vc::{v1::ToJwtClaims, AnyJsonCredential},
-    Verifier,
+    VerificationParameters,
 };
 use ssi_dids::DIDResolver;
 use static_iref::{iri, uri};
@@ -51,7 +50,7 @@ async fn verify(proof_format_in: &str, proof_format_out: &str, input_vc: &str) {
     let mut key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     key.key_id = Some("did:example:foo#key2".to_string());
     let resolver = ssi::dids::example::ExampleDIDResolver::default().into_vm_resolver();
-    let verifier = Verifier::from_resolver(&resolver);
+    let verifier = VerificationParameters::from_resolver(&resolver);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     // let mut proof_options = ssi::vc::LinkedDataProofOptions::default();

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -20,6 +20,7 @@ use ssi::{
 use ssi_claims::{
     data_integrity::AnyDataIntegrity,
     vc::{v1::ToJwtClaims, AnyJsonCredential},
+    Verifier
 };
 use ssi_dids::DIDResolver;
 use static_iref::{iri, uri};
@@ -50,6 +51,7 @@ async fn verify(proof_format_in: &str, proof_format_out: &str, input_vc: &str) {
     let mut key: ssi::jwk::JWK = serde_json::from_str(key_str).unwrap();
     key.key_id = Some("did:example:foo#key2".to_string());
     let resolver = ssi::dids::example::ExampleDIDResolver::default().with_default_options();
+    let verifier = Verifier::from_resolver(&resolver);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
     // let mut proof_options = ssi::vc::LinkedDataProofOptions::default();
@@ -69,7 +71,7 @@ async fn verify(proof_format_in: &str, proof_format_out: &str, input_vc: &str) {
             let suite = AnySuite::pick(&key, params.verification_method.as_ref()).unwrap();
             let vp = suite.sign(vp, &resolver, &signer, params).await.unwrap();
 
-            let result = vp.verify(&resolver).await.expect("verification failed");
+            let result = vp.verify(verifier).await.expect("verification failed");
             if result.is_err() {
                 panic!("verify failed");
             }
@@ -80,7 +82,7 @@ async fn verify(proof_format_in: &str, proof_format_out: &str, input_vc: &str) {
         "jwt" => {
             let jwt = vp.to_jwt_claims().unwrap().sign(&key).await.unwrap();
 
-            let result = jwt.verify(&resolver).await.expect("verification failed");
+            let result = jwt.verify(verifier).await.expect("verification failed");
             if result.is_err() {
                 panic!("verify failed");
             }

--- a/examples/vc_verify.rs
+++ b/examples/vc_verify.rs
@@ -1,5 +1,5 @@
 //! This example shows how to verify a Data-Integrity Verifiable Credential.
-use ssi_claims::{VerifiableClaims, Verifier};
+use ssi_claims::VerificationParameters;
 use ssi_dids::{DIDResolver, StaticDIDResolver, VerificationMethodDIDResolver};
 use ssi_verification_methods::AnyMethod;
 use std::fs;
@@ -21,7 +21,8 @@ async fn main() {
     println!("Success!")
 }
 
-fn create_verifier() -> Verifier<VerificationMethodDIDResolver<StaticDIDResolver, AnyMethod>> {
+fn create_verifier(
+) -> VerificationParameters<VerificationMethodDIDResolver<StaticDIDResolver, AnyMethod>> {
     // Create a static DID resolver that resolves `did:example:foo` into a
     // static DID document.
     let mut did_resolver = ssi::dids::StaticDIDResolver::new();
@@ -38,5 +39,5 @@ fn create_verifier() -> Verifier<VerificationMethodDIDResolver<StaticDIDResolver
     let resolver = did_resolver.into_vm_resolver();
 
     // Create a verifier using the verification method resolver.
-    Verifier::from_resolver(resolver)
+    VerificationParameters::from_resolver(resolver)
 }

--- a/examples/vc_verify.rs
+++ b/examples/vc_verify.rs
@@ -35,7 +35,7 @@ fn create_verifier() -> Verifier<VerificationMethodDIDResolver<StaticDIDResolver
 
     // Turn the DID resolver into a verification method resolver by setting
     // resolution options.
-    let resolver = did_resolver.with_default_options();
+    let resolver = did_resolver.into_vm_resolver();
 
     // Create a verifier using the verification method resolver.
     Verifier::from_resolver(resolver)

--- a/examples/vc_verify.rs
+++ b/examples/vc_verify.rs
@@ -1,5 +1,5 @@
 //! This example shows how to verify a Data-Integrity Verifiable Credential.
-use ssi_claims::VerifiableClaims;
+use ssi_claims::{VerifiableClaims, Verifier};
 use ssi_dids::{DIDResolver, StaticDIDResolver, VerificationMethodDIDResolver};
 use ssi_verification_methods::AnyMethod;
 use std::fs;
@@ -21,7 +21,7 @@ async fn main() {
     println!("Success!")
 }
 
-fn create_verifier() -> VerificationMethodDIDResolver<StaticDIDResolver, AnyMethod> {
+fn create_verifier() -> Verifier<VerificationMethodDIDResolver<StaticDIDResolver, AnyMethod>> {
     // Create a static DID resolver that resolves `did:example:foo` into a
     // static DID document.
     let mut did_resolver = ssi::dids::StaticDIDResolver::new();
@@ -35,5 +35,8 @@ fn create_verifier() -> VerificationMethodDIDResolver<StaticDIDResolver, AnyMeth
 
     // Turn the DID resolver into a verification method resolver by setting
     // resolution options.
-    did_resolver.with_default_options()
+    let resolver = did_resolver.with_default_options();
+
+    // Create a verifier using the verification method resolver.
+    Verifier::from_resolver(resolver)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! // public key used to sign the JWT.
 //! // Here we use the example `ExampleDIDResolver` resolver, enabled with the
 //! // `example` feature.
-//! let vm_resolver = ExampleDIDResolver::default().with_default_options::<AnyJwkMethod>();
+//! let vm_resolver = ExampleDIDResolver::default().into_vm_resolver::<AnyJwkMethod>();
 //!
 //! // Create a verifier from our verification method resolver.
 //! let verifier = Verifier::from_resolver(vm_resolver);
@@ -93,7 +93,7 @@
 //!
 //! // Setup a verification method resolver, in charge of retrieving the
 //! // public key used to sign the JWT.
-//! let vm_resolver = ExampleDIDResolver::default().with_default_options();
+//! let vm_resolver = ExampleDIDResolver::default().into_vm_resolver();
 //!
 //! // Create a verifier from our verification method resolver.
 //! let verifier = Verifier::from_resolver(vm_resolver);
@@ -143,7 +143,7 @@
 //!
 //! // Create a verification method resolver, which will be in charge of
 //! // decoding the DID back into a public key.
-//! let vm_resolver = DIDJWK.with_default_options::<AnyJwkMethod>();
+//! let vm_resolver = DIDJWK.into_vm_resolver::<AnyJwkMethod>();
 //!
 //! // Create a verifier from our verification method resolver.
 //! let verifier = Verifier::from_resolver(vm_resolver);
@@ -198,7 +198,7 @@
 //!
 //! // Create a verification method resolver, which will be in charge of
 //! // decoding the DID back into a public key.
-//! let vm_resolver = DIDJWK.with_default_options();
+//! let vm_resolver = DIDJWK.into_vm_resolver();
 //!
 //! // Create a signer from the secret key.
 //! // Here we use the simple `SingleSecretSigner` signer type which always uses

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,11 @@
 //! // `example` feature.
 //! let vm_resolver = ExampleDIDResolver::default().with_default_options::<AnyJwkMethod>();
 //!
+//! // Create a verifier from our verification method resolver.
+//! let verifier = Verifier::from_resolver(vm_resolver);
+//!
 //! // Verify the JWT.
-//! assert!(jwt.verify(&vm_resolver).await.expect("verification failed").is_ok())
+//! assert!(jwt.verify(&verifier).await.expect("verification failed").is_ok())
 //! # }
 //! ```
 //!
@@ -92,7 +95,10 @@
 //! // public key used to sign the JWT.
 //! let vm_resolver = ExampleDIDResolver::default().with_default_options();
 //!
-//! assert!(vc.verify(&vm_resolver).await.expect("verification failed").is_ok());
+//! // Create a verifier from our verification method resolver.
+//! let verifier = Verifier::from_resolver(vm_resolver);
+//!
+//! assert!(vc.verify(&verifier).await.expect("verification failed").is_ok());
 //! # }
 //! ```
 //!
@@ -139,8 +145,11 @@
 //! // decoding the DID back into a public key.
 //! let vm_resolver = DIDJWK.with_default_options::<AnyJwkMethod>();
 //!
+//! // Create a verifier from our verification method resolver.
+//! let verifier = Verifier::from_resolver(vm_resolver);
+//!
 //! // Verify the JWT.
-//! assert!(jwt.verify(&vm_resolver).await.expect("verification failed").is_ok());
+//! assert!(jwt.verify(&verifier).await.expect("verification failed").is_ok());
 //!
 //! // Print the JWT.
 //! println!("{jwt}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,11 +60,11 @@
 //! // `example` feature.
 //! let vm_resolver = ExampleDIDResolver::default().into_vm_resolver::<AnyJwkMethod>();
 //!
-//! // Create a verifier from our verification method resolver.
-//! let verifier = Verifier::from_resolver(vm_resolver);
+//! // Setup the verification parameters.
+//! let params = VerificationParameters::from_resolver(vm_resolver);
 //!
 //! // Verify the JWT.
-//! assert!(jwt.verify(&verifier).await.expect("verification failed").is_ok())
+//! assert!(jwt.verify(&params).await.expect("verification failed").is_ok())
 //! # }
 //! ```
 //!
@@ -95,10 +95,10 @@
 //! // public key used to sign the JWT.
 //! let vm_resolver = ExampleDIDResolver::default().into_vm_resolver();
 //!
-//! // Create a verifier from our verification method resolver.
-//! let verifier = Verifier::from_resolver(vm_resolver);
+//! // Setup the verification parameters.
+//! let params = VerificationParameters::from_resolver(vm_resolver);
 //!
-//! assert!(vc.verify(&verifier).await.expect("verification failed").is_ok());
+//! assert!(vc.verify(&params).await.expect("verification failed").is_ok());
 //! # }
 //! ```
 //!
@@ -145,11 +145,11 @@
 //! // decoding the DID back into a public key.
 //! let vm_resolver = DIDJWK.into_vm_resolver::<AnyJwkMethod>();
 //!
-//! // Create a verifier from our verification method resolver.
-//! let verifier = Verifier::from_resolver(vm_resolver);
+//! // Setup the verification parameters.
+//! let params = VerificationParameters::from_resolver(vm_resolver);
 //!
 //! // Verify the JWT.
-//! assert!(jwt.verify(&verifier).await.expect("verification failed").is_ok());
+//! assert!(jwt.verify(&params).await.expect("verification failed").is_ok());
 //!
 //! // Print the JWT.
 //! println!("{jwt}")
@@ -274,6 +274,18 @@ pub use ssi_security as security;
 /// Includes Verifiable Credentials and Data-Integrity Proofs.
 #[doc(inline)]
 pub use ssi_claims as claims;
+
+/// Default verification parameters type.
+///
+/// This type can be used as parameters of the
+/// [`claims::VerifiableClaims::verify`] function for most claims and signature
+/// types. It provides sensible defaults for common parameters:
+///   - A DID resolver with support for various DID methods,
+///   - A JSON-LD document loader recognizing popular JSON-LD contexts,
+///   - the current date and time.
+pub type DefaultVerificationParameters = claims::VerificationParameters<
+    dids::VerificationMethodDIDResolver<dids::AnyDidMethod, verification_methods::AnyMethod>,
+>;
 
 /// Verification Methods.
 #[doc(inline)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,7 +6,7 @@ pub use crate::{
         },
         vc::syntax::{AnyJsonCredential, AnyJsonPresentation},
         CompactJWS, CompactJWSBuf, CompactJWSStr, CompactJWSString, JWSPayload, JWTClaims,
-        VerifiableClaims,
+        VerifiableClaims, Verifier,
     },
     dids::{DIDResolver, DIDJWK},
     verification_methods::{AnyJwkMethod, AnyMethod, SingleSecretSigner},

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,12 +6,12 @@ pub use crate::{
         },
         vc::syntax::{AnyJsonCredential, AnyJsonPresentation},
         CompactJWS, CompactJWSBuf, CompactJWSStr, CompactJWSString, JWSPayload, JWTClaims,
-        VerifiableClaims, Verifier,
+        VerificationParameters,
     },
     dids::{DIDResolver, DIDJWK},
     verification_methods::{AnyJwkMethod, AnyMethod, SingleSecretSigner},
     xsd_types::DateTime,
-    JWK,
+    DefaultVerificationParameters, JWK,
 };
 
 #[cfg(feature = "example")]

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -34,7 +34,7 @@ fn data_integrity_sign_is_send() {
 
     let key = JWK::generate_p256(); // requires the `p256` feature.
     let did = DIDJWK::generate_url(&key.to_public());
-    let vm_resolver = DIDJWK.with_default_options();
+    let vm_resolver = DIDJWK.into_vm_resolver();
     let signer = SingleSecretSigner::new(key.clone()).into_local();
     let verification_method = did.into_iri().into();
 

--- a/tests/vcdm_v1_sign.rs
+++ b/tests/vcdm_v1_sign.rs
@@ -3,7 +3,7 @@ use ssi::JWK;
 use ssi_claims::{
     data_integrity::{AnySuite, CryptographicSuite, ProofOptions},
     vc::v1::JsonCredential,
-    VerifiableClaims,
+    VerificationParameters,
 };
 use ssi_dids::{AnyDidMethod, VerificationMethodDIDResolver};
 use ssi_verification_methods::{AnyMethod, SingleSecretSigner};
@@ -43,5 +43,9 @@ async fn ed25519_signature_2020() {
         )
         .await
         .unwrap();
-    signed_vc.verify(&resolver).await.unwrap().unwrap();
+    signed_vc
+        .verify(VerificationParameters::from_resolver(resolver))
+        .await
+        .unwrap()
+        .unwrap();
 }


### PR DESCRIPTION
Currently the `VerifiableClaims::verify` function (or more precisely `verify_with`) takes a "verifier" and an "environment". The "verifier" is in fact a public key resolver (W3C verification method resolver or JWK resolver, etc), while the environment provides any other resource required to validate the claims and signature.

I realized there is no real reason to separate the resolver from the environment. Merging them into a single `verifier` allows us to remove an input argument to many functions (including `VerifiableClaims::verify`) and remove a type parameter to some traits. This is the purpose of this PR.

Here is an overview of the changes:
  - Remove the `environment` argument in `VerifiableClaims::verify`, the `verifier` is now the "environment".
  - Remove the `VerifiableClaims::verify_with`, now unnecessary.
  - Add a `ResolverEnvironment` trait implemented by any type providing a public key resolver (similar to other `*Environment` traits).
  - Add a `Verifier` type, implementing `ResolverEnvironment` and all the commonly used `*Environment` traits. This is the default built-in verifier type that works with most verifiable claims. It replaces the old `VerificationEnvironment` type.
  - Rename `Validate` into `ValidateClaims`.
  - Remove the `verifier` argument from `ValidateProof`. Now `ValidateClaims` and `ValidateProof` are completely symmetrical.
  - Rename `JWSVerifier` into `JWKResolver`. This makes the function of this trait clearer: its a type that can resolve a key id into a JWK. Just like `VerificationMethodResolver` resolves a key id into a W3C verification method.

The only downside is that the `verify` function must take an actual verifier as parameter, and not just the public key resolver. A verifier can be built from a resolver using `Verifier::from_resolver`. It's one more step, but I also think it makes more sense while making customizing the verifier easier. For instance its possible to customize the JSON-LD context loader while constructing the verifier with one line:
```
// Create verifier with custom LD loader.
let verifier = Verifier::from_resolver(my_resolver).with_json_ld_loader(my_custom_loader);

// Verify the claims.
vc.verify(&verifier).await;
```
Before, you would need to construct your own verification environment and use `verify_with` instead of `verify`.