### PR TITLE
parse non-normative mime type for did method resolver

### DIFF
--- a/crates/dids/methods/web/Cargo.toml
+++ b/crates/dids/methods/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-web"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/dids/methods/web/src/lib.rs
+++ b/crates/dids/methods/web/src/lib.rs
@@ -125,6 +125,7 @@ impl DIDMethodResolver for DIDWeb {
             .get(header::CONTENT_TYPE)
             .map(|value| match value.as_bytes() {
                 b"application/json" => Ok(MediaType::Json),
+                b"application/json; charset=utf-8" => Ok(MediaType::Json),
                 other => MediaType::from_bytes(other),
             })
             .transpose()?


### PR DESCRIPTION
## Description

Adds a match arm for `application/json; charset=utf-8` to `DIDMethodResolver` implementation for `DIDWeb`.

### Other changes

Bumps patch version to `0.3.3`

## Tested

This change is tested as part of a compatibility check with a third-party verifier. 