### PR TITLE
Fully specializable credentials.

### DIFF
--- a/crates/claims/crates/vc/src/v1/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/credential.rs
@@ -35,13 +35,14 @@ pub type JsonCredentialTypes<T = ()> = Types<CredentialType, T>;
 
 /// JSON Credential, without required context nor type.
 ///
-/// If you care about required context and/or type, use the
-/// [`SpecializedJsonCredential`] type directly.
+/// If you care about required context and/or type, or want to customize other
+/// aspects of the credential, use the [`SpecializedJsonCredential`] type
+/// directly.
 pub type JsonCredential<S = json_syntax::Object> = SpecializedJsonCredential<S>;
 
-/// Specialized JSON Credential with custom required context and type.
+/// Specialized JSON Credential with custom types for each component.
 ///
-/// If you don't care about required context and/or type, you can use the
+/// If you don't care about the type of each component, you can use the
 /// [`JsonCredential`] type alias instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(

--- a/crates/claims/crates/vc/src/v1/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/credential.rs
@@ -46,8 +46,8 @@ pub type JsonCredential<S = json_syntax::Object> = SpecializedJsonCredential<S>;
 /// [`JsonCredential`] type alias instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(
-    serialize = "Subject: Serialize, Issuer: Serialize, Status: Serialize, Evidence: Serialize, Schema: Serialize, RefreshService: Serialize, TermsOfUse: Serialize",
-    deserialize = "Subject: Deserialize<'de>, RequiredContext: RequiredContextList, RequiredType: RequiredTypeSet, Issuer: Deserialize<'de>, Status: Deserialize<'de>, Evidence: Deserialize<'de>, Schema: Deserialize<'de>, RefreshService: Deserialize<'de>, TermsOfUse: Deserialize<'de>"
+    serialize = "Subject: Serialize, Issuer: Serialize, Status: Serialize, Evidence: Serialize, Schema: Serialize, RefreshService: Serialize, TermsOfUse: Serialize, ExtraProperties: Serialize",
+    deserialize = "Subject: Deserialize<'de>, RequiredContext: RequiredContextList, RequiredType: RequiredTypeSet, Issuer: Deserialize<'de>, Status: Deserialize<'de>, Evidence: Deserialize<'de>, Schema: Deserialize<'de>, RefreshService: Deserialize<'de>, TermsOfUse: Deserialize<'de>, ExtraProperties: Deserialize<'de>"
 ))]
 pub struct SpecializedJsonCredential<
     Subject = json_syntax::Object,
@@ -59,6 +59,7 @@ pub struct SpecializedJsonCredential<
     Schema = IdentifiedTypedObject,
     RefreshService = IdentifiedTypedObject,
     TermsOfUse = MaybeIdentifiedTypedObject,
+    ExtraProperties = BTreeMap<String, json_syntax::Value>,
 > {
     /// JSON-LD context.
     #[serde(rename = "@context")]
@@ -142,7 +143,7 @@ pub struct SpecializedJsonCredential<
     pub refresh_services: Vec<RefreshService>,
 
     #[serde(flatten)]
-    pub additional_properties: BTreeMap<String, json_syntax::Value>,
+    pub additional_properties: ExtraProperties,
 }
 
 impl<
@@ -155,6 +156,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
     SpecializedJsonCredential<
         Subject,
@@ -166,10 +168,12 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 where
     RequiredContext: RequiredContextList,
     RequiredType: RequiredTypeSet,
+    ExtraProperties: Default,
 {
     /// Creates a new credential.
     pub fn new(
@@ -191,7 +195,7 @@ where
             evidence: Vec::new(),
             credential_schema: Vec::new(),
             refresh_services: Vec::new(),
-            additional_properties: BTreeMap::new(),
+            additional_properties: ExtraProperties::default(),
         }
     }
 }
@@ -206,6 +210,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     > JsonLdObject
     for SpecializedJsonCredential<
         Subject,
@@ -217,6 +222,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 {
     fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
@@ -234,6 +240,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     > JsonLdNodeObject
     for SpecializedJsonCredential<
         Subject,
@@ -245,6 +252,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 {
     fn json_ld_type(&self) -> JsonLdTypes {
@@ -262,6 +270,7 @@ impl<
         Schema: Identified + Typed,
         RefreshService: Identified + Typed,
         TermsOfUse: MaybeIdentified + Typed,
+        ExtraProperties,
         E,
         P,
     > ValidateClaims<E, P>
@@ -275,6 +284,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 where
     E: DateTimeProvider,
@@ -294,6 +304,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     > crate::MaybeIdentified
     for SpecializedJsonCredential<
         Subject,
@@ -305,6 +316,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 {
     fn id(&self) -> Option<&Uri> {
@@ -322,6 +334,7 @@ impl<
         Schema: Identified + Typed,
         RefreshService: Identified + Typed,
         TermsOfUse: MaybeIdentified + Typed,
+        ExtraProperties,
     > crate::v1::Credential
     for SpecializedJsonCredential<
         Subject,
@@ -333,6 +346,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 {
     type Subject = Subject;
@@ -398,6 +412,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     > ssi_json_ld::Expandable
     for SpecializedJsonCredential<
         Subject,
@@ -409,6 +424,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 where
     Subject: Serialize,
@@ -418,6 +434,7 @@ where
     Schema: Serialize,
     RefreshService: Serialize,
     TermsOfUse: Serialize,
+    ExtraProperties: Serialize,
 {
     type Error = JsonLdError;
 

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -32,8 +32,8 @@ pub type JsonCredential<S = NonEmptyObject> = SpecializedJsonCredential<S>;
 /// [`JsonCredential`] type alias instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(
-    serialize = "Subject: Serialize, Issuer: Serialize, Status: Serialize, Evidence: Serialize, Schema: Serialize, RefreshService: Serialize, TermsOfUse: Serialize",
-    deserialize = "Subject: Deserialize<'de>, RequiredContext: RequiredContextList, RequiredType: RequiredTypeSet, Issuer: Deserialize<'de>, Status: Deserialize<'de>, Evidence: Deserialize<'de>, Schema: Deserialize<'de>, RefreshService: Deserialize<'de>, TermsOfUse: Deserialize<'de>"
+    serialize = "Subject: Serialize, Issuer: Serialize, Status: Serialize, Evidence: Serialize, Schema: Serialize, RefreshService: Serialize, TermsOfUse: Serialize, ExtraProperties: Serialize",
+    deserialize = "Subject: Deserialize<'de>, RequiredContext: RequiredContextList, RequiredType: RequiredTypeSet, Issuer: Deserialize<'de>, Status: Deserialize<'de>, Evidence: Deserialize<'de>, Schema: Deserialize<'de>, RefreshService: Deserialize<'de>, TermsOfUse: Deserialize<'de>, ExtraProperties: Deserialize<'de>"
 ))]
 pub struct SpecializedJsonCredential<
     Subject = NonEmptyObject,
@@ -45,6 +45,7 @@ pub struct SpecializedJsonCredential<
     Schema = IdentifiedTypedObject,
     RefreshService = TypedObject,
     TermsOfUse = MaybeIdentifiedTypedObject,
+    ExtraProperties = BTreeMap<String, json_syntax::Value>,
 > {
     /// JSON-LD context.
     #[serde(rename = "@context")]
@@ -123,7 +124,7 @@ pub struct SpecializedJsonCredential<
     pub refresh_services: Vec<RefreshService>,
 
     #[serde(flatten)]
-    pub extra_properties: BTreeMap<String, json_syntax::Value>,
+    pub extra_properties: ExtraProperties,
 }
 
 impl<
@@ -136,6 +137,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
     SpecializedJsonCredential<
         Subject,
@@ -147,10 +149,12 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 where
     RequiredContext: RequiredContextList,
     RequiredType: RequiredTypeSet,
+    ExtraProperties: Default,
 {
     /// Creates a new credential.
     pub fn new(
@@ -171,7 +175,7 @@ where
             evidence: Vec::new(),
             credential_schema: Vec::new(),
             refresh_services: Vec::new(),
-            extra_properties: BTreeMap::new(),
+            extra_properties: ExtraProperties::default(),
         }
     }
 }
@@ -186,6 +190,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     > JsonLdObject
     for SpecializedJsonCredential<
         Subject,
@@ -197,6 +202,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 {
     fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
@@ -214,6 +220,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     > JsonLdNodeObject
     for SpecializedJsonCredential<
         Subject,
@@ -225,6 +232,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 {
     fn json_ld_type(&self) -> JsonLdTypes {
@@ -242,6 +250,7 @@ impl<
         Schema: Identified + Typed,
         RefreshService: Typed,
         TermsOfUse: MaybeIdentified + Typed,
+        ExtraProperties,
         E,
         P,
     > ValidateClaims<E, P>
@@ -255,6 +264,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 where
     E: DateTimeProvider,
@@ -274,6 +284,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     > crate::MaybeIdentified
     for SpecializedJsonCredential<
         Subject,
@@ -285,6 +296,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 {
     fn id(&self) -> Option<&Uri> {
@@ -302,6 +314,7 @@ impl<
         Schema: Identified + Typed,
         RefreshService: Typed,
         TermsOfUse: MaybeIdentified + Typed,
+        ExtraProperties,
     > crate::v2::Credential
     for SpecializedJsonCredential<
         Subject,
@@ -313,6 +326,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 {
     type Subject = Subject;
@@ -376,6 +390,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     > ssi_json_ld::Expandable
     for SpecializedJsonCredential<
         Subject,
@@ -387,6 +402,7 @@ impl<
         Schema,
         RefreshService,
         TermsOfUse,
+        ExtraProperties,
     >
 where
     Subject: Serialize,
@@ -396,6 +412,7 @@ where
     Schema: Serialize,
     RefreshService: Serialize,
     TermsOfUse: Serialize,
+    ExtraProperties: Serialize,
 {
     type Error = JsonLdError;
 

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -21,13 +21,14 @@ pub use crate::v1::syntax::{CredentialType, JsonCredentialTypes, VERIFIABLE_CRED
 
 /// JSON Credential, without required context nor type.
 ///
-/// If you care about required context and/or type, use the
-/// [`SpecializedJsonCredential`] type directly.
+/// If you care about required context and/or type, or want to customize other
+/// aspects of the credential, use the [`SpecializedJsonCredential`] type
+/// directly.
 pub type JsonCredential<S = NonEmptyObject> = SpecializedJsonCredential<S>;
 
-/// Specialized JSON Credential with custom required context and type.
+/// Specialized JSON Credential with custom types for each component.
 ///
-/// If you don't care about required context and/or type, you can use the
+/// If you don't care about the type of each component, you can use the
 /// [`JsonCredential`] type alias instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -1,10 +1,13 @@
 use std::{borrow::Cow, collections::BTreeMap, hash::Hash};
 
 use super::{Context, InternationalString, RelatedResource};
-use crate::syntax::{
-    non_empty_value_or_array, not_null, value_or_array, IdOr, IdentifiedObject,
-    IdentifiedTypedObject, MaybeIdentifiedTypedObject, NonEmptyObject, NonEmptyVec,
-    RequiredContextList, RequiredTypeSet, TypedObject,
+use crate::{
+    syntax::{
+        non_empty_value_or_array, not_null, value_or_array, IdOr, IdentifiedObject,
+        IdentifiedTypedObject, MaybeIdentifiedTypedObject, NonEmptyObject, NonEmptyVec,
+        RequiredContextList, RequiredTypeSet, TypedObject,
+    },
+    Identified, MaybeIdentified, Typed,
 };
 use iref::{Uri, UriBuf};
 use rdf_types::VocabularyMut;
@@ -28,13 +31,23 @@ pub type JsonCredential<S = NonEmptyObject> = SpecializedJsonCredential<S>;
 /// [`JsonCredential`] type alias instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(
-    serialize = "S: Serialize",
-    deserialize = "S: Deserialize<'de>, C: RequiredContextList, T: RequiredTypeSet"
+    serialize = "Subject: Serialize, Issuer: Serialize, Status: Serialize, Evidence: Serialize, Schema: Serialize, RefreshService: Serialize, TermsOfUse: Serialize",
+    deserialize = "Subject: Deserialize<'de>, RequiredContext: RequiredContextList, RequiredType: RequiredTypeSet, Issuer: Deserialize<'de>, Status: Deserialize<'de>, Evidence: Deserialize<'de>, Schema: Deserialize<'de>, RefreshService: Deserialize<'de>, TermsOfUse: Deserialize<'de>"
 ))]
-pub struct SpecializedJsonCredential<S = NonEmptyObject, C = (), T = ()> {
+pub struct SpecializedJsonCredential<
+    Subject = NonEmptyObject,
+    RequiredContext = (),
+    RequiredType = (),
+    Issuer = IdOr<IdentifiedObject>,
+    Status = MaybeIdentifiedTypedObject,
+    Evidence = MaybeIdentifiedTypedObject,
+    Schema = IdentifiedTypedObject,
+    RefreshService = TypedObject,
+    TermsOfUse = MaybeIdentifiedTypedObject,
+> {
     /// JSON-LD context.
     #[serde(rename = "@context")]
-    pub context: Context<C>,
+    pub context: Context<RequiredContext>,
 
     /// Credential identifier.
     #[serde(
@@ -46,15 +59,15 @@ pub struct SpecializedJsonCredential<S = NonEmptyObject, C = (), T = ()> {
 
     /// Credential type.
     #[serde(rename = "type")]
-    pub types: JsonCredentialTypes<T>,
+    pub types: JsonCredentialTypes<RequiredType>,
 
     /// Credential subjects.
     #[serde(rename = "credentialSubject")]
     #[serde(with = "non_empty_value_or_array")]
-    pub credential_subjects: NonEmptyVec<S>,
+    pub credential_subjects: NonEmptyVec<Subject>,
 
     /// Issuer.
-    pub issuer: IdOr<IdentifiedObject>,
+    pub issuer: Issuer,
 
     /// Issuance date.
     #[serde(rename = "validFrom")]
@@ -73,7 +86,7 @@ pub struct SpecializedJsonCredential<S = NonEmptyObject, C = (), T = ()> {
         default,
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub credential_status: Vec<MaybeIdentifiedTypedObject>,
+    pub credential_status: Vec<Status>,
 
     /// Terms of use.
     #[serde(rename = "termsOfUse")]
@@ -82,7 +95,7 @@ pub struct SpecializedJsonCredential<S = NonEmptyObject, C = (), T = ()> {
         default,
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub terms_of_use: Vec<MaybeIdentifiedTypedObject>,
+    pub terms_of_use: Vec<TermsOfUse>,
 
     /// Evidence.
     #[serde(
@@ -90,7 +103,7 @@ pub struct SpecializedJsonCredential<S = NonEmptyObject, C = (), T = ()> {
         default,
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub evidence: Vec<MaybeIdentifiedTypedObject>,
+    pub evidence: Vec<Evidence>,
 
     #[serde(rename = "credentialSchema")]
     #[serde(
@@ -98,7 +111,7 @@ pub struct SpecializedJsonCredential<S = NonEmptyObject, C = (), T = ()> {
         default,
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub credential_schema: Vec<IdentifiedTypedObject>,
+    pub credential_schema: Vec<Schema>,
 
     #[serde(rename = "refreshService")]
     #[serde(
@@ -106,18 +119,43 @@ pub struct SpecializedJsonCredential<S = NonEmptyObject, C = (), T = ()> {
         default,
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub refresh_services: Vec<TypedObject>,
+    pub refresh_services: Vec<RefreshService>,
 
     #[serde(flatten)]
     pub extra_properties: BTreeMap<String, json_syntax::Value>,
 }
 
-impl<S, C: RequiredContextList, T: RequiredTypeSet> SpecializedJsonCredential<S, C, T> {
+impl<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    >
+    SpecializedJsonCredential<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    >
+where
+    RequiredContext: RequiredContextList,
+    RequiredType: RequiredTypeSet,
+{
     /// Creates a new credential.
     pub fn new(
         id: Option<UriBuf>,
-        issuer: IdOr<IdentifiedObject>,
-        credential_subjects: NonEmptyVec<S>,
+        issuer: Issuer,
+        credential_subjects: NonEmptyVec<Subject>,
     ) -> Self {
         Self {
             context: Context::default(),
@@ -137,19 +175,86 @@ impl<S, C: RequiredContextList, T: RequiredTypeSet> SpecializedJsonCredential<S,
     }
 }
 
-impl<S, C, T> JsonLdObject for SpecializedJsonCredential<S, C, T> {
+impl<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    > JsonLdObject
+    for SpecializedJsonCredential<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    >
+{
     fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
 
-impl<S, C, T> JsonLdNodeObject for SpecializedJsonCredential<S, C, T> {
+impl<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    > JsonLdNodeObject
+    for SpecializedJsonCredential<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    >
+{
     fn json_ld_type(&self) -> JsonLdTypes {
         self.types.to_json_ld_types()
     }
 }
 
-impl<S, C, T, E, P> ValidateClaims<E, P> for SpecializedJsonCredential<S, C, T>
+impl<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer: Identified,
+        Status: MaybeIdentified + Typed,
+        Evidence: MaybeIdentified + Typed,
+        Schema: Identified + Typed,
+        RefreshService: Typed,
+        TermsOfUse: MaybeIdentified + Typed,
+        E,
+        P,
+    > ValidateClaims<E, P>
+    for SpecializedJsonCredential<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    >
 where
     E: DateTimeProvider,
 {
@@ -158,21 +263,65 @@ where
     }
 }
 
-impl<S, C, T> crate::MaybeIdentified for SpecializedJsonCredential<S, C, T> {
+impl<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    > crate::MaybeIdentified
+    for SpecializedJsonCredential<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    >
+{
     fn id(&self) -> Option<&Uri> {
         self.id.as_deref()
     }
 }
 
-impl<S, C, T> crate::v2::Credential for SpecializedJsonCredential<S, C, T> {
-    type Subject = S;
+impl<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer: Identified,
+        Status: MaybeIdentified + Typed,
+        Evidence: MaybeIdentified + Typed,
+        Schema: Identified + Typed,
+        RefreshService: Typed,
+        TermsOfUse: MaybeIdentified + Typed,
+    > crate::v2::Credential
+    for SpecializedJsonCredential<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    >
+{
+    type Subject = Subject;
     type Description = InternationalString;
-    type Issuer = IdOr<IdentifiedObject>;
-    type Status = MaybeIdentifiedTypedObject;
-    type RefreshService = TypedObject;
-    type TermsOfUse = MaybeIdentifiedTypedObject;
-    type Evidence = MaybeIdentifiedTypedObject;
-    type Schema = IdentifiedTypedObject;
+    type Issuer = Issuer;
+    type Status = Status;
+    type RefreshService = RefreshService;
+    type TermsOfUse = TermsOfUse;
+    type Evidence = Evidence;
+    type Schema = Schema;
     type RelatedResource = RelatedResource;
 
     fn additional_types(&self) -> &[String] {
@@ -216,9 +365,36 @@ impl<S, C, T> crate::v2::Credential for SpecializedJsonCredential<S, C, T> {
     }
 }
 
-impl<S, C, T> ssi_json_ld::Expandable for SpecializedJsonCredential<S, C, T>
+impl<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    > ssi_json_ld::Expandable
+    for SpecializedJsonCredential<
+        Subject,
+        RequiredContext,
+        RequiredType,
+        Issuer,
+        Status,
+        Evidence,
+        Schema,
+        RefreshService,
+        TermsOfUse,
+    >
 where
-    S: Serialize,
+    Subject: Serialize,
+    Issuer: Serialize,
+    Status: Serialize,
+    Evidence: Serialize,
+    Schema: Serialize,
+    RefreshService: Serialize,
+    TermsOfUse: Serialize,
 {
     type Error = JsonLdError;
 


### PR DESCRIPTION
The `SpecializedJsonCredential` type allows an application to define a new credential type by customizing the input type parameters. However for now only the credential subject type, context and type can be customized, whereas some applications may want to customize others components like the credential status type.

This PR adds all the credential components as parameters to the `SpecializedJsonCredential` type, with defaults matching the current type for each component (so it does not impact existing code).