### PR TITLE
Tighten JsonPointer and methods

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,3 +13,6 @@ thiserror.workspace = true
 async-trait.workspace = true
 serde = { workspace = true, features = ["derive"] }
 pin-project.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true


### PR DESCRIPTION
The `JsonPointer` type ought to be `#[repr(transparent)]` if `std::mem::transmute` is going to be used to coerce one from a `str`. `ReferenceToken` already did.

The `validate` method did not ensure that a string starts with a `/`. This may not have led a direct path to any undefined behavior, because it was ensured that all `~` are followed by a `0` or `1`, but other methods do act as though they assumed a pointer string always starts with a `/`. I think this makes things a bit more clear.

The private `token_end` can be mostly replaced by `find("/")`.

`as_array_index` can be implemented in terms of the standard library's integer parsing. (Allowing "+000" is an annoying gotcha in seemingly every major language's standard library!).

I've added `Deserialize` for `&JsonPointer`.

I've made the internals of the new `json_pointer!` macro `const {}` to better ensure that its checks actually happen at compile time.

I've adjusted some methods to reduce the total number of `unsafe` blocks