### PR TITLE
Address compile errors due to serde >1.0.219 removing serde::__private::* visibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ rust-version = "1.82"
 
 [workspace]
 members = [
-    "crates/*",
-    "crates/verification-methods/core",
-    "crates/dids/core",
-    "crates/dids/methods/*",
-    "crates/claims/core",
-    "crates/claims/crates/*",
-    "crates/claims/crates/data-integrity/core",
-    "crates/claims/crates/data-integrity/suites",
+  "crates/*",
+  "crates/verification-methods/core",
+  "crates/dids/core",
+  "crates/dids/methods/*",
+  "crates/claims/core",
+  "crates/claims/crates/*",
+  "crates/claims/crates/data-integrity/core",
+  "crates/claims/crates/data-integrity/suites",
 ]
 
 [workspace.dependencies]
@@ -93,7 +93,7 @@ locspan = "0.8"
 json-syntax = "0.12.5"
 nquads-syntax = "0.19"
 multibase = "0.9.1"
-serde = "1.0"
+serde = "=1.0.219"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 serde_jcs = "0.1.0"
 ciborium = "0.2.2"
@@ -115,13 +115,13 @@ uuid = "1.9"
 
 [features]
 default = [
-    "w3c",
-    "rsa",
-    "ed25519",
-    "secp256k1",
-    "secp256r1",
-    "ripemd-160",
-    "eip712",
+  "w3c",
+  "rsa",
+  "ed25519",
+  "secp256k1",
+  "secp256r1",
+  "ripemd-160",
+  "eip712",
 ]
 
 ## Signature suites specified by the W3C.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

- Pinning serde to "=1.0.219" as the last working serde version
- Incrementing ssi crate from 0.12.0 to 0.12.1

### Other changes

No other changes

### Optional section

Ideally the de/se implementations need to be refactored to work with the latest serde versions.

## Tested

Tested compilation and tests, everything passed.