### PR TITLE
Version 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
@@ -37,9 +37,9 @@ ssi-json-ld = { path = "./crates/json-ld", version = "0.3.1", default-features =
 ssi-security = { path = "./crates/security", version = "0.1", default-features = false }
 ssi-caips = { path = "./crates/caips", version = "0.2.1", default-features = false }
 ssi-ucan = { path = "./crates/ucan", version = "0.2.1", default-features = false }
-ssi-zcap-ld = { path = "./crates/zcap-ld", version = "0.4.0", default-features = false }
+ssi-zcap-ld = { path = "./crates/zcap-ld", version = "0.5.0", default-features = false }
 ssi-ssh = { path = "./crates/ssh", version = "0.2.1", default-features = false }
-ssi-status = { path = "./crates/status", version = "0.4", default-features = false }
+ssi-status = { path = "./crates/status", version = "0.5", default-features = false }
 ssi-bbs = { path = "./crates/bbs", version = "0.1.1", default-features = false }
 
 # Verifiable Claims
@@ -48,13 +48,13 @@ ssi-jws = { path = "./crates/claims/crates/jws", version = "0.3", default-featur
 ssi-jwt = { path = "./crates/claims/crates/jwt", version = "0.3", default-features = false }
 ssi-sd-jwt = { path = "./crates/claims/crates/sd-jwt", version = "0.3", default-features = false }
 ssi-cose = { path = "./crates/claims/crates/cose", version = "0.1", default-features = false }
-ssi-vc = { path = "./crates/claims/crates/vc", version = "0.5", default-features = false }
-ssi-vc-jose-cose = { path = "./crates/claims/crates/vc-jose-cose", version = "0.3", default-features = false }
+ssi-vc = { path = "./crates/claims/crates/vc", version = "0.6", default-features = false }
+ssi-vc-jose-cose = { path = "./crates/claims/crates/vc-jose-cose", version = "0.4", default-features = false }
 ssi-data-integrity-core = { path = "./crates/claims/crates/data-integrity/core", version = "0.3", default-features = false }
 ssi-di-sd-primitives = { path = "./crates/claims/crates/data-integrity/sd-primitives", version = "0.2", default-features = false }
 ssi-data-integrity-suites = { path = "./crates/claims/crates/data-integrity/suites", version = "0.2", default-features = false }
 ssi-data-integrity = { path = "./crates/claims/crates/data-integrity", version = "0.2", default-features = false }
-ssi-claims = { path = "./crates/claims", version = "0.3.0", default-features = false }
+ssi-claims = { path = "./crates/claims", version = "0.4", default-features = false }
 
 # DID methods
 ssi-dids-core = { path = "./crates/dids/core", version = "0.1.2", default-features = false }

--- a/crates/claims/Cargo.toml
+++ b/crates/claims/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-claims"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/vc-jose-cose/Cargo.toml
+++ b/crates/claims/crates/vc-jose-cose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-vc-jose-cose"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/vc/Cargo.toml
+++ b/crates/claims/crates/vc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-vc"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/status/Cargo.toml
+++ b/crates/status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-status"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/zcap-ld/Cargo.toml
+++ b/crates/zcap-ld/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-zcap-ld"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"


### PR DESCRIPTION
Bump all the crate versions for ssi@0.12.0. Here is the summary of version changes:

- `ssi`: 0.11.0 -> 0.12.0
	- `ssi-claims`: 0.3.0 -> 0.4.0
		- `ssi-vc`: 0.5.0 -> 0.6.0
		- `ssi-vc-jose-cose`: 0.3.0 -> 0.4.0
	- `ssi-status`: 0.4.0 -> 0.5.0
	- `ssi-zcap-ld`: 0.4.0 -> 0.5.0