### PR TITLE
Add `Ed25519Signature2020` context when missing

### DIFF
--- a/crates/claims/crates/data-integrity/core/src/suite/configuration.rs
+++ b/crates/claims/crates/data-integrity/core/src/suite/configuration.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use ssi_claims_core::SignatureError;
+use ssi_json_ld::syntax::Context;
 
 use crate::{CryptographicSuite, ProofConfiguration, ProofOptions};
 
@@ -79,7 +80,12 @@ where
         options: ProofOptions<S::VerificationMethod, S::ProofOptions>,
     ) -> Result<ProofConfiguration<S>, ConfigurationError> {
         let mut result = options.into_configuration(suite.clone())?;
-        result.context = Some(C::default().into());
+        result.context = match result.context {
+            None => Some(C::default().into()),
+            Some(c) => Some(Context::Many(
+                c.into_iter().chain(C::default().into()).collect(),
+            )),
+        };
         Ok(result)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2020.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2020.rs
@@ -5,14 +5,23 @@
 //!
 //! See: <https://w3c.github.io/vc-di-eddsa/#the-ed25519signature2020-suite>
 use k256::sha2::Sha256;
+use lazy_static::lazy_static;
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     signing::{Base58Btc, MultibaseSigning},
-    suite::NoConfiguration,
+    suite::AddProofContext,
     StandardCryptographicSuite, TypeRef,
 };
 use ssi_verification_methods::Ed25519VerificationKey2020;
-use static_iref::iri;
+use static_iref::{iri, iri_ref};
+
+lazy_static! {
+    static ref PROOF_CONTEXT: ssi_json_ld::syntax::ContextEntry = {
+        ssi_json_ld::syntax::ContextEntry::IriRef(
+            iri_ref!("https://w3id.org/security/suites/ed25519-2020/v1").to_owned(),
+        )
+    };
+}
 
 /// EdDSA Cryptosuite v2020.
 ///
@@ -29,8 +38,17 @@ impl Ed25519Signature2020 {
     pub const IRI: &'static iref::Iri = iri!("https://w3id.org/security#Ed25519Signature2020");
 }
 
+#[derive(Default)]
+pub struct Ed25519Signature2020v1Context;
+
+impl From<Ed25519Signature2020v1Context> for ssi_json_ld::syntax::Context {
+    fn from(_: Ed25519Signature2020v1Context) -> Self {
+        ssi_json_ld::syntax::Context::One(PROOF_CONTEXT.clone())
+    }
+}
+
 impl StandardCryptographicSuite for Ed25519Signature2020 {
-    type Configuration = NoConfiguration;
+    type Configuration = AddProofContext<Ed25519Signature2020v1Context>;
 
     type Transformation = CanonicalizeClaimsAndConfiguration;
 

--- a/tests/send.rs
+++ b/tests/send.rs
@@ -4,6 +4,8 @@
 //! This test ensures that the Rust compiler is able to prove that the
 //! `CryptographicSuite::sign` returns a future that is `Send` without
 //! triggering the issue.
+mod vcdm_v1_sign;
+
 use serde::{Deserialize, Serialize};
 use ssi::{
     claims::{

--- a/tests/vcdm_v1_sign.rs
+++ b/tests/vcdm_v1_sign.rs
@@ -1,0 +1,47 @@
+use serde_json::json;
+use ssi::JWK;
+use ssi_claims::{
+    data_integrity::{AnySuite, CryptographicSuite, ProofOptions},
+    vc::v1::JsonCredential,
+    VerifiableClaims,
+};
+use ssi_dids::{AnyDidMethod, VerificationMethodDIDResolver};
+use ssi_verification_methods::{AnyMethod, SingleSecretSigner};
+use static_iref::iri;
+
+#[async_std::test]
+async fn ed25519_signature_2020() {
+    let jwk: JWK = serde_json::from_value(json!({
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "HvjBEw94RHAh9KkiD385aYZNxGkxIkwBcrLBY5Z7Koo",
+      "d": "1onWu34oC29Y09qCRl0aD2FOp5y5obTqHZxQQRT3-bs"
+    }))
+    .unwrap();
+    let resolver = VerificationMethodDIDResolver::<_, AnyMethod>::new(AnyDidMethod::default());
+    let vc: JsonCredential = serde_json::from_value(json!({
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1"
+      ],
+      "type": [
+        "VerifiableCredential"
+      ],
+      "credentialSubject": {
+        "id": "did:key:z6MkhTNL7i2etLerDK8Acz5t528giE5KA4p75T6ka1E1D74r"
+      },
+      "issuanceDate": "2024-06-01T09:09:48Z",
+      "id": "urn:uuid:7a6cafb9-11c3-41a8-98d8-8b5a45c2548f",
+      "issuer": "did:key:z6MkgYAGxLBSXa6Ygk1PnUbK2F7zya8juE9nfsZhrvY7c9GD"
+    }))
+    .unwrap();
+    let signed_vc = AnySuite::Ed25519Signature2020
+        .sign(
+            vc,
+            &resolver,
+            SingleSecretSigner::new(jwk).into_local(),
+            ProofOptions::from_method(iri!("did:key:z6MkgYAGxLBSXa6Ygk1PnUbK2F7zya8juE9nfsZhrvY7c9GD#z6MkgYAGxLBSXa6Ygk1PnUbK2F7zya8juE9nfsZhrvY7c9GD").into()),
+        )
+        .await
+        .unwrap();
+    signed_vc.verify(&resolver).await.unwrap().unwrap();
+}


### PR DESCRIPTION
Also:
- add end-to-end test for signing a `Ed25519Signature2020` VCDM v1 credential
- tweak `AddProofContext` to append contexts instead of replacing

(We talked about having `AddProofContext` only add the context when it's missing from the global context but that's a bit too much work for this PR)