### PR TITLE
Remove arbitrary_precision feature from serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ json-syntax = "0.12.5"
 nquads-syntax = "0.19"
 multibase = "0.9.1"
 serde = "1.0"
-serde_json = { version = "1.0", features = ["arbitrary_precision"] }
+serde_json = "1.0"
 serde_jcs = "0.1.0"
 bs58 = "0.4"
 base64 = "0.12"


### PR DESCRIPTION
Related to #528 (without closing it though).

I'm not entirely sure if this feature is really unused, since Rust features are additive and Cargo coalesces multiple packages with different feature sets into a single package with a unified feature set, but this feature breaks number serialization into JSON for usage on other platforms, since numbers serialize as an object.

Pinging @timothee-haudebourg per `git blame` output.