### PR TITLE
Fix `did:web` media type.

### DIFF
--- a/crates/dids/core/src/document/representation.rs
+++ b/crates/dids/core/src/document/representation.rs
@@ -108,6 +108,14 @@ impl MediaType {
     pub fn into_name(self) -> &'static str {
         self.name()
     }
+
+    pub fn from_bytes(s: &[u8]) -> Result<Self, Unknown> {
+        match s {
+            b"application/did+json" => Ok(Self::Json),
+            b"application/did+ld+json" => Ok(Self::JsonLd),
+            unknown => Err(Unknown(String::from_utf8_lossy(unknown).into_owned())),
+        }
+    }
 }
 
 impl From<MediaType> for String {


### PR DESCRIPTION
The DID document media type returned by the `DIDWeb` resolver is always JSON-LD, even if the server response is a JSON document. This PR fixes it by using the response content type as DID document media type. It accepts `application/json` in addition to `application/did+json` as recommended by the specification.