### PR TITLE
Correctly sort SD-JWT concealing JSON pointers.

### DIFF
--- a/crates/claims/crates/sd-jwt/src/conceal.rs
+++ b/crates/claims/crates/sd-jwt/src/conceal.rs
@@ -154,13 +154,8 @@ impl SdJwtPayload {
         let mut sorted_pointers: Vec<_> = pointers.iter().map(Borrow::borrow).collect();
         sorted_pointers.sort_unstable();
 
-        for pointer in pointers.iter().rev() {
-            disclosures.push(conceal_object_at(
-                &mut claims,
-                &mut rng,
-                sd_alg,
-                pointer.borrow(),
-            )?);
+        for pointer in sorted_pointers.into_iter().rev() {
+            disclosures.push(conceal_object_at(&mut claims, &mut rng, sd_alg, pointer)?);
         }
 
         let concealed = Self { sd_alg, claims };

--- a/crates/claims/crates/sd-jwt/tests/full_pathway.rs
+++ b/crates/claims/crates/sd-jwt/tests/full_pathway.rs
@@ -177,10 +177,21 @@ async fn nested_claims() {
         })
         .unwrap();
 
-    let base_sd_jwt = base_claims
+    // Conceal the base claims.
+    base_claims
         .conceal_and_sign(
             SdAlg::Sha256,
             &[json_pointer!("/outer"), json_pointer!("/outer/inner")],
+            &*JWK,
+        )
+        .await
+        .unwrap();
+
+    // Conceal again but changing the order of pointers (this should have no effect).
+    let base_sd_jwt = base_claims
+        .conceal_and_sign(
+            SdAlg::Sha256,
+            &[json_pointer!("/outer/inner"), json_pointer!("/outer")],
             &*JWK,
         )
         .await


### PR DESCRIPTION
I spotted a mistake in `SdJwtPayload::conceal_claims` where I sort JSON pointers to conceal claims in the correct order, but never use the `sorted_pointers` array I create.