### PR TITLE
Fix support for Algorithm `none`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ssi-multicodec = { path = "./crates/multicodec", version = "0.2", default-featur
 ssi-crypto = { path = "./crates/crypto", version = "0.2.1", default-features = false }
 ssi-verification-methods-core = { path = "./crates/verification-methods/core", version = "0.1.1", default-features = false }
 ssi-verification-methods = { path = "./crates/verification-methods", version = "0.1.1", default-features = false }
-ssi-jwk = { path = "./crates/jwk", version = "0.3", default-features = false }
+ssi-jwk = { path = "./crates/jwk", version = "0.3.1", default-features = false }
 ssi-tzkey = { path = "./crates/tzkey", version = "0.2.1", default-features = false }
 ssi-eip712 = { path = "./crates/eip712", version = "0.1", default-features = false }
 ssi-rdf = { path = "./crates/rdf", version = "0.1", default-features = false }

--- a/crates/jwk/Cargo.toml
+++ b/crates/jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-jwk"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/jwk/src/algorithm.rs
+++ b/crates/jwk/src/algorithm.rs
@@ -26,7 +26,7 @@ macro_rules! algorithms {
             ///
             /// Per the specs it should only be `none` but `None` is kept for backwards
             /// compatibility.
-            #[serde(alias = "None")]
+            #[serde(alias = "none")]
             None
         }
 

--- a/crates/jwk/src/algorithm.rs
+++ b/crates/jwk/src/algorithm.rs
@@ -26,7 +26,7 @@ macro_rules! algorithms {
             ///
             /// Per the specs it should only be `none` but `None` is kept for backwards
             /// compatibility.
-            #[serde(alias = "none")]
+            #[serde(alias = "None", rename = "none")]
             None
         }
 
@@ -290,5 +290,30 @@ impl From<ES256OrES384> for Algorithm {
             ES256OrES384::ES256 => Self::ES256,
             ES256OrES384::ES384 => Self::ES384,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Algorithm;
+
+    #[test]
+    fn none_serializes() {
+        assert_eq!(
+            serde_json::to_string(&Algorithm::None).unwrap(),
+            r#""none""#
+        )
+    }
+
+    #[test]
+    fn none_deserializes() {
+        assert_eq!(
+            serde_json::from_str::<Algorithm>(r#""none""#).unwrap(),
+            Algorithm::None
+        );
+        assert_eq!(
+            serde_json::from_str::<Algorithm>(r#""None""#).unwrap(),
+            Algorithm::None
+        )
     }
 }


### PR DESCRIPTION
## Description

Fix `Algorithm::None` deserialization. Currently `"none"` is rejected.

### Other changes

N/A

## Tested

N/A
