### PR TITLE
Upgrade `json-ld` to version 0.20

### DIFF
--- a/crates/claims/crates/vc/src/v1/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/credential.rs
@@ -266,3 +266,28 @@ where
         json.expand_with(ld, loader).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ssi_json_ld::{CompactJsonLd, ContextLoader, Expandable};
+
+    #[async_std::test]
+    async fn reject_undefined_type() {
+        let input = CompactJsonLd(json_syntax::json!({
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                { "@vocab": null }
+            ],
+            "type": [
+                "VerifiableCredential",
+                "ExampleTestCredential"
+            ],
+            "issuer": "did:example:issuer",
+            "credentialSubject": {
+                "id": "did:example:subject"
+            }
+        }));
+
+        assert!(input.expand(&ContextLoader::default()).await.is_err());
+    }
+}

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -247,3 +247,28 @@ where
         json.expand_with(ld, loader).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ssi_json_ld::{CompactJsonLd, ContextLoader, Expandable};
+
+    #[async_std::test]
+    async fn reject_undefined_type() {
+        let input = CompactJsonLd(json_syntax::json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                { "@vocab": null }
+            ],
+            "type": [
+                "VerifiableCredential",
+                "ExampleTestCredential"
+            ],
+            "issuer": "did:example:issuer",
+            "credentialSubject": {
+                "id": "did:example:subject"
+            }
+        }));
+
+        assert!(input.expand(&ContextLoader::default()).await.is_err());
+    }
+}

--- a/crates/json-ld/Cargo.toml
+++ b/crates/json-ld/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/ssi-json-ld/"
 [dependencies]
 thiserror.workspace = true
 async-std = { version = "1.9", features = ["attributes"] }
-json-ld = { version = "0.19.2", features = ["serde"] }
+json-ld = { version = "0.20", features = ["serde"] }
 iref.workspace = true
 static-iref.workspace = true
 rdf-types.workspace = true

--- a/crates/json-ld/src/lib.rs
+++ b/crates/json-ld/src/lib.rs
@@ -231,3 +231,46 @@ impl<T> WithContext<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{CompactJsonLd, ContextLoader, Expandable};
+
+    #[async_std::test]
+    async fn accept_defined_type() {
+        let input = CompactJsonLd(json_syntax::json!({
+            "@context": { "Defined": "http://example.org/#Defined" },
+            "@type": ["Defined"]
+        }));
+
+        assert!(input.expand(&ContextLoader::default()).await.is_ok());
+    }
+
+    #[async_std::test]
+    async fn reject_undefined_type() {
+        let input = CompactJsonLd(json_syntax::json!({
+            "@type": ["Undefined"]
+        }));
+
+        assert!(input.expand(&ContextLoader::default()).await.is_err());
+    }
+
+    #[async_std::test]
+    async fn accept_defined_property() {
+        let input = CompactJsonLd(json_syntax::json!({
+            "@context": { "defined": "http://example.org/#defined" },
+            "defined": "foo"
+        }));
+
+        assert!(input.expand(&ContextLoader::default()).await.is_ok());
+    }
+
+    #[async_std::test]
+    async fn reject_undefined_property() {
+        let input = CompactJsonLd(json_syntax::json!({
+            "undefined": "foo"
+        }));
+
+        assert!(input.expand(&ContextLoader::default()).await.is_err());
+    }
+}

--- a/crates/json-ld/src/lib.rs
+++ b/crates/json-ld/src/lib.rs
@@ -4,6 +4,7 @@ mod context;
 use std::{borrow::Cow, hash::Hash};
 
 pub use context::*;
+use json_ld::expansion::Action;
 use json_ld::Expand;
 use linked_data::{LinkedData, LinkedDataResource, LinkedDataSubject};
 
@@ -111,7 +112,11 @@ impl Expandable for CompactJsonLd {
                 None,
                 loader,
                 json_ld::expansion::Options {
-                    policy: json_ld::expansion::Policy::Strict,
+                    policy: json_ld::expansion::Policy {
+                        invalid: Action::Reject,
+                        allow_undefined: false,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 (),


### PR DESCRIPTION
This version introduce a finer expansion policy option, which is also applied to node types.