### PR TITLE
Disable rustls by default, bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,11 +97,11 @@ serde = "1.0"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 serde_jcs = "0.1.0"
 ciborium = "0.2.2"
-bs58 = "0.4"
+bs58 = "0.5.1"
 base64 = "0.22"
 hex = "0.4.3"
 derivative = "2.2.0"
-educe = "0.4.22"
+educe = "0.6.0"
 pin-project = "1.1.3"
 futures = "0.3.28"
 linked-data = "0.1.2"
@@ -112,6 +112,10 @@ contextual = "0.1.6"
 lazy_static = "1.4.0"
 indexmap = "2.0.0"
 uuid = "1.9"
+reqwest = { version = "0.12.8", default-features = false, features = ["json"] }
+json-patch = "2.0.0"
+flate2 = "1.0.28"
+simple_asn1 = "0.6.2"
 
 [features]
 default = [
@@ -125,7 +129,7 @@ default = [
 ]
 
 ## Signature suites specified by the W3C.
-## 
+##
 ## This will enable the following Data-Integrity suites:
 ##   - `JsonWebSignature2020`
 ##   - `RsaSignature2018` (requires `rsa`)
@@ -190,7 +194,7 @@ tezos = ["ssi-claims/tezos", "ssi-caips/tezos", "ssi-dids/tezos"]
 aleo = ["ssi-claims/aleo", "ssi-caips/aleo", "ssi-dids/aleo"]
 
 ## Signature suites based on Ethereum EIP-712.
-## 
+##
 ## This includes:
 ##   - `Eip712Signature2021` (requires `ethereum`).
 ##   - `EthereumEip712Signature2021` (requires `w3c`)
@@ -217,6 +221,9 @@ ring = ["ssi-jwk/ring", "ssi-jws/ring", "ssi-crypto/ring"]
 
 ## Enable DID resolution tests using [hyper](https://crates.io/crates/hyper) and [tokio](https://crates.io/crates/tokio).
 http-did = ["ssi-dids/http"]
+
+http-native-tls = ["ssi-dids/native-tls"]
+http-rustls = ["ssi-dids/rustls"]
 
 # ## Enable resolving example HTTPS Verifiable credential Issuer URL, for [VC Test Suite](https://github.com/w3c/vc-test-suite/).
 # example-http-issuer = ["ssi-ldp/example-http-issuer"]

--- a/crates/claims/crates/vc/Cargo.toml
+++ b/crates/claims/crates/vc/Cargo.toml
@@ -31,16 +31,16 @@ educe.workspace = true
 
 # for revocation/status lists.
 base64.workspace = true
-bitvec = "0.20"
-flate2 = "1.0"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+bitvec = "0.20.4"
+flate2.workspace = true
+reqwest.workspace = true
 ssi-verification-methods.workspace = true
 ssi-dids-core.workspace = true
 ssi-data-integrity.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
-features = ["json", "native-tls-vendored"]
+workspace = true
+features = ["native-tls-vendored"]
 
 [dev-dependencies]
 ssi-verification-methods.workspace = true

--- a/crates/dids/Cargo.toml
+++ b/crates/dids/Cargo.toml
@@ -9,10 +9,12 @@ repository = "https://github.com/spruceid/ssi/"
 documentation = "https://docs.rs/ssi-dids/"
 
 [features]
-default = ["http", "secp256k1", "secp256r1", "ripemd-160", "eip", "tezos"]
+default = ["http", "rustls", "secp256k1", "secp256r1", "ripemd-160", "eip", "tezos"]
 
 example = ["ssi-dids-core/example"]
 http = ["ssi-dids-core/http"]
+native-tls = ["ssi-dids-core/native-tls"]
+rustls = ["ssi-dids-core/rustls"]
 
 secp256k1 = ["did-method-key/secp256k1"]
 secp256r1 = ["did-method-key/secp256r1"]

--- a/crates/dids/core/Cargo.toml
+++ b/crates/dids/core/Cargo.toml
@@ -10,6 +10,8 @@ documentation = "https://docs.rs/ssi-dids-core/"
 
 [features]
 http = ["reqwest", "percent-encoding"]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]
 example = []
 
 [dependencies]
@@ -32,12 +34,12 @@ pin-project.workspace = true
 ssi-jwk.workspace = true
 
 # for the `http` feature.
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"], optional = true }
+reqwest = { workspace = true, optional = true }
 percent-encoding = { version = "2.1", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
-features = ["json", "native-tls-vendored"]
+workspace = true
+features = ["native-tls-vendored"]
 
 [dev-dependencies]
 async-std = { version = "1.9", features = ["attributes"] }

--- a/crates/dids/methods/ion/Cargo.toml
+++ b/crates/dids/methods/ion/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-ion/"
 documentation = "https://docs.rs/did-ion/"
 
+[features]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]
+
 [dependencies]
 ssi-verification-methods.workspace = true
 ssi-dids-core = { workspace = true, features = ["http"] }
@@ -25,15 +29,12 @@ thiserror.workspace = true
 
 base64.workspace = true
 sha2 = "0.10"
-json-patch = "0.2.6"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+json-patch.workspace = true
+reqwest.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
-features = ["json", "native-tls-vendored"]
-
-# [target.'cfg(target_arch = "wasm32", target_arch = "wasm64")'.dependencies]
-
+workspace = true
+features = ["native-tls-vendored"]
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/crates/dids/methods/key/Cargo.toml
+++ b/crates/dids/methods/key/Cargo.toml
@@ -35,7 +35,7 @@ iref.workspace = true
 static-iref.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
-simple_asn1 = "^0.5.2"
+simple_asn1.workspace = true
 k256 = { workspace = true, optional = true, features = ["ecdsa"] }
 p256 = { workspace = true, optional = true, features = ["ecdsa"] }
 

--- a/crates/dids/methods/tz/Cargo.toml
+++ b/crates/dids/methods/tz/Cargo.toml
@@ -11,17 +11,21 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-tezos/"
 documentation = "https://docs.rs/did-tezos/"
 
+[features]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]
+
 [dependencies]
 ssi-dids-core.workspace = true
 # TODO Enabling the tezos feature all the time as it is gating the blakesig stuff in ssi_jwk
 ssi-jwk = { workspace = true, default-features = false, features = ["tezos"] }
 ssi-jws = { workspace = true, default-features = false }
 ssi-core.workspace = true
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
-json-patch = "0.2.6"
+json-patch.workspace = true
 bs58 = { workspace = true, features = ["check"] }
 url = "2.2.1"
 iref.workspace = true
@@ -35,8 +39,8 @@ chrono = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, features = ["serde", "wasmbind"] }
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
-features = ["json", "native-tls-vendored"]
+workspace = true
+features = ["native-tls-vendored"]
 
 [dev-dependencies]
 ssi-tzkey.workspace = true

--- a/crates/dids/methods/tz/src/lib.rs
+++ b/crates/dids/methods/tz/src/lib.rs
@@ -1,5 +1,5 @@
 use iref::{Iri, Uri, UriBuf};
-use json_patch::patch;
+use json_patch::{patch, Patch};
 use serde::Deserialize;
 use ssi_dids_core::{
     document::{
@@ -347,7 +347,7 @@ fn decode_public_key(public_key: &str) -> Result<Vec<u8>, UpdateError> {
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct SignedIetfJsonPatchPayload {
-    ietf_json_patch: serde_json::Value,
+    ietf_json_patch: Patch,
 }
 
 #[derive(Deserialize)]
@@ -597,14 +597,10 @@ impl DIDTz {
                                 decode_verify(&jws, &jwk).map_err(UpdateError::InvalidJws)?;
                             patch(
                                 &mut doc_json,
-                                &serde_json::from_slice(
-                                    serde_json::from_slice::<SignedIetfJsonPatchPayload>(&patch_)
-                                        .map_err(UpdateError::InvalidPatch)?
-                                        .ietf_json_patch
-                                        .to_string()
-                                        .as_bytes(),
-                                )
-                                .map_err(UpdateError::InvalidPatch)?,
+                                &serde_json::from_slice::<SignedIetfJsonPatchPayload>(&patch_)
+                                    .map_err(UpdateError::InvalidPatch)?
+                                    .ietf_json_patch
+                                    .0,
                             )
                             .map_err(UpdateError::Patch)?;
 

--- a/crates/dids/methods/web/Cargo.toml
+++ b/crates/dids/methods/web/Cargo.toml
@@ -11,14 +11,17 @@ repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/did-web/"
 documentation = "https://docs.rs/did-web/"
 
+[features]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]
+
 [dependencies]
 ssi-dids-core.workspace = true
 thiserror.workspace = true
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-http = "0.2"
+reqwest.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+workspace = true
 features = ["native-tls-vendored"]
 
 [dev-dependencies]
@@ -35,4 +38,5 @@ static-iref.workspace = true
 xsd-types.workspace = true
 tokio = { version = "1.0", features = ["macros"] }
 futures = "0.3"
+http = "0.2.12"
 hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }

--- a/crates/dids/methods/web/src/lib.rs
+++ b/crates/dids/methods/web/src/lib.rs
@@ -1,4 +1,3 @@
-use http::header;
 use ssi_dids_core::{
     document::representation::MediaType,
     resolution::{self, DIDMethodResolver, Error, Output},
@@ -107,7 +106,7 @@ impl DIDMethodResolver for DIDWeb {
 
         let resp = client
             .get(&url)
-            .header(header::ACCEPT, accept.to_string())
+            .header(reqwest::header::ACCEPT, accept.to_string())
             .send()
             .await
             .map_err(|e| Error::internal(InternalError::Request(url.to_owned(), e)))?;

--- a/crates/json-ld/Cargo.toml
+++ b/crates/json-ld/Cargo.toml
@@ -21,7 +21,7 @@ json-syntax = { workspace = true, features = ["serde"] }
 linked-data.workspace = true
 futures = "0.3"
 lazy_static = "1.4"
-combination = "0.1"
+combination = "0.2.2"
 ssi-contexts.workspace = true
 ssi-crypto.workspace = true
 ssi-rdf.workspace = true

--- a/crates/jwk/Cargo.toml
+++ b/crates/jwk/Cargo.toml
@@ -27,7 +27,7 @@ ed25519 = ["ed25519-dalek", "rand", "getrandom"]
 rsa = ["dep:rsa"]
 
 ## Enable aleo ecosystem keys.
-## 
+##
 ## Not compatible with WASM targets.
 aleo = [
     "rand",
@@ -56,7 +56,7 @@ bbs = ["ssi-bbs", "rand"]
 [dependencies]
 ssi-claims-core.workspace = true
 num-bigint = "0.4"
-simple_asn1 = "^0.5.2"
+simple_asn1.workspace = true
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json.workspace = true

--- a/crates/status/Cargo.toml
+++ b/crates/status/Cargo.toml
@@ -26,9 +26,9 @@ serde_json.workspace = true
 rdf-types.workspace = true
 xsd-types.workspace = true
 log.workspace = true
-reqwest = "0.12.3"
+reqwest.workspace = true
 parking_lot = "0.12.1"
-flate2 = "1.0.28"
+flate2.workspace = true
 
 [dev-dependencies]
 ssi-jws = { workspace = true, features = ["secp256r1"] }


### PR DESCRIPTION
- Bumps some dependencies workspace-wide (this should reduce the dependency tree in general, since new projects usually use the latest library versions)
- Removes the `rustls` support by default, allowing users to choose from either `rustls` or `native-tls` (this is a breaking change, since I was unable to keep `rustls` enable by default due to Cargo [not supporting target-based features](https://github.com/rust-lang/cargo/issues/8170))