### PR TITLE
Make `_sd_alg` optional

### DIFF
--- a/crates/claims/crates/sd-jwt/src/digest.rs
+++ b/crates/claims/crates/sd-jwt/src/digest.rs
@@ -9,9 +9,10 @@ use crate::{disclosure::Disclosure, DecodeError, SD_ALG_CLAIM_NAME};
 
 /// Elements of the _sd_alg claim
 #[non_exhaustive]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SdAlg {
     /// SHA-256 Algortim for hashing disclosures
+    #[default]
     Sha256,
 }
 

--- a/crates/claims/crates/sd-jwt/src/lib.rs
+++ b/crates/claims/crates/sd-jwt/src/lib.rs
@@ -620,7 +620,7 @@ impl fmt::Display for PartsRef<'_> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SdJwtPayload {
     /// Hash algorithm used by the Issuer to generate the digests.
-    #[serde(rename = "_sd_alg")]
+    #[serde(rename = "_sd_alg", default)]
     pub sd_alg: SdAlg,
 
     /// Other claims.


### PR DESCRIPTION
## Description

Per [Section 4.1](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-22.html#section-4.1) of the SD-JWT specification, `_sd_alg` field is optional and in its absence implementations [should assume](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-22.html#name-hash-function-claim) the default value of `sha-256`.

## Tested

`cargo check`
