### PR TITLE
Make DataIntegrityProof created field optional

### DIFF
--- a/crates/claims/crates/data-integrity/core/src/options.rs
+++ b/crates/claims/crates/data-integrity/core/src/options.rs
@@ -14,7 +14,7 @@ pub struct ProofOptions<M, T> {
 
     /// Date a creation of the proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTime>,
+    pub created: Option<xsd_types::DateTimeStamp>,
 
     /// Verification method.
     pub verification_method: Option<ReferenceOrOwned<M>>,
@@ -74,7 +74,7 @@ impl<M, T: Default> Default for ProofOptions<M, T> {
     fn default() -> Self {
         Self {
             context: None,
-            created: Some(xsd_types::DateTime::now_ms()),
+            created: Some(xsd_types::DateTimeStamp::now_ms()),
             verification_method: None,
             proof_purpose: ProofPurpose::default(),
             expires: None,
@@ -89,7 +89,7 @@ impl<M, T: Default> Default for ProofOptions<M, T> {
 
 impl<M, T> ProofOptions<M, T> {
     pub fn new(
-        created: xsd_types::DateTime,
+        created: xsd_types::DateTimeStamp,
         verification_method: ReferenceOrOwned<M>,
         proof_purpose: ProofPurpose,
         options: T,
@@ -111,7 +111,7 @@ impl<M, T> ProofOptions<M, T> {
     pub fn from_method_and_options(verification_method: ReferenceOrOwned<M>, options: T) -> Self {
         Self {
             context: None,
-            created: Some(xsd_types::DateTime::now_ms()),
+            created: Some(xsd_types::DateTimeStamp::now_ms()),
             verification_method: Some(verification_method),
             proof_purpose: ProofPurpose::default(),
             expires: None,

--- a/crates/claims/crates/data-integrity/core/src/options.rs
+++ b/crates/claims/crates/data-integrity/core/src/options.rs
@@ -13,8 +13,8 @@ pub struct ProofOptions<M, T> {
     pub context: Option<ssi_json_ld::syntax::Context>,
 
     /// Date a creation of the proof.
-    #[serde(default = "xsd_types::DateTime::now")]
-    pub created: xsd_types::DateTime,
+    #[serde(default = "created_default", skip_serializing_if = "Option::is_none")]
+    pub created: Option<xsd_types::DateTime>,
 
     /// Verification method.
     pub verification_method: Option<ReferenceOrOwned<M>>,
@@ -70,11 +70,15 @@ pub struct ProofOptions<M, T> {
     pub extra_properties: BTreeMap<String, json_syntax::Value>,
 }
 
+fn created_default() -> Option<xsd_types::DateTime> {
+    Some(xsd_types::DateTime::now())
+}
+
 impl<M, T: Default> Default for ProofOptions<M, T> {
     fn default() -> Self {
         Self {
             context: None,
-            created: xsd_types::DateTime::now_ms(),
+            created: Some(xsd_types::DateTime::now_ms()),
             verification_method: None,
             proof_purpose: ProofPurpose::default(),
             expires: None,
@@ -96,7 +100,7 @@ impl<M, T> ProofOptions<M, T> {
     ) -> Self {
         Self {
             context: None,
-            created,
+            created: Some(created),
             verification_method: Some(verification_method),
             proof_purpose,
             expires: None,
@@ -111,7 +115,7 @@ impl<M, T> ProofOptions<M, T> {
     pub fn from_method_and_options(verification_method: ReferenceOrOwned<M>, options: T) -> Self {
         Self {
             context: None,
-            created: xsd_types::DateTime::now_ms(),
+            created: Some(xsd_types::DateTime::now_ms()),
             verification_method: Some(verification_method),
             proof_purpose: ProofPurpose::default(),
             expires: None,

--- a/crates/claims/crates/data-integrity/core/src/options.rs
+++ b/crates/claims/crates/data-integrity/core/src/options.rs
@@ -14,7 +14,7 @@ pub struct ProofOptions<M, T> {
 
     /// Date a creation of the proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTimeStamp>,
+    pub created: Option<xsd_types::DateTime>,
 
     /// Verification method.
     pub verification_method: Option<ReferenceOrOwned<M>>,
@@ -74,7 +74,7 @@ impl<M, T: Default> Default for ProofOptions<M, T> {
     fn default() -> Self {
         Self {
             context: None,
-            created: Some(xsd_types::DateTimeStamp::now_ms()),
+            created: Some(xsd_types::DateTime::now_ms()),
             verification_method: None,
             proof_purpose: ProofPurpose::default(),
             expires: None,
@@ -89,7 +89,7 @@ impl<M, T: Default> Default for ProofOptions<M, T> {
 
 impl<M, T> ProofOptions<M, T> {
     pub fn new(
-        created: xsd_types::DateTimeStamp,
+        created: xsd_types::DateTime,
         verification_method: ReferenceOrOwned<M>,
         proof_purpose: ProofPurpose,
         options: T,
@@ -111,7 +111,7 @@ impl<M, T> ProofOptions<M, T> {
     pub fn from_method_and_options(verification_method: ReferenceOrOwned<M>, options: T) -> Self {
         Self {
             context: None,
-            created: Some(xsd_types::DateTimeStamp::now_ms()),
+            created: Some(xsd_types::DateTime::now_ms()),
             verification_method: Some(verification_method),
             proof_purpose: ProofPurpose::default(),
             expires: None,

--- a/crates/claims/crates/data-integrity/core/src/options.rs
+++ b/crates/claims/crates/data-integrity/core/src/options.rs
@@ -13,7 +13,7 @@ pub struct ProofOptions<M, T> {
     pub context: Option<ssi_json_ld::syntax::Context>,
 
     /// Date a creation of the proof.
-    #[serde(default = "created_default", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<xsd_types::DateTime>,
 
     /// Verification method.
@@ -68,10 +68,6 @@ pub struct ProofOptions<M, T> {
     /// Extra properties.
     #[serde(flatten)]
     pub extra_properties: BTreeMap<String, json_syntax::Value>,
-}
-
-fn created_default() -> Option<xsd_types::DateTime> {
-    Some(xsd_types::DateTime::now())
 }
 
 impl<M, T: Default> Default for ProofOptions<M, T> {

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
@@ -31,7 +31,7 @@ pub struct ProofConfiguration<S: CryptographicSuite> {
 
     /// Date a creation of the proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTime>,
+    pub created: Option<xsd_types::DateTimeStamp>,
 
     /// Verification method.
     #[serde(serialize_with = "S::serialize_verification_method_ref")]
@@ -90,7 +90,7 @@ pub struct ProofConfiguration<S: CryptographicSuite> {
 impl<S: CryptographicSuite> ProofConfiguration<S> {
     pub fn new(
         type_: S,
-        created: xsd_types::DateTime,
+        created: xsd_types::DateTimeStamp,
         verification_method: ReferenceOrOwned<S::VerificationMethod>,
         proof_purpose: ProofPurpose,
         options: S::ProofOptions,
@@ -118,7 +118,7 @@ impl<S: CryptographicSuite> ProofConfiguration<S> {
         Self {
             context: None,
             type_,
-            created: Some(xsd_types::DateTime::now_ms()),
+            created: Some(xsd_types::DateTimeStamp::now_ms()),
             verification_method,
             proof_purpose: ProofPurpose::default(),
             expires: None,

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
@@ -30,7 +30,8 @@ pub struct ProofConfiguration<S: CryptographicSuite> {
     pub type_: S,
 
     /// Date a creation of the proof.
-    pub created: xsd_types::DateTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<xsd_types::DateTime>,
 
     /// Verification method.
     #[serde(serialize_with = "S::serialize_verification_method_ref")]
@@ -97,7 +98,7 @@ impl<S: CryptographicSuite> ProofConfiguration<S> {
         Self {
             context: None,
             type_,
-            created,
+            created: Some(created),
             verification_method,
             proof_purpose,
             expires: None,
@@ -117,7 +118,7 @@ impl<S: CryptographicSuite> ProofConfiguration<S> {
         Self {
             context: None,
             type_,
-            created: xsd_types::DateTime::now_ms(),
+            created: Some(xsd_types::DateTime::now_ms()),
             verification_method,
             proof_purpose: ProofPurpose::default(),
             expires: None,

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
@@ -31,7 +31,7 @@ pub struct ProofConfiguration<S: CryptographicSuite> {
 
     /// Date a creation of the proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTimeStamp>,
+    pub created: Option<xsd_types::DateTime>,
 
     /// Verification method.
     #[serde(serialize_with = "S::serialize_verification_method_ref")]
@@ -90,7 +90,7 @@ pub struct ProofConfiguration<S: CryptographicSuite> {
 impl<S: CryptographicSuite> ProofConfiguration<S> {
     pub fn new(
         type_: S,
-        created: xsd_types::DateTimeStamp,
+        created: xsd_types::DateTime,
         verification_method: ReferenceOrOwned<S::VerificationMethod>,
         proof_purpose: ProofPurpose,
         options: S::ProofOptions,
@@ -118,7 +118,7 @@ impl<S: CryptographicSuite> ProofConfiguration<S> {
         Self {
             context: None,
             type_,
-            created: Some(xsd_types::DateTimeStamp::now_ms()),
+            created: Some(xsd_types::DateTime::now_ms()),
             verification_method,
             proof_purpose: ProofPurpose::default(),
             expires: None,

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/reference.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/reference.rs
@@ -19,7 +19,8 @@ pub struct ProofConfigurationRef<'a, S: CryptographicSuite> {
     #[serde(flatten, serialize_with = "S::serialize_type")]
     pub type_: &'a S,
 
-    pub created: xsd_types::DateTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<xsd_types::DateTime>,
 
     #[serde(serialize_with = "S::serialize_verification_method_ref_ref")]
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,
@@ -139,7 +140,8 @@ pub struct ProofConfigurationRefWithoutOptions<'a, S: CryptographicSuite> {
     #[serde(flatten, serialize_with = "S::serialize_type")]
     pub type_: &'a S,
 
-    pub created: xsd_types::DateTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<xsd_types::DateTime>,
 
     #[serde(serialize_with = "S::serialize_verification_method_ref_ref")]
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/reference.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/reference.rs
@@ -20,7 +20,7 @@ pub struct ProofConfigurationRef<'a, S: CryptographicSuite> {
     pub type_: &'a S,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTime>,
+    pub created: Option<xsd_types::DateTimeStamp>,
 
     #[serde(serialize_with = "S::serialize_verification_method_ref_ref")]
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,
@@ -141,7 +141,7 @@ pub struct ProofConfigurationRefWithoutOptions<'a, S: CryptographicSuite> {
     pub type_: &'a S,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTime>,
+    pub created: Option<xsd_types::DateTimeStamp>,
 
     #[serde(serialize_with = "S::serialize_verification_method_ref_ref")]
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/reference.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/reference.rs
@@ -20,7 +20,7 @@ pub struct ProofConfigurationRef<'a, S: CryptographicSuite> {
     pub type_: &'a S,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTimeStamp>,
+    pub created: Option<xsd_types::DateTime>,
 
     #[serde(serialize_with = "S::serialize_verification_method_ref_ref")]
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,
@@ -141,7 +141,7 @@ pub struct ProofConfigurationRefWithoutOptions<'a, S: CryptographicSuite> {
     pub type_: &'a S,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTimeStamp>,
+    pub created: Option<xsd_types::DateTime>,
 
     #[serde(serialize_with = "S::serialize_verification_method_ref_ref")]
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,

--- a/crates/claims/crates/data-integrity/core/src/proof/de/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/mod.rs
@@ -84,8 +84,7 @@ impl<'de, T: DeserializeCryptographicSuite<'de>> Proof<T> {
         Ok(Self {
             context,
             type_: suite,
-            created: created
-                .ok_or_else(|| serde::de::Error::custom("missing `created` property"))?,
+            created,
             verification_method: verification_method
                 .map(|v| v.map(VerificationMethodOf::unwrap).into())
                 .ok_or_else(|| serde::de::Error::custom("missing `verificationMethod` property"))?,

--- a/crates/claims/crates/data-integrity/core/src/proof/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/mod.rs
@@ -48,7 +48,8 @@ pub struct Proof<S: CryptographicSuite> {
     pub type_: S,
 
     /// Date a creation of the proof.
-    pub created: xsd_types::DateTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<xsd_types::DateTime>,
 
     /// Verification method.
     #[serde(serialize_with = "S::serialize_verification_method_ref")]
@@ -121,7 +122,7 @@ impl<T: CryptographicSuite> Proof<T> {
         Self {
             context: None,
             type_,
-            created,
+            created: Some(created),
             verification_method,
             proof_purpose,
             expires: None,

--- a/crates/claims/crates/data-integrity/core/src/proof/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/mod.rs
@@ -49,7 +49,7 @@ pub struct Proof<S: CryptographicSuite> {
 
     /// Date a creation of the proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTime>,
+    pub created: Option<xsd_types::DateTimeStamp>,
 
     /// Verification method.
     #[serde(serialize_with = "S::serialize_verification_method_ref")]
@@ -113,7 +113,7 @@ impl<T: CryptographicSuite> Proof<T> {
     /// Creates a new proof.
     pub fn new(
         type_: T,
-        created: xsd_types::DateTime,
+        created: xsd_types::DateTimeStamp,
         verification_method: ReferenceOrOwned<T::VerificationMethod>,
         proof_purpose: ProofPurpose,
         options: T::ProofOptions,

--- a/crates/claims/crates/data-integrity/core/src/proof/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/mod.rs
@@ -49,7 +49,7 @@ pub struct Proof<S: CryptographicSuite> {
 
     /// Date a creation of the proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<xsd_types::DateTimeStamp>,
+    pub created: Option<xsd_types::DateTime>,
 
     /// Verification method.
     #[serde(serialize_with = "S::serialize_verification_method_ref")]
@@ -113,7 +113,7 @@ impl<T: CryptographicSuite> Proof<T> {
     /// Creates a new proof.
     pub fn new(
         type_: T,
-        created: xsd_types::DateTimeStamp,
+        created: xsd_types::DateTime,
         verification_method: ReferenceOrOwned<T::VerificationMethod>,
         proof_purpose: ProofPurpose,
         options: T::ProofOptions,

--- a/crates/claims/crates/data-integrity/core/src/proof/reference.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/reference.rs
@@ -9,7 +9,7 @@ pub struct ProofRef<'a, S: CryptographicSuite> {
 
     pub type_: &'a S,
 
-    pub created: Option<xsd_types::DateTime>,
+    pub created: Option<xsd_types::DateTimeStamp>,
 
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,
 

--- a/crates/claims/crates/data-integrity/core/src/proof/reference.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/reference.rs
@@ -9,7 +9,7 @@ pub struct ProofRef<'a, S: CryptographicSuite> {
 
     pub type_: &'a S,
 
-    pub created: xsd_types::DateTime,
+    pub created: Option<xsd_types::DateTime>,
 
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,
 

--- a/crates/claims/crates/data-integrity/core/src/proof/reference.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/reference.rs
@@ -9,7 +9,7 @@ pub struct ProofRef<'a, S: CryptographicSuite> {
 
     pub type_: &'a S,
 
-    pub created: Option<xsd_types::DateTimeStamp>,
+    pub created: Option<xsd_types::DateTime>,
 
     pub verification_method: ReferenceOrOwnedRef<'a, S::VerificationMethod>,
 

--- a/crates/claims/src/lib.rs
+++ b/crates/claims/src/lib.rs
@@ -73,3 +73,59 @@ pub enum JsonPresentationOrJws<S: CryptographicSuite = data_integrity::AnySuite>
     /// JSON Web Signature.
     Jws(jws::CompactJWSString),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accept_proof_without_created_vcdm11_json_ecdsa() {
+        let _: DataIntegrity<vc::AnyJsonCredential, data_integrity::AnySuite> =
+            serde_json::from_value(serde_json::json!({
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1"
+              ],
+              "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69757",
+              "type": [
+                "VerifiableCredential",
+              ],
+              "issuer": "did:example:issuer",
+              "credentialSubject": {
+                "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440"
+              },
+              "proof": {
+                "type": "DataIntegrityProof",
+                "verificationMethod": "did:example:issuer#key1",
+                "cryptosuite": "ecdsa-rdfc-2019",
+                "proofPurpose": "assertionMethod",
+                "proofValue": "sdfjlsdjflskdfj"
+              }
+            }))
+            .unwrap();
+    }
+
+    #[test]
+    fn accept_proof_without_created_vcdm2_json_or_jws_bbs() {
+        let _: JsonCredentialOrJws = serde_json::from_value(serde_json::json!({
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2"
+          ],
+          "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69757",
+          "type": [
+            "VerifiableCredential",
+          ],
+          "issuer": "did:example:issuer",
+          "credentialSubject": {
+            "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440"
+          },
+          "proof": {
+            "type": "DataIntegrityProof",
+            "verificationMethod": "did:example:issuer#key1",
+            "cryptosuite": "bbs-2023",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "sdfjlsdjflskdfj"
+          }
+        }))
+        .unwrap();
+    }
+}


### PR DESCRIPTION
According to https://www.w3.org/TR/vc-data-integrity/#proofs it should be optional (and some VC API tests fail because of it). I didn't change any of the functions that require `created` because it seems like we should enforce having a `created` field for some cryptosuites (like EdDSA where the language only defines the type of `created` but doesn't explicitely say that it should be present). But happy to change the API to be more tidy