### PR TITLE
Fix `async-std` features

### DIFF
--- a/crates/claims/crates/sd-jwt/Cargo.toml
+++ b/crates/claims/crates/sd-jwt/Cargo.toml
@@ -25,4 +25,4 @@ indexmap.workspace = true
 [dev-dependencies]
 hex-literal = "0.4.1"
 ssi-jws = { workspace = true, features = ["secp256r1"] }
-async-std.workspace = true
+async-std = { workspace = true, features = ["attributes"] }

--- a/crates/claims/crates/vc-jose-cose/Cargo.toml
+++ b/crates/claims/crates/vc-jose-cose/Cargo.toml
@@ -27,5 +27,5 @@ base64.workspace = true
 ssi-jws = { workspace = true, features = ["secp256r1"] }
 ssi-jwk.workspace = true
 ssi-cose = { workspace = true, features = ["secp256r1"] }
-async-std.workspace = true
+async-std = { workspace = true, features = ["attributes"] }
 hex.workspace = true


### PR DESCRIPTION
## Description

The `attributes` feature was missing in `dev-dependencies`, making the async tests fail to compile.
- In `ssi-sd-jwt`
- In `ssi-vc-jose-cose`