### PR TITLE
Change ssi-contexts license to pure Apache2 like other crates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
 
   test-each-feature:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
     - name: Checkout SSI Library
       uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ssi-jwk = { path = "./crates/jwk", version = "0.3.1", default-features = false }
 ssi-tzkey = { path = "./crates/tzkey", version = "0.2.1", default-features = false }
 ssi-eip712 = { path = "./crates/eip712", version = "0.1", default-features = false }
 ssi-rdf = { path = "./crates/rdf", version = "0.1", default-features = false }
-ssi-contexts = { path = "./crates/contexts", version = "0.1.6", default-features = false }
+ssi-contexts = { path = "./crates/contexts", version = "0.1.7", default-features = false }
 ssi-json-ld = { path = "./crates/json-ld", version = "0.3", default-features = false }
 ssi-security = { path = "./crates/security", version = "0.1", default-features = false }
 ssi-caips = { path = "./crates/caips", version = "0.2.1", default-features = false }

--- a/crates/contexts/Cargo.toml
+++ b/crates/contexts/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ssi-contexts"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
-license = "Apache-2.0 AND W3C-20150513 AND CC-BY-SA-3.0 AND BSD-3-Clause"
+license = "Apache-2.0"
 description = "JSON-LD context files related to Verifiable Credentials, Decentralized Identifiers, and Linked Data Proofs"
 repository = "https://github.com/spruceid/ssi/"
 homepage = "https://github.com/spruceid/ssi/tree/main/contexts/"

--- a/deny.toml
+++ b/deny.toml
@@ -93,13 +93,12 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",
-    "CC-BY-SA-3.0",
     "ISC",
     "MIT",
     "MPL-2.0",
     "OpenSSL",
     "Unicode-DFS-2016",
-    "W3C-20150513",
+    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
## Description

After careful analysis, the CC-BY-SA license (as well as the others) considers such a library as a collection and mostly requires recognition of the ownership of the context files, which we are already doing in the README and LICENSE files. Therefore ssi-contexts doesn't need to use those licenses itself, and we can have it be pure Apache2 like the rest of the crates.

### Other changes

N/A

### Optional section

N/A

## Tested

N/A
