### PR TITLE
Improve JWS ownership.

### DIFF
--- a/crates/claims/crates/jws/src/lib.rs
+++ b/crates/claims/crates/jws/src/lib.rs
@@ -229,6 +229,11 @@ impl<'a, T> DecodedJws<'a, T> {
         .unwrap()
     }
 
+    /// Takes ownership of the signing bytes, cloning them if necessary.
+    pub fn into_owned_signing_bytes(self) -> DecodedJws<'static, T> {
+        DecodedJws::new(self.signing_bytes.into_owned_bytes(), self.signature)
+    }
+
     /// Verify the JWS signature.
     ///
     /// This will check the signature and the validity of the decoded payload.
@@ -317,6 +322,14 @@ impl<'a, T> DecodedSigningBytes<'a, T> {
             header: self.header,
             payload: f(self.payload)?,
         })
+    }
+
+    pub fn into_owned_bytes(self) -> DecodedSigningBytes<'static, T> {
+        DecodedSigningBytes {
+            bytes: Cow::Owned(self.bytes.into_owned()),
+            header: self.header,
+            payload: self.payload,
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Implements a few traits and methods to improve ownership control over JWSs:
- `Jws: ToOwned<Owned = JwsBuf>`, `JwsBuf: Borrow<Jws>`
- `JwsStr: ToOwned<Owned = JwsString>`, `JwsString: Borrow<JwsStr>`
- `JwsSlice: ToOwned<Owned = JwsVec>`, `JwsVec: Borrow<JwsSlice>`
- `DecodedJws::into_owned_signing_bytes` (move and take ownership of the signing bytes only)

### Other changes

- Renamed a few borrowing methods.
- Impl `ToDecodedJwt` for `Jws`,
- Impl `IntoDecodedJwt` for `JwsBuf`
- Remove `ToDecodedJwt` impl for `JwsString` (it was probably implemented by mistake over `Jws: ToDedodedJwt` and is still accessible through `JwsString: Deref<Target = JwsStr>` anyway).

## Tested

- [x] Test suite still passes.