### PR TITLE
Make clippy happy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Core library for Verifiable Credentials and Decentralized Identif
 repository = "https://github.com/spruceid/ssi/"
 documentation = "https://docs.rs/ssi/"
 keywords = ["ssi", "did", "vc", "vp", "jsonld"]
-rust-version = "1.80"
+rust-version = "1.81"
 
 [workspace]
 members = [

--- a/crates/caips/src/caip10.rs
+++ b/crates/caips/src/caip10.rs
@@ -71,7 +71,7 @@ impl<'de> Deserialize<'de> for BlockchainAccountId {
     {
         struct Visitor;
 
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl serde::de::Visitor<'_> for Visitor {
             type Value = BlockchainAccountId;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/claims/core/src/verification/claims.rs
+++ b/crates/claims/core/src/verification/claims.rs
@@ -60,4 +60,4 @@ impl<E, P> ValidateClaims<E, P> for [u8] {}
 
 impl<E, P> ValidateClaims<E, P> for Vec<u8> {}
 
-impl<'a, E, P, T: ?Sized + ToOwned + ValidateClaims<E, P>> ValidateClaims<E, P> for Cow<'a, T> {}
+impl<E, P, T: ?Sized + ToOwned + ValidateClaims<E, P>> ValidateClaims<E, P> for Cow<'_, T> {}

--- a/crates/claims/core/src/verification/mod.rs
+++ b/crates/claims/core/src/verification/mod.rs
@@ -126,7 +126,7 @@ pub trait ResolverProvider {
     fn resolver(&self) -> &Self::Resolver;
 }
 
-impl<'a, E: ResolverProvider> ResolverProvider for &'a E {
+impl<E: ResolverProvider> ResolverProvider for &E {
     type Resolver = E::Resolver;
 
     fn resolver(&self) -> &Self::Resolver {
@@ -142,7 +142,7 @@ pub trait DateTimeProvider {
     fn date_time(&self) -> DateTime<Utc>;
 }
 
-impl<'a, E: DateTimeProvider> DateTimeProvider for &'a E {
+impl<E: DateTimeProvider> DateTimeProvider for &E {
     fn date_time(&self) -> DateTime<Utc> {
         E::date_time(*self)
     }

--- a/crates/claims/crates/cose/src/key.rs
+++ b/crates/claims/crates/cose/src/key.rs
@@ -24,7 +24,7 @@ pub trait CoseKeyResolver {
     ) -> Result<Cow<CoseKey>, ProofValidationError>;
 }
 
-impl<'a, T: CoseKeyResolver> CoseKeyResolver for &'a T {
+impl<T: CoseKeyResolver> CoseKeyResolver for &T {
     async fn fetch_public_cose_key(
         &self,
         id: Option<&[u8]>,

--- a/crates/claims/crates/cose/src/signature.rs
+++ b/crates/claims/crates/cose/src/signature.rs
@@ -72,7 +72,7 @@ pub trait CoseSigner {
     }
 }
 
-impl<'a, T: CoseSigner> CoseSigner for &'a T {
+impl<T: CoseSigner> CoseSigner for &T {
     async fn fetch_info(&self) -> Result<CoseSignerInfo, SignatureError> {
         T::fetch_info(*self).await
     }

--- a/crates/claims/crates/data-integrity/core/src/de.rs
+++ b/crates/claims/crates/data-integrity/core/src/de.rs
@@ -101,8 +101,7 @@ where
     }
 }
 
-impl<'a, 'de, D: serde::de::MapAccess<'de>, S> serde::Deserializer<'de>
-    for &'a mut Deserializer<'de, D, S>
+impl<'de, D: serde::de::MapAccess<'de>, S> serde::Deserializer<'de> for &mut Deserializer<'de, D, S>
 where
     S: DeserializeCryptographicSuite<'de>,
 {

--- a/crates/claims/crates/data-integrity/core/src/document.rs
+++ b/crates/claims/crates/data-integrity/core/src/document.rs
@@ -36,7 +36,8 @@ pub struct DataIntegrityDocument {
 impl ssi_json_ld::Expandable for DataIntegrityDocument {
     type Error = JsonLdError;
 
-    type Expanded<I: Interpretation, V: Vocabulary> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I: Interpretation, V: Vocabulary>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/expansion.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/expansion.rs
@@ -80,23 +80,22 @@ pub struct EmbeddedProofConfigurationRef<'d, 'a, S: CryptographicSuite> {
     proof: ProofConfigurationRef<'a, S>,
 }
 
-impl<'d, 'a, S: CryptographicSuite> JsonLdObject for EmbeddedProofConfigurationRef<'d, 'a, S> {
+impl<S: CryptographicSuite> JsonLdObject for EmbeddedProofConfigurationRef<'_, '_, S> {
     fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
         self.context.as_deref().map(Cow::Borrowed)
     }
 }
 
-impl<'d, 'a, S: CryptographicSuite> JsonLdNodeObject for EmbeddedProofConfigurationRef<'d, 'a, S> {
+impl<S: CryptographicSuite> JsonLdNodeObject for EmbeddedProofConfigurationRef<'_, '_, S> {
     fn json_ld_type(&self) -> JsonLdTypes {
         self.type_.reborrow()
     }
 }
 
-impl<'d, 'a, S: SerializeCryptographicSuite> Expandable
-    for EmbeddedProofConfigurationRef<'d, 'a, S>
-{
+impl<S: SerializeCryptographicSuite> Expandable for EmbeddedProofConfigurationRef<'_, '_, S> {
     type Error = ConfigurationExpansionError;
-    type Expanded<I, V> = ExpandedEmbeddedProofConfiguration<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ExpandedEmbeddedProofConfiguration<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/data-integrity/core/src/proof/de/ref_or_value.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/ref_or_value.rs
@@ -26,7 +26,7 @@ impl<'de, T: DeserializeTyped<'de, C>, C> DeserializeTyped<'de, C> for RefOrValu
     {
         struct Visitor<'a, T, C>(&'a C, PhantomData<T>);
 
-        impl<'a, 'de, T: DeserializeTyped<'de, C>, C> serde::de::Visitor<'de> for Visitor<'a, T, C> {
+        impl<'de, T: DeserializeTyped<'de, C>, C> serde::de::Visitor<'de> for Visitor<'_, T, C> {
             type Value = RefOrValue<T>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/claims/crates/data-integrity/core/src/proof/type.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/type.rs
@@ -102,7 +102,7 @@ impl<'a> TypeRef<'a> {
     }
 }
 
-impl<'a> Serialize for TypeRef<'a> {
+impl Serialize for TypeRef<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/claims/crates/data-integrity/core/src/suite/bounds.rs
+++ b/crates/claims/crates/data-integrity/core/src/suite/bounds.rs
@@ -270,7 +270,7 @@ pub struct VerificationMethodRefOf<'a, S: CryptographicSuite>(
     pub ReferenceOrOwnedRef<'a, S::VerificationMethod>,
 );
 
-impl<'a, S: DebugCryptographicSuite> fmt::Debug for VerificationMethodRefOf<'a, S> {
+impl<S: DebugCryptographicSuite> fmt::Debug for VerificationMethodRefOf<'_, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         S::fmt_verification_method_ref(&self.0, f)
     }
@@ -289,7 +289,7 @@ impl<'de, T: DeserializeCryptographicSuite<'de>> DeserializeTyped<'de, T> for Op
 
 pub struct OptionsRefOf<'a, S: CryptographicSuite>(pub &'a S::ProofOptions);
 
-impl<'a, S: DebugCryptographicSuite> fmt::Debug for OptionsRefOf<'a, S> {
+impl<S: DebugCryptographicSuite> fmt::Debug for OptionsRefOf<'_, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         S::fmt_proof_options(self.0, f)
     }
@@ -308,7 +308,7 @@ impl<'de, T: DeserializeCryptographicSuite<'de>> DeserializeTyped<'de, T> for Si
 
 pub struct SignatureRefOf<'a, S: CryptographicSuite>(pub &'a S::Signature);
 
-impl<'a, S: DebugCryptographicSuite> fmt::Debug for SignatureRefOf<'a, S> {
+impl<S: DebugCryptographicSuite> fmt::Debug for SignatureRefOf<'_, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         S::fmt_signature(self.0, f)
     }

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/eip712_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/eip712_signature_2021.rs
@@ -273,9 +273,7 @@ impl VerificationAlgorithm<Eip712Signature2021> for Eip712SignatureAlgorithm {
         proof: ssi_data_integrity_core::ProofRef<Eip712Signature2021>,
     ) -> Result<ProofValidity, ProofValidationError> {
         let signature_bytes = proof.signature.decode()?;
-        method
-            .verify_bytes(prepared_claims.as_slice(), &signature_bytes)
-            .map(Into::into)
+        method.verify_bytes(prepared_claims.as_slice(), &signature_bytes)
     }
 }
 

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/tezos/tezos_jcs_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/tezos/tezos_jcs_signature_2021.rs
@@ -191,13 +191,11 @@ impl VerificationAlgorithm<TezosJcsSignature2021> for TezosJcsSignatureAlgorithm
             .transpose()?;
 
         let (algorithm, signature_bytes) = proof.signature.decode()?;
-        method
-            .verify_bytes(
-                public_key_jwk.as_ref(),
-                &prepared_claims,
-                algorithm,
-                &signature_bytes,
-            )
-            .map(Into::into)
+        method.verify_bytes(
+            public_key_jwk.as_ref(),
+            &prepared_claims,
+            algorithm,
+            &signature_bytes,
+        )
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/tezos/tezos_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/tezos/tezos_signature_2021.rs
@@ -137,14 +137,12 @@ impl VerificationAlgorithm<TezosSignature2021> for TezosSignatureAlgorithm {
     ) -> Result<ProofValidity, ProofValidationError> {
         // AnyBlake2b
         let (algorithm, signature_bytes) = proof.signature.decode()?;
-        method
-            .verify_bytes(
-                proof.options.public_key_jwk.as_deref(),
-                &prepared_claims,
-                algorithm,
-                &signature_bytes,
-            )
-            .map(Into::into)
+        method.verify_bytes(
+            proof.options.public_key_jwk.as_deref(),
+            &prepared_claims,
+            algorithm,
+            &signature_bytes,
+        )
     }
 }
 

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/bbs_2023/tests/mod.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/bbs_2023/tests/mod.rs
@@ -52,7 +52,8 @@ impl<E, P> ValidateClaims<E, P> for JsonCredential {
 impl ssi_json_ld::Expandable for JsonCredential {
     type Error = JsonLdError;
 
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ethereum_eip712_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ethereum_eip712_signature_2021.rs
@@ -354,8 +354,6 @@ where
         proof: ProofRef<S>,
     ) -> Result<ProofValidity, ProofValidationError> {
         let signature_bytes = proof.signature.decode()?;
-        method
-            .verify_bytes(prepared_claims.as_ref(), &signature_bytes)
-            .map(Into::into)
+        method.verify_bytes(prepared_claims.as_ref(), &signature_bytes)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/rsa_signature_2018.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/rsa_signature_2018.rs
@@ -102,8 +102,6 @@ impl VerificationAlgorithm<RsaSignature2018> for RsaSignatureAlgorithm {
         let signature = base64::prelude::BASE64_STANDARD
             .decode(&proof.signature.signature_value)
             .map_err(|_| ProofValidationError::InvalidSignature)?;
-        method
-            .verify_bytes(&prepared_claims, &signature)
-            .map(Into::into)
+        method.verify_bytes(&prepared_claims, &signature)
     }
 }

--- a/crates/claims/crates/jws/src/compact/mod.rs
+++ b/crates/claims/crates/jws/src/compact/mod.rs
@@ -11,7 +11,7 @@ pub use url_safe::*;
 #[error("invalid JWS")]
 pub struct InvalidJws<B = String>(pub B);
 
-impl<'a> InvalidJws<&'a [u8]> {
+impl InvalidJws<&[u8]> {
     pub fn into_owned(self) -> InvalidJws<Vec<u8>> {
         InvalidJws(self.0.to_owned())
     }

--- a/crates/claims/crates/jws/src/compact/str.rs
+++ b/crates/claims/crates/jws/src/compact/str.rs
@@ -146,7 +146,7 @@ impl PartialEq<String> for JwsStr {
     }
 }
 
-impl<'a> PartialEq<String> for &'a JwsStr {
+impl PartialEq<String> for &JwsStr {
     fn eq(&self, other: &String) -> bool {
         self.as_str() == other
     }
@@ -328,7 +328,7 @@ impl<'de> serde::Deserialize<'de> for JwsString {
     {
         struct Visitor;
 
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl serde::de::Visitor<'_> for Visitor {
             type Value = JwsString;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -378,7 +378,7 @@ impl PartialEq<JwsString> for str {
     }
 }
 
-impl<'a> PartialEq<JwsString> for &'a str {
+impl PartialEq<JwsString> for &str {
     fn eq(&self, other: &JwsString) -> bool {
         *self == other.as_str()
     }

--- a/crates/claims/crates/jws/src/compact/url_safe.rs
+++ b/crates/claims/crates/jws/src/compact/url_safe.rs
@@ -175,7 +175,7 @@ impl PartialEq<String> for Jws {
     }
 }
 
-impl<'a> PartialEq<String> for &'a Jws {
+impl PartialEq<String> for &Jws {
     fn eq(&self, other: &String) -> bool {
         self.as_str() == other
     }
@@ -349,7 +349,7 @@ impl<'de> serde::Deserialize<'de> for JwsBuf {
     {
         struct Visitor;
 
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl serde::de::Visitor<'_> for Visitor {
             type Value = JwsBuf;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -399,7 +399,7 @@ impl PartialEq<JwsBuf> for str {
     }
 }
 
-impl<'a> PartialEq<JwsBuf> for &'a str {
+impl PartialEq<JwsBuf> for &str {
     fn eq(&self, other: &JwsBuf) -> bool {
         *self == other.as_str()
     }

--- a/crates/claims/crates/jws/src/lib.rs
+++ b/crates/claims/crates/jws/src/lib.rs
@@ -164,7 +164,7 @@ impl<T> JwsParts<T> {
     }
 }
 
-impl<'a, T: ?Sized + ToOwned> JwsParts<Cow<'a, T>> {
+impl<T: ?Sized + ToOwned> JwsParts<Cow<'_, T>> {
     pub fn into_owned(self) -> JwsParts<T::Owned> {
         JwsParts::new(self.header, self.payload.into_owned(), self.signature)
     }
@@ -263,7 +263,7 @@ impl<'a, T> DecodedJws<'a, T> {
     }
 }
 
-impl<'a, 'b, T: ?Sized + ToOwned> DecodedJws<'a, &'b T> {
+impl<T: ?Sized + ToOwned> DecodedJws<'_, &T> {
     pub fn to_owned(&self) -> DecodedJws<'static, T::Owned> {
         DecodedJws {
             signing_bytes: self.signing_bytes.to_owned(),
@@ -272,7 +272,7 @@ impl<'a, 'b, T: ?Sized + ToOwned> DecodedJws<'a, &'b T> {
     }
 }
 
-impl<'a, 'b, T: ?Sized + ToOwned> DecodedJws<'a, Cow<'b, T>> {
+impl<T: ?Sized + ToOwned> DecodedJws<'_, Cow<'_, T>> {
     pub fn into_owned(self) -> DecodedJws<'static, T::Owned> {
         DecodedJws::new(self.signing_bytes.into_owned(), self.signature)
     }
@@ -320,7 +320,7 @@ impl<'a, T> DecodedSigningBytes<'a, T> {
     }
 }
 
-impl<'a, 'b, T: ?Sized + ToOwned> DecodedSigningBytes<'a, &'b T> {
+impl<T: ?Sized + ToOwned> DecodedSigningBytes<'_, &T> {
     pub fn to_owned(&self) -> DecodedSigningBytes<'static, T::Owned> {
         DecodedSigningBytes {
             bytes: Cow::Owned(self.bytes.as_ref().to_owned()),
@@ -330,7 +330,7 @@ impl<'a, 'b, T: ?Sized + ToOwned> DecodedSigningBytes<'a, &'b T> {
     }
 }
 
-impl<'a, 'b, T: ?Sized + ToOwned> DecodedSigningBytes<'a, Cow<'b, T>> {
+impl<T: ?Sized + ToOwned> DecodedSigningBytes<'_, Cow<'_, T>> {
     pub fn into_owned(self) -> DecodedSigningBytes<'static, T::Owned> {
         DecodedSigningBytes {
             bytes: Cow::Owned(self.bytes.into_owned()),
@@ -704,8 +704,7 @@ pub fn verify_bytes_warnable(
         JWKParams::RSA(rsa_params) => {
             rsa_params.validate_key_size()?;
             use rsa::PublicKey;
-            let public_key =
-                rsa::RsaPublicKey::try_from(rsa_params).map_err(ssi_jwk::Error::from)?;
+            let public_key = rsa::RsaPublicKey::try_from(rsa_params)?;
             let padding;
             let hashed;
             match algorithm {
@@ -1313,6 +1312,6 @@ mod tests {
         decode_verify(&jws, &key).unwrap();
 
         const JWS: &str = "eyJhbGciOiJFUzM4NCJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTpmb28iLCJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJ9fQ.2vpBSFN7DxuS57epgq_e7-NyNiJ5eOOrExmi65C_wtZOC2-9i6fVvMnfUig7QmgiirznAg1wr_b7_kH-bbMCI5Pdf8pAnxQg3LL9I9OhzttyG06qAl9L7BE6aNS-aqnf";
-        decode_verify(&JWS, &key).unwrap();
+        decode_verify(JWS, &key).unwrap();
     }
 }

--- a/crates/claims/crates/jws/src/signature.rs
+++ b/crates/claims/crates/jws/src/signature.rs
@@ -29,7 +29,7 @@ pub trait JwsPayload {
     }
 }
 
-impl<'a, P: ?Sized + JwsPayload> JwsPayload for &'a P {
+impl<P: ?Sized + JwsPayload> JwsPayload for &P {
     fn typ(&self) -> Option<&str> {
         P::typ(*self)
     }
@@ -134,7 +134,7 @@ pub trait JwsSigner {
     }
 }
 
-impl<'a, T: JwsSigner> JwsSigner for &'a T {
+impl<T: JwsSigner> JwsSigner for &T {
     async fn fetch_info(&self) -> Result<JwsSignerInfo, SignatureError> {
         T::fetch_info(*self).await
     }
@@ -148,7 +148,7 @@ impl<'a, T: JwsSigner> JwsSigner for &'a T {
     }
 }
 
-impl<'a, T: JwsSigner + Clone> JwsSigner for Cow<'a, T> {
+impl<T: JwsSigner + Clone> JwsSigner for Cow<'_, T> {
     async fn fetch_info(&self) -> Result<JwsSignerInfo, SignatureError> {
         T::fetch_info(self.as_ref()).await
     }
@@ -191,7 +191,7 @@ impl<'a> JwkWithAlgorithm<'a> {
     }
 }
 
-impl<'a> JwsSigner for JwkWithAlgorithm<'a> {
+impl JwsSigner for JwkWithAlgorithm<'_> {
     async fn fetch_info(&self) -> Result<JwsSignerInfo, SignatureError> {
         Ok(JwsSignerInfo {
             key_id: self.jwk.key_id.clone(),

--- a/crates/claims/crates/jws/src/verification.rs
+++ b/crates/claims/crates/jws/src/verification.rs
@@ -18,14 +18,14 @@ pub trait ValidateJwsHeader<E> {
 
 impl<E> ValidateJwsHeader<E> for [u8] {}
 
-impl<'a, E, T: ?Sized + ToOwned + ValidateJwsHeader<E>> ValidateJwsHeader<E> for Cow<'a, T> {
+impl<E, T: ?Sized + ToOwned + ValidateJwsHeader<E>> ValidateJwsHeader<E> for Cow<'_, T> {
     fn validate_jws_header(&self, env: &E, header: &Header) -> ClaimsValidity {
         self.as_ref().validate_jws_header(env, header)
     }
 }
 
-impl<'a, E, T: ValidateClaims<E, JwsSignature> + ValidateJwsHeader<E>>
-    ValidateClaims<E, JwsSignature> for DecodedSigningBytes<'a, T>
+impl<E, T: ValidateClaims<E, JwsSignature> + ValidateJwsHeader<E>> ValidateClaims<E, JwsSignature>
+    for DecodedSigningBytes<'_, T>
 {
     fn validate_claims(&self, env: &E, signature: &JwsSignature) -> ClaimsValidity {
         self.payload.validate_jws_header(env, &self.header)?;

--- a/crates/claims/crates/jwt/src/claims/mixed/de.rs
+++ b/crates/claims/crates/jwt/src/claims/mixed/de.rs
@@ -33,9 +33,7 @@ impl<'de, D: serde::de::MapAccess<'de>> ClaimsDeserializer<D> {
     }
 }
 
-impl<'a, 'de, D: serde::de::MapAccess<'de>> serde::de::MapAccess<'de>
-    for &'a mut ClaimsDeserializer<D>
-{
+impl<'de, D: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for &mut ClaimsDeserializer<D> {
     type Error = D::Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -63,9 +61,7 @@ impl<'a, 'de, D: serde::de::MapAccess<'de>> serde::de::MapAccess<'de>
     }
 }
 
-impl<'a, 'de, D: serde::de::MapAccess<'de>> serde::Deserializer<'de>
-    for &'a mut ClaimsDeserializer<D>
-{
+impl<'de, D: serde::de::MapAccess<'de>> serde::Deserializer<'de> for &mut ClaimsDeserializer<D> {
     type Error = D::Error;
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/crates/claims/crates/jwt/src/claims/mod.rs
+++ b/crates/claims/crates/jwt/src/claims/mod.rs
@@ -128,7 +128,7 @@ impl<'de> serde::Deserialize<'de> for ClaimKind {
     }
 }
 
-impl<'a> ClaimKind<&'a str> {
+impl ClaimKind<&str> {
     pub fn into_owned(self) -> ClaimKind {
         match self {
             Self::Registered(r) => ClaimKind::Registered(r),

--- a/crates/claims/crates/sd-jwt/src/lib.rs
+++ b/crates/claims/crates/sd-jwt/src/lib.rs
@@ -582,7 +582,7 @@ impl<'a> PartsRef<'a> {
     }
 }
 
-impl<'a> fmt::Display for PartsRef<'a> {
+impl fmt::Display for PartsRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.jwt.fmt(f)?;
         f.write_char('~')?;

--- a/crates/claims/crates/sd-jwt/src/reveal.rs
+++ b/crates/claims/crates/sd-jwt/src/reveal.rs
@@ -239,7 +239,7 @@ fn as_concealed_array_item(item: &serde_json::Value) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use std::cell::LazyCell;
+    use std::sync::LazyLock;
 
     use crate::SdJwt;
 
@@ -267,7 +267,7 @@ mod tests {
         "a2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgImNvdW50cnkiLCAiSlAiXQ~"
     );
 
-    const DISCLOSED_CLAIMS: LazyCell<serde_json::Value> = LazyCell::new(|| {
+    static DISCLOSED_CLAIMS: LazyLock<serde_json::Value> = LazyLock::new(|| {
         json!({
             "iss": "https://example.com/issuer",
             "iat": 1683000000,

--- a/crates/claims/crates/vc/examples/sign.rs
+++ b/crates/claims/crates/vc/examples/sign.rs
@@ -83,7 +83,8 @@ impl ssi_vc::v1::Credential for Credential {
 
 impl Expandable for Credential {
     type Error = std::convert::Infallible;
-    type Expanded<I, V> = Self
+    type Expanded<I, V>
+        = Self
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/vc/src/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/syntax/credential.rs
@@ -79,7 +79,8 @@ where
 {
     type Error = JsonLdError;
 
-    type Expanded<I: Interpretation, V: Vocabulary> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I: Interpretation, V: Vocabulary>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/vc/src/syntax/non_empty_object.rs
+++ b/crates/claims/crates/vc/src/syntax/non_empty_object.rs
@@ -188,10 +188,16 @@ pub struct EmptyObject;
 #[derive(Debug, thiserror::Error)]
 pub enum RemoveUniqueError {
     #[error(transparent)]
-    DuplicateEntry(#[from] Duplicate<Entry>),
+    DuplicateEntry(Box<Duplicate<Entry>>),
 
     #[error("empty object")]
     EmptyObject,
+}
+
+impl From<Duplicate<Entry>> for RemoveUniqueError {
+    fn from(value: Duplicate<Entry>) -> Self {
+        Self::DuplicateEntry(Box::new(value))
+    }
 }
 
 impl Deref for NonEmptyObject {

--- a/crates/claims/crates/vc/src/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/syntax/presentation.rs
@@ -50,7 +50,8 @@ where
 {
     type Error = JsonLdError;
 
-    type Expanded<I: Interpretation, V: Vocabulary> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I: Interpretation, V: Vocabulary>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/vc/src/v1/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/credential.rs
@@ -434,7 +434,8 @@ where
 {
     type Error = JsonLdError;
 
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/vc/src/v1/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/presentation.rs
@@ -140,7 +140,8 @@ where
 {
     type Error = JsonLdError;
 
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -416,7 +416,8 @@ where
 {
     type Error = JsonLdError;
 
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/claims/crates/vc/src/v2/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/presentation.rs
@@ -140,7 +140,8 @@ where
 {
     type Error = JsonLdError;
 
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/core/src/de.rs
+++ b/crates/core/src/de.rs
@@ -25,7 +25,7 @@ impl<'a, T, U> WithType<'a, T, U> {
     }
 }
 
-impl<'a, 'de, T, U: DeserializeTyped<'de, T>> DeserializeSeed<'de> for WithType<'a, T, U> {
+impl<'de, T, U: DeserializeTyped<'de, T>> DeserializeSeed<'de> for WithType<'_, T, U> {
     type Value = U;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>

--- a/crates/core/src/json_pointer.rs
+++ b/crates/core/src/json_pointer.rs
@@ -28,7 +28,7 @@ pub struct InvalidJsonPointer<T = String>(pub T);
 #[repr(transparent)]
 pub struct JsonPointer(str);
 
-impl<'a> Default for &'a JsonPointer {
+impl Default for &JsonPointer {
     fn default() -> Self {
         JsonPointer::ROOT
     }

--- a/crates/dids/core/src/did.rs
+++ b/crates/dids/core/src/did.rs
@@ -363,7 +363,7 @@ impl<'de> Deserialize<'de> for DIDBuf {
     {
         struct Visitor;
 
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl serde::de::Visitor<'_> for Visitor {
             type Value = DIDBuf;
 
             fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/dids/core/src/did/url.rs
+++ b/crates/dids/core/src/did/url.rs
@@ -572,7 +572,7 @@ impl<'de> Deserialize<'de> for DIDURLBuf {
     {
         struct Visitor;
 
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl serde::de::Visitor<'_> for Visitor {
             type Value = DIDURLBuf;
 
             fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/dids/core/src/did/url/reference.rs
+++ b/crates/dids/core/src/did/url/reference.rs
@@ -11,7 +11,7 @@ pub enum DIDURLReference<'a> {
     Relative(&'a RelativeDIDURL),
 }
 
-impl<'a> DIDURLReference<'a> {
+impl DIDURLReference<'_> {
     pub fn resolve(&self, base_id: &DID) -> Cow<DIDURL> {
         match self {
             Self::Absolute(a) => Cow::Borrowed(a),

--- a/crates/dids/core/src/did/url/relative.rs
+++ b/crates/dids/core/src/did/url/relative.rs
@@ -227,7 +227,7 @@ impl<'de> Deserialize<'de> for RelativeDIDURLBuf {
     {
         struct Visitor;
 
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl serde::de::Visitor<'_> for Visitor {
             type Value = RelativeDIDURLBuf;
 
             fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/dids/core/src/lib.rs
+++ b/crates/dids/core/src/lib.rs
@@ -33,6 +33,6 @@ pub trait DIDMethod {
     const DID_METHOD_NAME: &'static str;
 }
 
-impl<'a, M: DIDMethod> DIDMethod for &'a M {
+impl<M: DIDMethod> DIDMethod for &M {
     const DID_METHOD_NAME: &'static str = M::DID_METHOD_NAME;
 }

--- a/crates/dids/core/src/method_resolver.rs
+++ b/crates/dids/core/src/method_resolver.rs
@@ -68,7 +68,10 @@ impl<T: DIDResolver, M> DIDResolver for VerificationMethodDIDResolver<T, M> {
 }
 
 impl<T: DIDResolver, M> ControllerProvider for VerificationMethodDIDResolver<T, M> {
-    type Controller<'a> = Document where Self: 'a;
+    type Controller<'a>
+        = Document
+    where
+        Self: 'a;
 
     async fn get_controller<'a>(
         &'a self,

--- a/crates/dids/core/src/resolution.rs
+++ b/crates/dids/core/src/resolution.rs
@@ -345,7 +345,7 @@ pub trait DIDMethodResolver: DIDMethod {
     ) -> Result<Output<Vec<u8>>, Error>;
 }
 
-impl<'a, T: DIDMethodResolver> DIDMethodResolver for &'a T {
+impl<T: DIDMethodResolver> DIDMethodResolver for &T {
     fn method_name(&self) -> &str {
         T::method_name(*self)
     }

--- a/crates/dids/methods/ethr/src/lib.rs
+++ b/crates/dids/methods/ethr/src/lib.rs
@@ -587,7 +587,7 @@ mod tests {
 
         // test that holder is verified
         let mut vp_bad_holder = vp;
-        vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned().into());
+        vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned());
 
         // It should fail.
         assert!(vp_bad_holder.verify(&verifier).await.unwrap().is_err());

--- a/crates/dids/methods/ion/src/sidetree/mod.rs
+++ b/crates/dids/methods/ion/src/sidetree/mod.rs
@@ -682,7 +682,6 @@ pub struct ServiceEndpointEntry {
 #[serde(rename_all = "camelCase")]
 pub struct DocumentState {
     /// Public key entries
-
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_keys: Option<Vec<PublicKeyEntry>>,
 

--- a/crates/dids/methods/ion/src/sidetree/operation/update.rs
+++ b/crates/dids/methods/ion/src/sidetree/operation/update.rs
@@ -49,7 +49,6 @@ impl SidetreeOperation for UpdateOperation {
     /// The [DID Suffix](UpdateOperation::did_suffix) is **not** verified
     /// by this function. The correspondence of the reveal value's hash to the previous update
     /// commitment is not checked either, since that is not known from this function.
-
     fn partial_verify<S: Sidetree>(
         self,
     ) -> Result<PartiallyVerifiedUpdateOperation, PartialVerificationError> {

--- a/crates/dids/methods/pkh/src/lib.rs
+++ b/crates/dids/methods/pkh/src/lib.rs
@@ -982,7 +982,7 @@ mod tests {
             })),
         );
 
-        let issuance_date = cred.issuance_date.clone().unwrap();
+        let issuance_date = cred.issuance_date.unwrap();
         let created_date =
             xsd_types::DateTimeStamp::new(issuance_date.date_time, issuance_date.offset.unwrap());
         let issue_options = ProofOptions::new(
@@ -1074,7 +1074,7 @@ mod tests {
 
         // Test that holder is verified.
         let mut vp_bad_holder = vp.clone();
-        vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned().into());
+        vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned());
 
         // It should fail.
         assert!(vp_bad_holder.verify(&params).await.unwrap().is_err());
@@ -1115,7 +1115,7 @@ mod tests {
                 "id": "did:example:foo"
             })),
         );
-        let issuance_date = cred.issuance_date.clone().unwrap();
+        let issuance_date = cred.issuance_date.unwrap();
         let created_date =
             xsd_types::DateTimeStamp::new(issuance_date.date_time, issuance_date.offset.unwrap());
         let issue_options = ProofOptions::new(
@@ -1142,7 +1142,7 @@ mod tests {
         // test that issuer property is used for verification
         let mut vc_bad_issuer = vc.clone();
         vc_bad_issuer.issuer = uri!("did:pkh:example:bad").to_owned().into();
-        assert!(!vc_bad_issuer.verify(&verifier).await.unwrap().is_ok());
+        assert!(vc_bad_issuer.verify(&verifier).await.unwrap().is_err());
 
         // Check that proof JWK must match proof verificationMethod.
         let wrong_signer = SingleSecretSigner::new(wrong_key.clone()).into_local();
@@ -1188,7 +1188,7 @@ mod tests {
 
         // Test that holder is verified.
         let mut vp_bad_holder = vp.clone();
-        vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned().into());
+        vp_bad_holder.holder = Some(uri!("did:pkh:example:bad").to_owned());
         // It should fail.
         assert!(vp_bad_holder.verify(&verifier).await.unwrap().is_err());
     }

--- a/crates/dids/methods/tz/tests/did.rs
+++ b/crates/dids/methods/tz/tests/did.rs
@@ -206,7 +206,7 @@ async fn credential_prove_verify_did_tz1() {
         .mount(&mock_server)
         .await;
     Mock::given(method("GET"))
-		.and(path(&format!("v1/contracts/{}/storage", "KT1ACXxefCq3zVG9cth4whZqS1XYK9Qsn8Gi")))
+		.and(path(format!("v1/contracts/{}/storage", "KT1ACXxefCq3zVG9cth4whZqS1XYK9Qsn8Gi")))
 		.respond_with(
 		ResponseTemplate::new(200)
 		.set_body_json(json!({"verification_method": "did:tz:delphinet:tz1WvvbEGpBXGeTVbLiR6DYBe1izmgiYuZbq#blockchainAccountId",
@@ -339,7 +339,7 @@ async fn credential_prove_verify_did_tz2() {
     let params = VerificationParameters::from_resolver(&didtz);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
-    let issuance_date = cred.issuance_date.clone().unwrap();
+    let issuance_date = cred.issuance_date.unwrap();
     let created_date =
         xsd_types::DateTimeStamp::new(issuance_date.date_time, issuance_date.offset.unwrap());
     let vc_issue_options = SuiteOptions::new(
@@ -437,7 +437,7 @@ async fn credential_prove_verify_did_tz3() {
     let params = VerificationParameters::from_resolver(&didtz);
     let signer = SingleSecretSigner::new(key.clone()).into_local();
 
-    let issuance_date = cred.issuance_date.clone().unwrap();
+    let issuance_date = cred.issuance_date.unwrap();
     let created_date =
         xsd_types::DateTimeStamp::new(issuance_date.date_time, issuance_date.offset.unwrap());
     let vc_issue_options = SuiteOptions::new(

--- a/crates/dids/methods/web/src/lib.rs
+++ b/crates/dids/methods/web/src/lib.rs
@@ -13,7 +13,7 @@ use std::cell::RefCell;
 
 #[cfg(test)]
 thread_local! {
-  static PROXY: RefCell<Option<String>> = RefCell::new(None);
+  static PROXY: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/eip712/src/ty.rs
+++ b/crates/eip712/src/ty.rs
@@ -40,7 +40,7 @@ impl TypesLoader for () {
     }
 }
 
-impl<'a, T: TypesLoader> TypesLoader for &'a T {
+impl<T: TypesLoader> TypesLoader for &T {
     async fn fetch_types(&self, uri: &Uri) -> Result<Types, TypesFetchError> {
         T::fetch_types(*self, uri).await
     }
@@ -52,7 +52,7 @@ pub trait Eip712TypesLoaderProvider {
     fn eip712_types(&self) -> &Self::Loader;
 }
 
-impl<'a, E: Eip712TypesLoaderProvider> Eip712TypesLoaderProvider for &'a E {
+impl<E: Eip712TypesLoaderProvider> Eip712TypesLoaderProvider for &E {
     type Loader = E::Loader;
 
     fn eip712_types(&self) -> &Self::Loader {

--- a/crates/json-ld/src/lib.rs
+++ b/crates/json-ld/src/lib.rs
@@ -22,7 +22,7 @@ pub trait JsonLdLoaderProvider {
     fn loader(&self) -> &Self::Loader;
 }
 
-impl<'a, E: JsonLdLoaderProvider> JsonLdLoaderProvider for &'a E {
+impl<E: JsonLdLoaderProvider> JsonLdLoaderProvider for &E {
     type Loader = E::Loader;
 
     fn loader(&self) -> &Self::Loader {
@@ -155,7 +155,7 @@ pub struct JsonLdTypes<'a> {
     non_static: Cow<'a, [String]>,
 }
 
-impl<'a> Default for JsonLdTypes<'a> {
+impl Default for JsonLdTypes<'_> {
     fn default() -> Self {
         Self::new(&[], Cow::Owned(vec![]))
     }
@@ -185,7 +185,7 @@ impl<'a> JsonLdTypes<'a> {
     }
 }
 
-impl<'a> From<&'static &'static str> for JsonLdTypes<'a> {
+impl From<&'static &'static str> for JsonLdTypes<'_> {
     fn from(value: &'static &'static str) -> Self {
         Self::new(std::slice::from_ref(value), Cow::Owned(vec![]))
     }
@@ -197,7 +197,7 @@ impl<'a> From<&'a [String]> for JsonLdTypes<'a> {
     }
 }
 
-impl<'a> From<Vec<String>> for JsonLdTypes<'a> {
+impl From<Vec<String>> for JsonLdTypes<'_> {
     fn from(value: Vec<String>) -> Self {
         Self::new(&[], Cow::Owned(value))
     }
@@ -209,7 +209,7 @@ impl<'a> From<Cow<'a, [String]>> for JsonLdTypes<'a> {
     }
 }
 
-impl<'a> serde::Serialize for JsonLdTypes<'a> {
+impl serde::Serialize for JsonLdTypes<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/jwk/src/resolver.rs
+++ b/crates/jwk/src/resolver.rs
@@ -20,7 +20,7 @@ pub trait JWKResolver {
     ) -> Result<Cow<JWK>, ProofValidationError>;
 }
 
-impl<'a, T: JWKResolver> JWKResolver for &'a T {
+impl<T: JWKResolver> JWKResolver for &T {
     async fn fetch_public_jwk(
         &self,
         key_id: Option<&str>,

--- a/crates/jwk/src/ripemd160.rs
+++ b/crates/jwk/src/ripemd160.rs
@@ -26,7 +26,7 @@ mod tests {
         let pk_bytes = hex::decode(pk_hex).unwrap();
         let pk = k256::PublicKey::from_sec1_bytes(&pk_bytes).unwrap();
         let jwk = JWK {
-            params: Params::EC(ECParams::try_from(&pk).unwrap()),
+            params: Params::EC(ECParams::from(&pk)),
             public_key_use: None,
             key_operations: None,
             algorithm: None,

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -107,7 +107,7 @@ where
 /// Wrapper to display an RDF Quad as an N-Quads statement.
 pub struct NQuadsStatement<'a>(pub &'a LexicalQuad);
 
-impl<'a> fmt::Display for NQuadsStatement<'a> {
+impl fmt::Display for NQuadsStatement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{} .", self.0)
     }

--- a/crates/rdf/src/urdna2015.rs
+++ b/crates/rdf/src/urdna2015.rs
@@ -583,7 +583,7 @@ mod tests {
                     .map(LexicalQuad::as_lexical_quad_ref),
             )
             .into_nquads();
-            if &normalized == &expected_str {
+            if normalized == expected_str {
                 passed += 1;
             } else {
                 let changes = difference::Changeset::new(&normalized, &expected_str, "\n");

--- a/crates/status/examples/status_list.rs
+++ b/crates/status/examples/status_list.rs
@@ -94,11 +94,13 @@ impl Command {
 
                 let jwk = read_jwk(&key)?;
 
-                let mut header = ssi_jws::Header::default();
-                header.algorithm = jwk.algorithm.unwrap();
-                header.type_ = Some("vc+ld+json+jwt".to_owned());
-                header.content_type = Some("vc+ld+json".to_owned());
-                header.key_id = Some(DIDJWK::generate_url(&jwk.to_public()).into_string());
+                let header = ssi_jws::Header {
+                    algorithm: jwk.algorithm.unwrap(),
+                    type_: Some("vc+ld+json+jwt".to_owned()),
+                    content_type: Some("vc+ld+json".to_owned()),
+                    key_id: Some(DIDJWK::generate_url(&jwk.to_public()).into_string()),
+                    ..Default::default()
+                };
 
                 let signing_bytes = header.encode_signing_bytes(&bytes);
                 let signature =

--- a/crates/status/src/impl/bitstring_status_list/mod.rs
+++ b/crates/status/src/impl/bitstring_status_list/mod.rs
@@ -712,7 +712,7 @@ pub struct BitStringIter<'a> {
     index: usize,
 }
 
-impl<'a> Iterator for BitStringIter<'a> {
+impl Iterator for BitStringIter<'_> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -740,8 +740,7 @@ impl StatusMap for StatusList {
     ) -> Result<Option<u8>, StatusSizeError> {
         Ok(self
             .bit_string
-            .get(status_size.ok_or(StatusSizeError::Missing)?, key)
-            .map(Into::into))
+            .get(status_size.ok_or(StatusSizeError::Missing)?, key))
     }
 }
 
@@ -803,8 +802,8 @@ mod tests {
 
         assert!(decoded.len() >= len);
 
-        for i in 0..len {
-            assert_eq!(decoded.get(i), Some(values[i]))
+        for (i, item) in values.into_iter().enumerate().take(len) {
+            assert_eq!(decoded.get(i), Some(item))
         }
     }
 
@@ -819,8 +818,8 @@ mod tests {
             values[i] = value;
         }
 
-        for i in 0..len {
-            assert_eq!(bit_string.get(i), Some(values[i]))
+        for (i, item) in values.into_iter().enumerate().take(len) {
+            assert_eq!(bit_string.get(i), Some(item))
         }
     }
 

--- a/crates/status/src/impl/bitstring_status_list/syntax/entry_set/credential.rs
+++ b/crates/status/src/impl/bitstring_status_list/syntax/entry_set/credential.rs
@@ -47,7 +47,10 @@ pub struct BitstringStatusListEntrySetCredential {
 }
 
 impl StatusMapEntrySet for BitstringStatusListEntrySetCredential {
-    type Entry<'a> = &'a BitstringStatusListEntry where Self: 'a;
+    type Entry<'a>
+        = &'a BitstringStatusListEntry
+    where
+        Self: 'a;
 
     fn get_entry(&self, purpose: crate::StatusPurpose<&str>) -> Option<Self::Entry<'_>> {
         (&self.credential_status)
@@ -70,7 +73,8 @@ impl JsonLdNodeObject for BitstringStatusListEntrySetCredential {
 
 impl Expandable for BitstringStatusListEntrySetCredential {
     type Error = JsonLdError;
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/status/src/impl/bitstring_status_list/syntax/status_list/credential.rs
+++ b/crates/status/src/impl/bitstring_status_list/syntax/status_list/credential.rs
@@ -100,7 +100,8 @@ impl JsonLdNodeObject for BitstringStatusListCredential {
 impl Expandable for BitstringStatusListCredential {
     type Error = JsonLdError;
 
-    type Expanded<I: Interpretation, V: Vocabulary> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I: Interpretation, V: Vocabulary>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/status/src/impl/bitstring_status_list_20240406/mod.rs
+++ b/crates/status/src/impl/bitstring_status_list_20240406/mod.rs
@@ -528,7 +528,7 @@ pub struct BitStringIter<'a> {
     index: usize,
 }
 
-impl<'a> Iterator for BitStringIter<'a> {
+impl Iterator for BitStringIter<'_> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -552,7 +552,7 @@ impl StatusMap for StatusList {
         _status_size: Option<StatusSize>,
         key: Self::Key,
     ) -> Result<Option<u8>, StatusSizeError> {
-        Ok(self.bit_string.get(key).map(Into::into))
+        Ok(self.bit_string.get(key))
     }
 }
 
@@ -630,8 +630,8 @@ mod tests {
             values[i] = value;
         }
 
-        for i in 0..len {
-            assert_eq!(bit_string.get(i), Some(values[i]))
+        for (i, item) in values.into_iter().enumerate().take(len) {
+            assert_eq!(bit_string.get(i), Some(item))
         }
     }
 

--- a/crates/status/src/impl/bitstring_status_list_20240406/syntax/entry_set/credential.rs
+++ b/crates/status/src/impl/bitstring_status_list_20240406/syntax/entry_set/credential.rs
@@ -47,7 +47,10 @@ pub struct BitstringStatusListEntrySetCredential {
 }
 
 impl StatusMapEntrySet for BitstringStatusListEntrySetCredential {
-    type Entry<'a> = &'a BitstringStatusListEntry where Self: 'a;
+    type Entry<'a>
+        = &'a BitstringStatusListEntry
+    where
+        Self: 'a;
 
     fn get_entry(&self, purpose: crate::StatusPurpose<&str>) -> Option<Self::Entry<'_>> {
         (&self.credential_status)
@@ -70,7 +73,8 @@ impl JsonLdNodeObject for BitstringStatusListEntrySetCredential {
 
 impl Expandable for BitstringStatusListEntrySetCredential {
     type Error = JsonLdError;
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/status/src/impl/bitstring_status_list_20240406/syntax/status_list/credential.rs
+++ b/crates/status/src/impl/bitstring_status_list_20240406/syntax/status_list/credential.rs
@@ -100,7 +100,8 @@ impl JsonLdNodeObject for BitstringStatusListCredential {
 impl Expandable for BitstringStatusListCredential {
     type Error = JsonLdError;
 
-    type Expanded<I: Interpretation, V: Vocabulary> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I: Interpretation, V: Vocabulary>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/crates/status/src/impl/token_status_list/mod.rs
+++ b/crates/status/src/impl/token_status_list/mod.rs
@@ -503,7 +503,7 @@ pub struct BitStringIter<'a> {
     index: usize,
 }
 
-impl<'a> Iterator for BitStringIter<'a> {
+impl Iterator for BitStringIter<'_> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -593,7 +593,10 @@ where
 }
 
 impl StatusMapEntrySet for AnyStatusListEntrySet {
-    type Entry<'a> = AnyStatusListReference<'a> where Self: 'a;
+    type Entry<'a>
+        = AnyStatusListReference<'a>
+    where
+        Self: 'a;
 
     fn get_entry(&self, purpose: crate::StatusPurpose<&str>) -> Option<Self::Entry<'_>> {
         match self {
@@ -606,7 +609,7 @@ pub enum AnyStatusListReference<'a> {
     Json(&'a json::StatusListReference),
 }
 
-impl<'a> StatusMapEntry for AnyStatusListReference<'a> {
+impl StatusMapEntry for AnyStatusListReference<'_> {
     type Key = usize;
     type StatusSize = StatusSize;
 
@@ -666,8 +669,8 @@ mod tests {
 
         assert!(decoded.len() >= len);
 
-        for i in 0..len {
-            assert_eq!(decoded.get(i), Some(values[i]))
+        for (i, item) in values.into_iter().enumerate().take(len) {
+            assert_eq!(decoded.get(i), Some(item))
         }
     }
 
@@ -682,8 +685,8 @@ mod tests {
             values[i] = value;
         }
 
-        for i in 0..len {
-            assert_eq!(bit_string.get(i), Some(values[i]))
+        for (i, item) in values.into_iter().enumerate().take(len) {
+            assert_eq!(bit_string.get(i), Some(item))
         }
     }
 

--- a/crates/status/src/lib.rs
+++ b/crates/status/src/lib.rs
@@ -131,7 +131,7 @@ pub trait StatusMapEntry {
     fn key(&self) -> Self::Key;
 }
 
-impl<'a, E: StatusMapEntry> StatusMapEntry for &'a E {
+impl<E: StatusMapEntry> StatusMapEntry for &E {
     type Key = E::Key;
     type StatusSize = E::StatusSize;
 

--- a/crates/ucan/src/lib.rs
+++ b/crates/ucan/src/lib.rs
@@ -691,12 +691,11 @@ mod tests {
         for case in cases {
             let ucan = match Ucan::decode(&case.token) {
                 Ok(u) => u,
-                Err(e) => Err(e).unwrap(),
+                Err(e) => panic!("{:?}", e),
             };
 
-            match ucan.verify_signature(&DIDKey).await {
-                Err(e) => Err(e).unwrap(),
-                _ => {}
+            if let Err(e) = ucan.verify_signature(&DIDKey).await {
+                panic!("{:?}", e)
             };
 
             assert_eq!(ucan.payload, case.assertions.payload);
@@ -714,7 +713,7 @@ mod tests {
                     if u.payload.validate_time(None).is_ok()
                         && u.verify_signature(&DIDKey).await.is_ok()
                     {
-                        assert!(false, "{}", case.comment);
+                        panic!("{}", case.comment);
                     }
                 }
                 Err(_e) => {}

--- a/crates/verification-methods/core/src/controller.rs
+++ b/crates/verification-methods/core/src/controller.rs
@@ -18,7 +18,7 @@ pub trait Controller {
     fn allows_verification_method(&self, id: &Iri, proof_purposes: ProofPurposes) -> bool;
 }
 
-impl<'a, T: Controller> Controller for &'a T {
+impl<T: Controller> Controller for &T {
     fn allows_verification_method(&self, id: &Iri, proof_purposes: ProofPurposes) -> bool {
         T::allows_verification_method(*self, id, proof_purposes)
     }

--- a/crates/verification-methods/core/src/lib.rs
+++ b/crates/verification-methods/core/src/lib.rs
@@ -155,7 +155,7 @@ pub trait VerificationMethodResolver {
     }
 }
 
-impl<'t, T: VerificationMethodResolver> VerificationMethodResolver for &'t T {
+impl<T: VerificationMethodResolver> VerificationMethodResolver for &T {
     type Method = T::Method;
 
     async fn resolve_verification_method_with(
@@ -255,7 +255,7 @@ pub trait LinkedDataVerificationMethod {
     fn quads(&self, quads: &mut Vec<rdf_types::Quad>) -> rdf_types::Object;
 }
 
-impl<'a, T: LinkedDataVerificationMethod> LinkedDataVerificationMethod for &'a T {
+impl<T: LinkedDataVerificationMethod> LinkedDataVerificationMethod for &T {
     fn quads(&self, quads: &mut Vec<rdf_types::Quad>) -> rdf_types::Object {
         T::quads(*self, quads)
     }

--- a/crates/verification-methods/core/src/signature/signer/mod.rs
+++ b/crates/verification-methods/core/src/signature/signer/mod.rs
@@ -22,7 +22,7 @@ pub trait Signer<M: VerificationMethod> {
     ) -> Result<Option<Self::MessageSigner>, SignatureError>;
 }
 
-impl<'s, M: VerificationMethod, S: Signer<M>> Signer<M> for &'s S {
+impl<M: VerificationMethod, S: Signer<M>> Signer<M> for &S {
     type MessageSigner = S::MessageSigner;
 
     async fn for_method(

--- a/crates/zcap-ld/src/lib.rs
+++ b/crates/zcap-ld/src/lib.rs
@@ -200,7 +200,7 @@ pub trait TargetCapabilityProvider {
     fn target_capability(&self) -> &Delegation<Self::Caveat, Self::AdditionalProperties>;
 }
 
-impl<'a, E: TargetCapabilityProvider> TargetCapabilityProvider for &'a E {
+impl<E: TargetCapabilityProvider> TargetCapabilityProvider for &E {
     type Caveat = E::Caveat;
     type AdditionalProperties = E::AdditionalProperties;
 
@@ -253,13 +253,13 @@ impl<'v, 'a, R, L1, L2, C, S> InvocationVerifier<'a, C, S, &'v R, &'v L1, &'v L2
     }
 }
 
-impl<'a, C, S, R, L1, L2> DateTimeProvider for InvocationVerifier<'a, C, S, R, L1, L2> {
+impl<C, S, R, L1, L2> DateTimeProvider for InvocationVerifier<'_, C, S, R, L1, L2> {
     fn date_time(&self) -> DateTime<Utc> {
         self.date_time.unwrap_or_else(Utc::now)
     }
 }
 
-impl<'a, C, S, R, L1, L2> ResolverProvider for InvocationVerifier<'a, C, S, R, L1, L2> {
+impl<C, S, R, L1, L2> ResolverProvider for InvocationVerifier<'_, C, S, R, L1, L2> {
     type Resolver = R;
 
     fn resolver(&self) -> &Self::Resolver {
@@ -267,8 +267,8 @@ impl<'a, C, S, R, L1, L2> ResolverProvider for InvocationVerifier<'a, C, S, R, L
     }
 }
 
-impl<'a, C, S, R, L1: ssi_json_ld::Loader, L2> JsonLdLoaderProvider
-    for InvocationVerifier<'a, C, S, R, L1, L2>
+impl<C, S, R, L1: ssi_json_ld::Loader, L2> JsonLdLoaderProvider
+    for InvocationVerifier<'_, C, S, R, L1, L2>
 {
     type Loader = L1;
 
@@ -277,8 +277,8 @@ impl<'a, C, S, R, L1: ssi_json_ld::Loader, L2> JsonLdLoaderProvider
     }
 }
 
-impl<'a, C, S, R, L1, L2: ssi_eip712::TypesLoader> Eip712TypesLoaderProvider
-    for InvocationVerifier<'a, C, S, R, L1, L2>
+impl<C, S, R, L1, L2: ssi_eip712::TypesLoader> Eip712TypesLoaderProvider
+    for InvocationVerifier<'_, C, S, R, L1, L2>
 {
     type Loader = L2;
 
@@ -287,7 +287,7 @@ impl<'a, C, S, R, L1, L2: ssi_eip712::TypesLoader> Eip712TypesLoaderProvider
     }
 }
 
-impl<'a, C, S, R, L1, L2> TargetCapabilityProvider for InvocationVerifier<'a, C, S, R, L1, L2> {
+impl<C, S, R, L1, L2> TargetCapabilityProvider for InvocationVerifier<'_, C, S, R, L1, L2> {
     type Caveat = C;
     type AdditionalProperties = S;
 
@@ -317,7 +317,8 @@ where
 {
     type Error = JsonLdError;
 
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,
@@ -443,7 +444,8 @@ where
 {
     type Error = JsonLdError;
 
-    type Expanded<I, V> = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
+    type Expanded<I, V>
+        = ssi_json_ld::ExpandedDocument<V::Iri, V::BlankId>
     where
         I: Interpretation,
         V: VocabularyMut,

--- a/tests/vcdm_v2_sign.rs
+++ b/tests/vcdm_v2_sign.rs
@@ -11,48 +11,6 @@ use static_iref::iri;
 
 #[cfg(feature = "secp256r1")]
 #[async_std::test]
-async fn ecdsa_secp256r1_2020() {
-    let jwk: JWK = serde_json::from_value(json!({
-        "kty": "EC",
-        "crv": "P-256",
-        "x": "c01opxmxLeRMYhyTaiOKzvOF6DDjEajzb968ClJWB9Q",
-        "y": "oM3B1R0J-Cynleb00D-PManSGnlltcgsMJaoPbPOewU",
-        "d": "g-jUBRnfkbsxOQhtrBZd9l_ElOAw8BoJufTFUut2uHI"
-    }))
-    .unwrap();
-    let resolver = VerificationMethodDIDResolver::<_, AnyMethod>::new(AnyDidMethod::default());
-    let vc: JsonCredential = serde_json::from_value(json!({
-      "@context": [
-        "https://www.w3.org/ns/credentials/v2"
-      ],
-      "type": [
-        "VerifiableCredential"
-      ],
-      "credentialSubject": {
-        "id": "did:key:z6MkhTNL7i2etLerDK8Acz5t528giE5KA4p75T6ka1E1D74r"
-      },
-      "id": "urn:uuid:7a6cafb9-11c3-41a8-98d8-8b5a45c2548f",
-      "issuer": "did:key:zDnaeqRNmCGRy8f4RgNSoj9YiwG697iWB7htXNX89G8Nu3Hxo"
-    }))
-    .unwrap();
-    let signed_vc = AnySuite::EcdsaSecp256r1Signature2019
-        .sign(
-            vc,
-            &resolver,
-            SingleSecretSigner::new(jwk).into_local(),
-            ProofOptions::from_method(iri!("did:key:zDnaeqRNmCGRy8f4RgNSoj9YiwG697iWB7htXNX89G8Nu3Hxo#zDnaeqRNmCGRy8f4RgNSoj9YiwG697iWB7htXNX89G8Nu3Hxo").into()),
-        )
-        .await
-        .unwrap();
-    signed_vc
-        .verify(VerificationParameters::from_resolver(resolver))
-        .await
-        .unwrap()
-        .unwrap();
-}
-
-#[cfg(feature = "secp256r1")]
-#[async_std::test]
 async fn ecdsa_rdfc_2019_p256() {
     let jwk: JWK = serde_json::from_value(json!({
         "kty": "EC",


### PR DESCRIPTION
## Description

Resolve warnings with the latest version of `clippy`.

### Other changes

Removed the `vcdm_v2_sign::ecdsa_secp256r1_2020` test because the [`EcdsaSecp256r1Signature2019` cryptosuite](https://www.w3.org/community/reports/credentials/CG-FINAL-di-ecdsa-2019-20220724) is not compatible with VCDM2.0. It's type term is not defined in the `credentials/v2` context. It was (probably) defined in the `https://w3id.org/security/suites/ecdsa-2019/v1` context mentioned by the CG, but not available anymore.

I had to change the MSRV for some reason.

## Tested

- [x] Test suite still passes.
