### PR TITLE
Fix/use option string as domain type

### DIFF
--- a/crates/claims/crates/data-integrity/core/src/lib.rs
+++ b/crates/claims/crates/data-integrity/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod suite;
 pub use decode::*;
 use educe::Educe;
 pub use options::ProofOptions;
+pub use proof::value_or_array;
 pub use proof::*;
 use serde::Serialize;
 use ssi_claims_core::{

--- a/crates/claims/crates/data-integrity/core/src/options.rs
+++ b/crates/claims/crates/data-integrity/core/src/options.rs
@@ -40,7 +40,12 @@ pub struct ProofOptions<M, T> {
     /// Example domain values include: `domain.example`` (DNS domain),
     /// `https://domain.example:8443` (Web origin), `mycorp-intranet` (bespoke
     /// text string), and `b31d37d4-dd59-47d3-9dd8-c973da43b63a` (UUID).
-    #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "domain")]
+    #[serde(
+        default,
+        with = "crate::value_or_array",
+        skip_serializing_if = "Vec::is_empty",
+        rename = "domain"
+    )]
     pub domains: Vec<String>,
 
     /// Used to mitigate replay attacks.

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
@@ -57,7 +57,11 @@ pub struct ProofConfiguration<S: CryptographicSuite> {
     /// Example domain values include: `domain.example`` (DNS domain),
     /// `https://domain.example:8443` (Web origin), `mycorp-intranet` (bespoke
     /// text string), and `b31d37d4-dd59-47d3-9dd8-c973da43b63a` (UUID).
-    #[serde(skip_serializing_if = "Vec::is_empty", rename = "domain")]
+    #[serde(
+        with = "crate::value_or_array",
+        skip_serializing_if = "Vec::is_empty",
+        rename = "domain"
+    )]
     pub domains: Vec<String>,
 
     /// Used to mitigate replay attacks.

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/reference.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/reference.rs
@@ -30,7 +30,11 @@ pub struct ProofConfigurationRef<'a, S: CryptographicSuite> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires: Option<xsd_types::DateTimeStamp>,
 
-    #[serde(skip_serializing_if = "<[String]>::is_empty")]
+    #[serde(
+        with = "crate::value_or_array",
+        skip_serializing_if = "<[String]>::is_empty",
+        rename = "domain"
+    )]
     pub domains: &'a [String],
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -151,7 +155,11 @@ pub struct ProofConfigurationRefWithoutOptions<'a, S: CryptographicSuite> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires: Option<xsd_types::DateTimeStamp>,
 
-    #[serde(skip_serializing_if = "<[String]>::is_empty")]
+    #[serde(
+        with = "crate::value_or_array",
+        skip_serializing_if = "<[String]>::is_empty",
+        rename = "domain"
+    )]
     pub domains: &'a [String],
 
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Description

Changes `domains` to use a `Option<String>` type instead of ` Vec<String>`. This was causing an error with vc playground verification.

## Other considerations

I've left the `domains` property as-is, but we should consider changing this value to `domain`. WDYT @timothee-haudebourg  ?

## Tested

Tested in sprucekit mobile.