### PR TITLE
Make the `bbs_2023::hashing` module public.

### DIFF
--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/bbs_2023/mod.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/bbs_2023/mod.rs
@@ -19,7 +19,7 @@ use ssi_verification_methods::{Multikey, VerificationMethodResolver};
 pub(crate) mod transformation;
 pub use transformation::{Bbs2023Transformation, Bbs2023TransformationOptions, Transformed};
 
-mod hashing;
+pub mod hashing;
 pub use hashing::{Bbs2023Hashing, HashData};
 
 mod signature;


### PR DESCRIPTION
Required to access its inner types and construct a `HashData`.
Fixes #602