### PR TITLE
Reject `null` identifiers in VCDM.

### DIFF
--- a/crates/claims/crates/vc/src/v1/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/credential.rs
@@ -9,8 +9,9 @@ use std::{borrow::Cow, collections::BTreeMap, hash::Hash};
 use xsd_types::DateTime;
 
 use crate::syntax::{
-    value_or_array, IdOr, IdentifiedObject, IdentifiedTypedObject, MaybeIdentifiedTypedObject,
-    RequiredContextList, RequiredType, RequiredTypeSet, TypeSerializationPolicy, Types,
+    not_null, value_or_array, IdOr, IdentifiedObject, IdentifiedTypedObject,
+    MaybeIdentifiedTypedObject, RequiredContextList, RequiredType, RequiredTypeSet,
+    TypeSerializationPolicy, Types,
 };
 
 use super::Context;
@@ -50,7 +51,11 @@ pub struct SpecializedJsonCredential<S = json_syntax::Value, C = (), T = ()> {
     pub context: Context<C>,
 
     /// Credential identifier.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "not_null",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub id: Option<UriBuf>,
 
     /// Credential type.

--- a/crates/claims/crates/vc/src/v1/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/presentation.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, collections::BTreeMap, hash::Hash};
 
-use crate::syntax::{value_or_array, RequiredType, TypeSerializationPolicy, Types};
+use crate::syntax::{not_null, value_or_array, RequiredType, TypeSerializationPolicy, Types};
 use crate::v1::{Context, Credential};
 use iref::{Uri, UriBuf};
 use linked_data::{LinkedDataResource, LinkedDataSubject};
@@ -38,7 +38,11 @@ pub struct JsonPresentation<C = SpecializedJsonCredential> {
     pub context: Context,
 
     /// Presentation identifier.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "not_null",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub id: Option<UriBuf>,
 
     /// Presentation type.

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -2,8 +2,8 @@ use std::{borrow::Cow, collections::BTreeMap, hash::Hash};
 
 use super::{Context, InternationalString, RelatedResource};
 use crate::syntax::{
-    value_or_array, IdOr, IdentifiedObject, IdentifiedTypedObject, MaybeIdentifiedTypedObject,
-    RequiredContextList, RequiredTypeSet, TypedObject,
+    not_null, value_or_array, IdOr, IdentifiedObject, IdentifiedTypedObject,
+    MaybeIdentifiedTypedObject, RequiredContextList, RequiredTypeSet, TypedObject,
 };
 use iref::{Uri, UriBuf};
 use rdf_types::VocabularyMut;
@@ -36,7 +36,11 @@ pub struct SpecializedJsonCredential<S = json_syntax::Value, C = (), T = ()> {
     pub context: Context<C>,
 
     /// Credential identifier.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "not_null",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub id: Option<UriBuf>,
 
     /// Credential type.

--- a/crates/claims/crates/vc/src/v2/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/presentation.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, collections::BTreeMap, hash::Hash};
 
-use crate::syntax::{value_or_array, IdOr, IdentifiedObject};
+use crate::syntax::{not_null, value_or_array, IdOr, IdentifiedObject};
 use crate::v2::{Context, Credential};
 use iref::{Uri, UriBuf};
 use rdf_types::VocabularyMut;
@@ -27,7 +27,11 @@ pub struct JsonPresentation<C = JsonCredential> {
     pub context: Context,
 
     /// Presentation identifier.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "not_null",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub id: Option<UriBuf>,
 
     /// Presentation type.


### PR DESCRIPTION
Fail when deserializing `id: null` in VCDM syntax types.