### PR TITLE
Fix `token_status_list::StatusSize` deserializer.

### DIFF
--- a/crates/claims/crates/status/src/impl/bitstream_status_list/mod.rs
+++ b/crates/claims/crates/status/src/impl/bitstream_status_list/mod.rs
@@ -664,6 +664,6 @@ mod tests {
 
     #[test]
     fn deserialize_status_size_overflow() {
-        assert!(serde_json::from_str::<StatusSize>("256").is_err())
+        assert!(serde_json::from_str::<StatusSize>("9").is_err())
     }
 }

--- a/crates/claims/crates/status/src/impl/bitstream_status_list/mod.rs
+++ b/crates/claims/crates/status/src/impl/bitstream_status_list/mod.rs
@@ -641,4 +641,29 @@ mod tests {
         // Too many bits.
         assert_eq!(bitstring.set(14, 2), Err(Overflow::Value(2)));
     }
+
+    #[test]
+    fn deserialize_status_size_1() {
+        assert!(serde_json::from_str::<StatusSize>("1").is_ok())
+    }
+
+    #[test]
+    fn deserialize_status_size_2() {
+        assert!(serde_json::from_str::<StatusSize>("2").is_ok())
+    }
+
+    #[test]
+    fn deserialize_status_size_3() {
+        assert!(serde_json::from_str::<StatusSize>("3").is_ok())
+    }
+
+    #[test]
+    fn deserialize_status_size_negative() {
+        assert!(serde_json::from_str::<StatusSize>("-1").is_err())
+    }
+
+    #[test]
+    fn deserialize_status_size_overflow() {
+        assert!(serde_json::from_str::<StatusSize>("256").is_err())
+    }
 }

--- a/crates/claims/crates/status/src/impl/token_status_list/json.rs
+++ b/crates/claims/crates/status/src/impl/token_status_list/json.rs
@@ -243,3 +243,19 @@ impl StatusMapEntry for StatusListReference {
         &self.uri
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::token_status_list::json::JsonStatusList;
+
+    #[test]
+    fn deserialize_json_status_list() {
+        assert!(serde_json::from_str::<JsonStatusList>(
+            r#"{
+                "bits": 1,
+                "lst": "eNrbuRgAAhcBXQ"
+            }"#
+        )
+        .is_ok())
+    }
+}

--- a/crates/claims/crates/status/src/impl/token_status_list/mod.rs
+++ b/crates/claims/crates/status/src/impl/token_status_list/mod.rs
@@ -216,24 +216,9 @@ impl<'de> serde::Deserialize<'de> for StatusSize {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Visitor;
-
-        impl<'de> serde::de::Visitor<'de> for Visitor {
-            type Value = StatusSize;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(formatter, "number of bits per Referenced Token")
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-        }
-
-        deserializer.deserialize_u8(Visitor)
+        u8::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -771,5 +756,10 @@ mod tests {
 
         // Too many bits.
         assert_eq!(bitstring.set(14, 2), Err(Overflow::Value(2)));
+    }
+
+    #[test]
+    fn deserialize_status_size() {
+        serde_json::from_str::<StatusSize>("2").unwrap();
     }
 }

--- a/crates/claims/crates/status/src/impl/token_status_list/mod.rs
+++ b/crates/claims/crates/status/src/impl/token_status_list/mod.rs
@@ -790,6 +790,6 @@ mod tests {
 
     #[test]
     fn deserialize_status_size_overflow() {
-        assert!(serde_json::from_str::<StatusSize>("256").is_err())
+        assert!(serde_json::from_str::<StatusSize>("9").is_err())
     }
 }

--- a/crates/claims/crates/status/src/impl/token_status_list/mod.rs
+++ b/crates/claims/crates/status/src/impl/token_status_list/mod.rs
@@ -759,7 +759,37 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_status_size() {
-        serde_json::from_str::<StatusSize>("2").unwrap();
+    fn deserialize_status_size_1() {
+        assert!(serde_json::from_str::<StatusSize>("1").is_ok())
+    }
+
+    #[test]
+    fn deserialize_status_size_2() {
+        assert!(serde_json::from_str::<StatusSize>("2").is_ok())
+    }
+
+    #[test]
+    fn deserialize_status_size_4() {
+        assert!(serde_json::from_str::<StatusSize>("4").is_ok())
+    }
+
+    #[test]
+    fn deserialize_status_size_8() {
+        assert!(serde_json::from_str::<StatusSize>("8").is_ok())
+    }
+
+    #[test]
+    fn deserialize_status_size_non_power_of_two() {
+        assert!(serde_json::from_str::<StatusSize>("3").is_err())
+    }
+
+    #[test]
+    fn deserialize_status_size_negative() {
+        assert!(serde_json::from_str::<StatusSize>("-1").is_err())
+    }
+
+    #[test]
+    fn deserialize_status_size_overflow() {
+        assert!(serde_json::from_str::<StatusSize>("256").is_err())
     }
 }


### PR DESCRIPTION
Deserializing a status size fails because the JSON deserializer does not follow hints. This fixes the issue by calling `u8::deserialize` instead.