### PR TITLE
Use `http` scheme resolving `did:web` with private IPv4 addresses.

### DIFF
--- a/crates/dids/methods/web/Cargo.toml
+++ b/crates/dids/methods/web/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
 ] }
 http = "0.2"
+iref.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
 version = "0.11"
@@ -32,7 +33,6 @@ linked-data.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 json-syntax.workspace = true
-iref.workspace = true
 static-iref.workspace = true
 xsd-types.workspace = true
 tokio = { version = "1.0", features = ["macros"] }


### PR DESCRIPTION
## Description

Uses the `http` scheme when resolving `did:web` with a private or loopback IPv4 address.

### Other changes

- Now reject public IPv4 addresses (as required by the spec).

## Tested

- Added more unit test vectors.
