### PR TITLE
add use_rustls_tls option to reqwest client builder

### DIFF
--- a/crates/dids/methods/web/Cargo.toml
+++ b/crates/dids/methods/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-web"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
@@ -14,7 +14,9 @@ documentation = "https://docs.rs/did-web/"
 [dependencies]
 ssi-dids-core.workspace = true
 thiserror.workspace = true
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "rustls-tls",
+] }
 http = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]

--- a/crates/dids/methods/web/Cargo.toml
+++ b/crates/dids/methods/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-web"
-version = "0.3.4"
+version = "0.3.3"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/crates/dids/methods/web/src/lib.rs
+++ b/crates/dids/methods/web/src/lib.rs
@@ -98,6 +98,14 @@ impl DIDMethodResolver for DIDWeb {
             reqwest::header::HeaderValue::from_static(USER_AGENT),
         );
 
+        #[cfg(target_os = "android")]
+        let client = reqwest::Client::builder()
+            .use_rustls_tls()
+            .default_headers(headers)
+            .build()
+            .map_err(|e| Error::internal(InternalError::Client(e)))?;
+
+        #[cfg(not(target_os = "android"))]
         let client = reqwest::Client::builder()
             .default_headers(headers)
             .build()


### PR DESCRIPTION
## Description

Adds `use_rustls_tls()` method to reqwest client builder to use the rustls option.

### Other changes

~Bumped version to 0.3.4~

## Tested

Has not been tested, but is expected to resolve the openssl error seen in android devices for sprucekit mobile.
