### PR TITLE
Skip `name` and `description` serialization when `None`.

### DIFF
--- a/crates/claims/crates/vc/Cargo.toml
+++ b/crates/claims/crates/vc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-vc"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -62,9 +62,11 @@ pub struct SpecializedJsonCredential<
     pub id: Option<UriBuf>,
 
     /// Name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<InternationalString>,
 
     /// Credential description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<InternationalString>,
 
     /// Credential type.


### PR DESCRIPTION
## Description

I forgot to `skip_serializing_if = "Option::is_none"` on the `name` and `description` fields.