### PR TITLE
Skip serializing missing id.

### DIFF
--- a/crates/claims/crates/vc/src/syntax/mod.rs
+++ b/crates/claims/crates/vc/src/syntax/mod.rs
@@ -48,6 +48,7 @@ pub struct IdentifiedObject {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MaybeIdentifiedObject {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<UriBuf>,
 
     #[serde(flatten)]
@@ -69,6 +70,7 @@ pub struct IdentifiedTypedObject {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MaybeIdentifiedTypedObject {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<UriBuf>,
 
     #[serde(rename = "type", with = "value_or_array")]


### PR DESCRIPTION
Skip serializing `None` identifier in `MaybeIdentifiedObject` and `MaybeIdentifiedTypedObject`. They are currently serialized as `id: null` which causes the JSON-LD expansion algorithm to fail.