### PR TITLE
Bump versions for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,16 +88,17 @@ jobs:
     - name: Test each feature
       run: cargo hack test --each-feature --workspace --clean-per-run --exclude ssi --exclude 'ssi-did-test' -- --test-threads=4
 
-  semver:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: lukka/get-cmake@latest
-    - uses: Swatinem/rust-cache@v2
-      with:
-        cache-on-failure: "true"
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-semver-checks
-    - name: Check semver
-      run: cargo semver-checks --workspace --exclude ssi-cose # not yet published
+  # Disabled until caching is fixed or cargo-semver-checks-actions works with our workspace
+  # semver:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: lukka/get-cmake@latest
+  #   - uses: Swatinem/rust-cache@v2
+  #     with:
+  #       cache-on-failure: "true"
+  #   - uses: taiki-e/install-action@v2
+  #     with:
+  #       tool: cargo-semver-checks
+  #   - name: Check semver
+  #     run: cargo semver-checks --workspace --exclude ssi-cose # not yet published

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,5 +93,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: lukka/get-cmake@latest
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: "true"
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-semver-checks
     - name: Check semver
-      uses: obi1kenobi/cargo-semver-checks-action@v2
+      run: cargo semver-checks --workspace --exclude ssi-cose # not yet published

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,16 @@ ssi-crypto = { path = "./crates/crypto", version = "0.2", default-features = fal
 ssi-verification-methods-core = { path = "./crates/verification-methods/core", version = "0.1", default-features = false }
 ssi-verification-methods = { path = "./crates/verification-methods", version = "0.1", default-features = false }
 ssi-jwk = { path = "./crates/jwk", version = "0.3", default-features = false }
-ssi-tzkey = { path = "./crates/tzkey", version = "0.2", default-features = false }
+ssi-tzkey = { path = "./crates/tzkey", version = "0.2.1", default-features = false }
 ssi-eip712 = { path = "./crates/eip712", version = "0.1", default-features = false }
 ssi-rdf = { path = "./crates/rdf", version = "0.1", default-features = false }
 ssi-contexts = { path = "./crates/contexts", version = "0.1.6", default-features = false }
 ssi-json-ld = { path = "./crates/json-ld", version = "0.3", default-features = false }
 ssi-security = { path = "./crates/security", version = "0.1", default-features = false }
 ssi-caips = { path = "./crates/caips", version = "0.2", default-features = false }
-ssi-ucan = { path = "./crates/ucan", version = "0.2", default-features = false }
-ssi-zcap-ld = { path = "./crates/zcap-ld", version = "0.2", default-features = false }
-ssi-ssh = { path = "./crates/ssh", version = "0.2", default-features = false }
+ssi-ucan = { path = "./crates/ucan", version = "0.2.1", default-features = false }
+ssi-zcap-ld = { path = "./crates/zcap-ld", version = "0.2.1", default-features = false }
+ssi-ssh = { path = "./crates/ssh", version = "0.2.1", default-features = false }
 ssi-status = { path = "./crates/status", version = "0.2", default-features = false }
 ssi-bbs = { path = "./crates/bbs", version = "0.1", default-features = false }
 
@@ -48,22 +48,22 @@ ssi-jws = { path = "./crates/claims/crates/jws", version = "0.3", default-featur
 ssi-jwt = { path = "./crates/claims/crates/jwt", version = "0.3", default-features = false }
 ssi-sd-jwt = { path = "./crates/claims/crates/sd-jwt", version = "0.3", default-features = false }
 ssi-cose = { path = "./crates/claims/crates/cose", version = "0.1", default-features = false }
-ssi-vc = { path = "./crates/claims/crates/vc", version = "0.3", default-features = false }
-ssi-vc-jose-cose = { path = "./crates/claims/crates/vc-jose-cose", version = "0.1", default-features = false }
+ssi-vc = { path = "./crates/claims/crates/vc", version = "0.3.1", default-features = false }
+ssi-vc-jose-cose = { path = "./crates/claims/crates/vc-jose-cose", version = "0.1.1", default-features = false }
 ssi-data-integrity-core = { path = "./crates/claims/crates/data-integrity/core", version = "0.2", default-features = false }
 ssi-di-sd-primitives = { path = "./crates/claims/crates/data-integrity/sd-primitives", version = "0.2", default-features = false }
-ssi-data-integrity-suites = { path = "./crates/claims/crates/data-integrity/suites", version = "0.1", default-features = false }
-ssi-data-integrity = { path = "./crates/claims/crates/data-integrity", version = "0.1", default-features = false }
-ssi-claims = { path = "./crates/claims", version = "0.1", default-features = false }
+ssi-data-integrity-suites = { path = "./crates/claims/crates/data-integrity/suites", version = "0.1.1", default-features = false }
+ssi-data-integrity = { path = "./crates/claims/crates/data-integrity", version = "0.1.1", default-features = false }
+ssi-claims = { path = "./crates/claims", version = "0.1.1", default-features = false }
 
 # DID methods
-ssi-dids-core = { path = "./crates/dids/core", version = "0.1", default-features = false }
+ssi-dids-core = { path = "./crates/dids/core", version = "0.1.1", default-features = false }
 did-ethr = { path = "./crates/dids/methods/ethr", version = "0.3", default-features = false }
-did-ion = { path = "./crates/dids/methods/ion", version = "0.3", default-features = false }
-did-jwk = { path = "./crates/dids/methods/jwk", version = "0.2", default-features = false }
-did-method-key = { path = "./crates/dids/methods/key", version = "0.3", default-features = false }
+did-ion = { path = "./crates/dids/methods/ion", version = "0.3.1", default-features = false }
+did-jwk = { path = "./crates/dids/methods/jwk", version = "0.2.1", default-features = false }
+did-method-key = { path = "./crates/dids/methods/key", version = "0.3.1", default-features = false }
 did-pkh = { path = "./crates/dids/methods/pkh", version = "0.3", default-features = false }
-did-tz = { path = "./crates/dids/methods/tz", version = "0.3", default-features = false }
+did-tz = { path = "./crates/dids/methods/tz", version = "0.3.1", default-features = false }
 did-web = { path = "./crates/dids/methods/web", version = "0.3", default-features = false }
 ssi-dids = { path = "./crates/dids", version = "0.2", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ ssi-multicodec = { path = "./crates/multicodec", version = "0.2", default-featur
 ssi-crypto = { path = "./crates/crypto", version = "0.2", default-features = false }
 ssi-verification-methods-core = { path = "./crates/verification-methods/core", version = "0.1", default-features = false }
 ssi-verification-methods = { path = "./crates/verification-methods", version = "0.1", default-features = false }
-ssi-jwk = { path = "./crates/jwk", version = "0.2", default-features = false }
+ssi-jwk = { path = "./crates/jwk", version = "0.3", default-features = false }
 ssi-tzkey = { path = "./crates/tzkey", version = "0.2", default-features = false }
 ssi-eip712 = { path = "./crates/eip712", version = "0.1", default-features = false }
 ssi-rdf = { path = "./crates/rdf", version = "0.1", default-features = false }
@@ -39,19 +39,19 @@ ssi-caips = { path = "./crates/caips", version = "0.2", default-features = false
 ssi-ucan = { path = "./crates/ucan", version = "0.2", default-features = false }
 ssi-zcap-ld = { path = "./crates/zcap-ld", version = "0.2", default-features = false }
 ssi-ssh = { path = "./crates/ssh", version = "0.2", default-features = false }
-ssi-status = { path = "./crates/status", version = "0.1", default-features = false }
+ssi-status = { path = "./crates/status", version = "0.2", default-features = false }
 ssi-bbs = { path = "./crates/bbs", version = "0.1", default-features = false }
 
 # Verifiable Claims
 ssi-claims-core = { path = "./crates/claims/core", version = "0.1", default-features = false }
-ssi-jws = { path = "./crates/claims/crates/jws", version = "0.2", default-features = false }
-ssi-jwt = { path = "./crates/claims/crates/jwt", version = "0.2", default-features = false }
-ssi-sd-jwt = { path = "./crates/claims/crates/sd-jwt", version = "0.2", default-features = false }
+ssi-jws = { path = "./crates/claims/crates/jws", version = "0.3", default-features = false }
+ssi-jwt = { path = "./crates/claims/crates/jwt", version = "0.3", default-features = false }
+ssi-sd-jwt = { path = "./crates/claims/crates/sd-jwt", version = "0.3", default-features = false }
 ssi-cose = { path = "./crates/claims/crates/cose", version = "0.1", default-features = false }
 ssi-vc = { path = "./crates/claims/crates/vc", version = "0.3", default-features = false }
 ssi-vc-jose-cose = { path = "./crates/claims/crates/vc-jose-cose", version = "0.1", default-features = false }
-ssi-data-integrity-core = { path = "./crates/claims/crates/data-integrity/core", version = "0.1", default-features = false }
-ssi-di-sd-primitives = { path = "./crates/claims/crates/data-integrity/sd-primitives", version = "0.1", default-features = false }
+ssi-data-integrity-core = { path = "./crates/claims/crates/data-integrity/core", version = "0.2", default-features = false }
+ssi-di-sd-primitives = { path = "./crates/claims/crates/data-integrity/sd-primitives", version = "0.2", default-features = false }
 ssi-data-integrity-suites = { path = "./crates/claims/crates/data-integrity/suites", version = "0.1", default-features = false }
 ssi-data-integrity = { path = "./crates/claims/crates/data-integrity", version = "0.1", default-features = false }
 ssi-claims = { path = "./crates/claims", version = "0.1", default-features = false }
@@ -266,4 +266,3 @@ sign-tag = true
 tag-prefix = "{{crate_name}}/"
 tag-message = "Release {{crate_name}} version {{version}}."
 pre-release-commit-message = "Release"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ did-method-key = { path = "./crates/dids/methods/key", version = "0.3.1", defaul
 did-pkh = { path = "./crates/dids/methods/pkh", version = "0.3", default-features = false }
 did-tz = { path = "./crates/dids/methods/tz", version = "0.3.1", default-features = false }
 did-web = { path = "./crates/dids/methods/web", version = "0.3", default-features = false }
-ssi-dids = { path = "./crates/dids", version = "0.2", default-features = false }
+ssi-dids = { path = "./crates/dids", version = "0.2.1", default-features = false }
 
 # crypto
 digest = "0.10"

--- a/crates/claims/Cargo.toml
+++ b/crates/claims/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-claims"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/data-integrity/Cargo.toml
+++ b/crates/claims/crates/data-integrity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-data-integrity"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/data-integrity/core/Cargo.toml
+++ b/crates/claims/crates/data-integrity/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-data-integrity-core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/data-integrity/sd-primitives/Cargo.toml
+++ b/crates/claims/crates/data-integrity/sd-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-di-sd-primitives"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/data-integrity/suites/Cargo.toml
+++ b/crates/claims/crates/data-integrity/suites/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-data-integrity-suites"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/jws/Cargo.toml
+++ b/crates/claims/crates/jws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-jws"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/jwt/Cargo.toml
+++ b/crates/claims/crates/jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-jwt"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/sd-jwt/Cargo.toml
+++ b/crates/claims/crates/sd-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-sd-jwt"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/vc-jose-cose/Cargo.toml
+++ b/crates/claims/crates/vc-jose-cose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-vc-jose-cose"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/vc/Cargo.toml
+++ b/crates/claims/crates/vc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-vc"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/dids/Cargo.toml
+++ b/crates/dids/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-dids"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/dids/core/Cargo.toml
+++ b/crates/dids/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-dids-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/dids/methods/ion/Cargo.toml
+++ b/crates/dids/methods/ion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-ion"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/dids/methods/jwk/Cargo.toml
+++ b/crates/dids/methods/jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-jwk"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/dids/methods/key/Cargo.toml
+++ b/crates/dids/methods/key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-method-key"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/dids/methods/tz/Cargo.toml
+++ b/crates/dids/methods/tz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-tz"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/jwk/Cargo.toml
+++ b/crates/jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-jwk"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/ssh/Cargo.toml
+++ b/crates/ssh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-ssh"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/status/Cargo.toml
+++ b/crates/status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-status"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/tzkey/Cargo.toml
+++ b/crates/tzkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-tzkey"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/ucan/Cargo.toml
+++ b/crates/ucan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-ucan"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/zcap-ld/Cargo.toml
+++ b/crates/zcap-ld/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-zcap-ld"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"


### PR DESCRIPTION
Also:
- fix the use of cargo-semver-checks in CI

To do:
- [x] rebase on latest main once #609 is merged

---

As a side note, bumping all the versions is becoming painful and error-prone with so many crates, we might want to automate the process 😅 