### PR TITLE
Replace suites deserialization with flattened structs

### DIFF
--- a/crates/claims/crates/data-integrity/core/src/de.rs
+++ b/crates/claims/crates/data-integrity/core/src/de.rs
@@ -1,12 +1,15 @@
 use std::marker::PhantomData;
 
-use crate::{CryptographicSuite, DataIntegrity, DeserializeCryptographicSuite, Proofs};
+use crate::{
+    suite::bounds::DeserializeCryptographicSuiteMultiplexing, CryptographicSuite, DataIntegrity,
+    Proofs,
+};
 use serde::Deserialize;
 
 impl<'de, T, S> Deserialize<'de> for DataIntegrity<T, S>
 where
     T: Deserialize<'de>,
-    S: DeserializeCryptographicSuite<'de>,
+    S: DeserializeCryptographicSuiteMultiplexing<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -21,7 +24,7 @@ struct Visitor<T, S>(PhantomData<(T, S)>);
 impl<'de, T, S> serde::de::Visitor<'de> for Visitor<T, S>
 where
     T: Deserialize<'de>,
-    S: DeserializeCryptographicSuite<'de>,
+    S: DeserializeCryptographicSuiteMultiplexing<'de>,
 {
     type Value = DataIntegrity<T, S>;
 
@@ -52,7 +55,7 @@ struct Deserializer<'de, D, S: CryptographicSuite> {
     de: PhantomData<&'de ()>,
 }
 
-impl<'de, D: serde::de::MapAccess<'de>, S: DeserializeCryptographicSuite<'de>>
+impl<'de, D: serde::de::MapAccess<'de>, S: DeserializeCryptographicSuiteMultiplexing<'de>>
     Deserializer<'de, D, S>
 {
     fn into_proofs(mut self) -> Result<Proofs<S>, D::Error> {
@@ -69,7 +72,7 @@ impl<'de, D: serde::de::MapAccess<'de>, S: DeserializeCryptographicSuite<'de>>
 
 impl<'de, D: serde::de::MapAccess<'de>, S> serde::de::MapAccess<'de> for Deserializer<'de, D, S>
 where
-    S: DeserializeCryptographicSuite<'de>,
+    S: DeserializeCryptographicSuiteMultiplexing<'de>,
 {
     type Error = D::Error;
 
@@ -103,7 +106,7 @@ where
 
 impl<'de, D: serde::de::MapAccess<'de>, S> serde::Deserializer<'de> for &mut Deserializer<'de, D, S>
 where
-    S: DeserializeCryptographicSuite<'de>,
+    S: DeserializeCryptographicSuiteMultiplexing<'de>,
 {
     type Error = D::Error;
 

--- a/crates/claims/crates/data-integrity/core/src/proof/de/field.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/field.rs
@@ -1,12 +1,14 @@
+use core::fmt;
+
 use serde::Deserialize;
 
-pub enum TypeField<'de> {
+pub enum TypeField {
     Type,
     Cryptosuite,
-    Other(serde::__private::de::Content<'de>),
+    Other(String),
 }
 
-pub enum Field<'de> {
+pub enum Field {
     Context,
     Created,
     VerificationMethod,
@@ -15,180 +17,29 @@ pub enum Field<'de> {
     Domains,
     Challenge,
     Nonce,
-    Other(serde::__private::de::Content<'de>),
+    Other(String),
 }
 
 struct TypeFieldVisitor;
 
 impl<'de> serde::de::Visitor<'de> for TypeFieldVisitor {
-    type Value = TypeField<'de>;
-    fn expecting(
-        &self,
-        __formatter: &mut serde::__private::Formatter,
-    ) -> serde::__private::fmt::Result {
-        serde::__private::Formatter::write_str(__formatter, "field identifier")
+    type Value = TypeField;
+    fn expecting(&self, __formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(__formatter, "field identifier")
     }
-    fn visit_bool<__E>(self, __value: bool) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::Bool(
-            __value,
-        )))
-    }
-    fn visit_i8<__E>(self, __value: i8) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::I8(__value)))
-    }
-    fn visit_i16<__E>(self, __value: i16) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::I16(
-            __value,
-        )))
-    }
-    fn visit_i32<__E>(self, __value: i32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::I32(
-            __value,
-        )))
-    }
-    fn visit_i64<__E>(self, __value: i64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::I64(
-            __value,
-        )))
-    }
-    fn visit_u8<__E>(self, __value: u8) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::U8(__value)))
-    }
-    fn visit_u16<__E>(self, __value: u16) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::U16(
-            __value,
-        )))
-    }
-    fn visit_u32<__E>(self, __value: u32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::U32(
-            __value,
-        )))
-    }
-    fn visit_u64<__E>(self, __value: u64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::U64(
-            __value,
-        )))
-    }
-    fn visit_f32<__E>(self, __value: f32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::F32(
-            __value,
-        )))
-    }
-    fn visit_f64<__E>(self, __value: f64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::F64(
-            __value,
-        )))
-    }
-    fn visit_char<__E>(self, __value: char) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::Char(
-            __value,
-        )))
-    }
-    fn visit_unit<__E>(self) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::Unit))
-    }
-    fn visit_str<__E>(self, __value: &str) -> serde::__private::Result<Self::Value, __E>
+    fn visit_str<__E>(self, __value: &str) -> Result<Self::Value, __E>
     where
         __E: serde::de::Error,
     {
         match __value {
             "type" => Ok(TypeField::Type),
             "cryptosuite" => Ok(TypeField::Cryptosuite),
-            _ => {
-                let __value = serde::__private::de::Content::String(
-                    serde::__private::ToString::to_string(__value),
-                );
-                serde::__private::Ok(TypeField::Other(__value))
-            }
-        }
-    }
-    fn visit_bytes<__E>(self, __value: &[u8]) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            b"type" => Ok(TypeField::Type),
-            b"cryptosuite" => Ok(TypeField::Cryptosuite),
-            _ => {
-                let __value = serde::__private::de::Content::ByteBuf(__value.to_vec());
-                serde::__private::Ok(TypeField::Other(__value))
-            }
-        }
-    }
-    fn visit_borrowed_str<__E>(
-        self,
-        __value: &'de str,
-    ) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            "type" => Ok(TypeField::Type),
-            "cryptosuite" => Ok(TypeField::Cryptosuite),
-            _ => {
-                let __value = serde::__private::de::Content::Str(__value);
-                serde::__private::Ok(TypeField::Other(__value))
-            }
-        }
-    }
-    fn visit_borrowed_bytes<__E>(
-        self,
-        __value: &'de [u8],
-    ) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            b"type" => Ok(TypeField::Type),
-            b"cryptosuite" => Ok(TypeField::Cryptosuite),
-            _ => {
-                let __value = serde::__private::de::Content::Bytes(__value);
-                serde::__private::Ok(TypeField::Other(__value))
-            }
+            _ => Ok(TypeField::Other(__value.to_string())),
         }
     }
 }
 
-impl<'de> Deserialize<'de> for TypeField<'de> {
+impl<'de> Deserialize<'de> for TypeField {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -200,92 +51,11 @@ impl<'de> Deserialize<'de> for TypeField<'de> {
 struct FieldVisitor;
 
 impl<'de> serde::de::Visitor<'de> for FieldVisitor {
-    type Value = Field<'de>;
-    fn expecting(
-        &self,
-        __formatter: &mut serde::__private::Formatter,
-    ) -> serde::__private::fmt::Result {
-        serde::__private::Formatter::write_str(__formatter, "field identifier")
+    type Value = Field;
+    fn expecting(&self, __formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(__formatter, "field identifier")
     }
-    fn visit_bool<__E>(self, __value: bool) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::Bool(__value)))
-    }
-    fn visit_i8<__E>(self, __value: i8) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::I8(__value)))
-    }
-    fn visit_i16<__E>(self, __value: i16) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::I16(__value)))
-    }
-    fn visit_i32<__E>(self, __value: i32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::I32(__value)))
-    }
-    fn visit_i64<__E>(self, __value: i64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::I64(__value)))
-    }
-    fn visit_u8<__E>(self, __value: u8) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::U8(__value)))
-    }
-    fn visit_u16<__E>(self, __value: u16) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::U16(__value)))
-    }
-    fn visit_u32<__E>(self, __value: u32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::U32(__value)))
-    }
-    fn visit_u64<__E>(self, __value: u64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::U64(__value)))
-    }
-    fn visit_f32<__E>(self, __value: f32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::F32(__value)))
-    }
-    fn visit_f64<__E>(self, __value: f64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::F64(__value)))
-    }
-    fn visit_char<__E>(self, __value: char) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::Char(__value)))
-    }
-    fn visit_unit<__E>(self) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::Unit))
-    }
-    fn visit_str<__E>(self, __value: &str) -> serde::__private::Result<Self::Value, __E>
+    fn visit_str<__E>(self, __value: &str) -> Result<Self::Value, __E>
     where
         __E: serde::de::Error,
     {
@@ -298,80 +68,12 @@ impl<'de> serde::de::Visitor<'de> for FieldVisitor {
             "domain" => Ok(Field::Domains),
             "challenge" => Ok(Field::Challenge),
             "nonce" => Ok(Field::Nonce),
-            _ => {
-                let __value = serde::__private::de::Content::String(
-                    serde::__private::ToString::to_string(__value),
-                );
-                serde::__private::Ok(Field::Other(__value))
-            }
-        }
-    }
-    fn visit_bytes<__E>(self, __value: &[u8]) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            b"@context" => Ok(Field::Context),
-            b"created" => Ok(Field::Created),
-            b"verificationMethod" => Ok(Field::VerificationMethod),
-            b"proofPurpose" => Ok(Field::ProofPurpose),
-            b"expires" => Ok(Field::Expires),
-            b"domain" => Ok(Field::Domains),
-            b"challenge" => Ok(Field::Challenge),
-            b"nonce" => Ok(Field::Nonce),
-            _ => {
-                let __value = serde::__private::de::Content::ByteBuf(__value.to_vec());
-                serde::__private::Ok(Field::Other(__value))
-            }
-        }
-    }
-    fn visit_borrowed_str<__E>(
-        self,
-        __value: &'de str,
-    ) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            "@context" => Ok(Field::Context),
-            "created" => Ok(Field::Created),
-            "verificationMethod" => Ok(Field::VerificationMethod),
-            "proofPurpose" => Ok(Field::ProofPurpose),
-            "expires" => Ok(Field::Expires),
-            "domain" => Ok(Field::Domains),
-            "challenge" => Ok(Field::Challenge),
-            "nonce" => Ok(Field::Nonce),
-            _ => {
-                let __value = serde::__private::de::Content::Str(__value);
-                serde::__private::Ok(Field::Other(__value))
-            }
-        }
-    }
-    fn visit_borrowed_bytes<__E>(
-        self,
-        __value: &'de [u8],
-    ) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            b"@context" => Ok(Field::Context),
-            b"created" => Ok(Field::Created),
-            b"verificationMethod" => Ok(Field::VerificationMethod),
-            b"proofPurpose" => Ok(Field::ProofPurpose),
-            b"expires" => Ok(Field::Expires),
-            b"domain" => Ok(Field::Domains),
-            b"challenge" => Ok(Field::Challenge),
-            b"nonce" => Ok(Field::Nonce),
-            _ => {
-                let __value = serde::__private::de::Content::Bytes(__value);
-                serde::__private::Ok(Field::Other(__value))
-            }
+            _ => Ok(Field::Other(__value.to_string())),
         }
     }
 }
 
-impl<'de> Deserialize<'de> for Field<'de> {
+impl<'de> Deserialize<'de> for Field {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/crates/claims/crates/data-integrity/core/src/proof/de/replay_map.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/replay_map.rs
@@ -1,20 +1,13 @@
-pub struct ReplayMap<'de, M> {
-    past: std::vec::IntoIter<(
-        serde::__private::de::Content<'de>,
-        serde::__private::de::Content<'de>,
-    )>,
-    past_value: Option<serde::__private::de::Content<'de>>,
+use serde::de::Error;
+
+pub struct ReplayMap<M> {
+    past: std::vec::IntoIter<(String, serde_json::Value)>,
+    past_value: Option<serde_json::Value>,
     future: M,
 }
 
-impl<'de, M> ReplayMap<'de, M> {
-    pub fn new(
-        past: Vec<(
-            serde::__private::de::Content<'de>,
-            serde::__private::de::Content<'de>,
-        )>,
-        future: M,
-    ) -> Self {
+impl<M> ReplayMap<M> {
+    pub fn new(past: Vec<(String, serde_json::Value)>, future: M) -> Self {
         Self {
             past: past.into_iter(),
             past_value: None,
@@ -23,7 +16,7 @@ impl<'de, M> ReplayMap<'de, M> {
     }
 }
 
-impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<'de, M> {
+impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<M> {
     type Error = M::Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -33,8 +26,9 @@ impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<
         match self.past.next() {
             Some((key, value)) => {
                 self.past_value = Some(value);
-                seed.deserialize(serde::__private::de::ContentDeserializer::new(key))
+                seed.deserialize(serde_json::Value::String(key))
                     .map(Some)
+                    .map_err(Self::Error::custom)
             }
             None => self.future.next_key_seed(seed),
         }
@@ -45,7 +39,7 @@ impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<
         V: serde::de::DeserializeSeed<'de>,
     {
         match self.past_value.take() {
-            Some(value) => seed.deserialize(serde::__private::de::ContentDeserializer::new(value)),
+            Some(value) => seed.deserialize(value).map_err(Self::Error::custom),
             None => self.future.next_value_seed(seed),
         }
     }

--- a/crates/claims/crates/data-integrity/core/src/proof/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/mod.rs
@@ -1,11 +1,11 @@
-use crate::suite::bounds::{OptionsRefOf, SignatureRefOf, VerificationMethodRefOf};
+use crate::suite::bounds::{
+    DeserializeCryptographicSuiteMultiplexing, OptionsRefOf, SignatureRefOf,
+    VerificationMethodRefOf,
+};
 use crate::suite::{
     CryptographicSuiteVerification, InputVerificationOptions, SerializeCryptographicSuite,
 };
-use crate::{
-    CloneCryptographicSuite, CryptographicSuite, DataIntegrity, DebugCryptographicSuite,
-    DeserializeCryptographicSuite,
-};
+use crate::{CloneCryptographicSuite, CryptographicSuite, DataIntegrity, DebugCryptographicSuite};
 use educe::Educe;
 use serde::{Deserialize, Serialize};
 use ssi_claims_core::{AttachProof, ProofValidationError, ProofValidity, ResourceProvider};
@@ -429,7 +429,7 @@ impl<T: SerializeCryptographicSuite> Serialize for Proofs<T> {
     }
 }
 
-impl<'de, S: DeserializeCryptographicSuite<'de>> Deserialize<'de> for Proofs<S> {
+impl<'de, S: DeserializeCryptographicSuiteMultiplexing<'de>> Deserialize<'de> for Proofs<S> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/crates/claims/crates/data-integrity/core/src/suite/standard/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/suite/standard/mod.rs
@@ -1,6 +1,7 @@
 //! Cryptographic suites.
 use std::borrow::Cow;
 
+use serde::{Deserialize, Serialize};
 use ssi_claims_core::{
     ProofValidationError, ProofValidity, ResolverProvider, ResourceProvider, SignatureError,
 };
@@ -26,6 +27,10 @@ use super::{
 };
 
 // mod test_bbs;
+
+/// Empty cryptography suite options
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EmptyProofOptions {}
 
 /// Standard cryptographic suite.
 ///

--- a/crates/claims/crates/data-integrity/src/any/options.rs
+++ b/crates/claims/crates/data-integrity/src/any/options.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use ssi_data_integrity_core::ProofOptions;
+use ssi_data_integrity_core::{suite::standard::EmptyProofOptions, ProofOptions};
 use ssi_jwk::JWK;
 use ssi_verification_methods::AnyMethod;
 
@@ -31,12 +31,14 @@ impl AnyInputSuiteOptions {
     }
 }
 
-impl From<AnyInputSuiteOptions> for () {
-    fn from(_: AnyInputSuiteOptions) -> Self {}
+impl From<AnyInputSuiteOptions> for EmptyProofOptions {
+    fn from(_: AnyInputSuiteOptions) -> Self {
+        Self {}
+    }
 }
 
-impl From<()> for AnyInputSuiteOptions {
-    fn from(_: ()) -> Self {
+impl From<EmptyProofOptions> for AnyInputSuiteOptions {
+    fn from(_: EmptyProofOptions) -> Self {
         Self::default()
     }
 }

--- a/crates/claims/crates/data-integrity/src/any/sd.rs
+++ b/crates/claims/crates/data-integrity/src/any/sd.rs
@@ -2,7 +2,10 @@ use serde::{Deserialize, Serialize};
 use ssi_claims_core::ResolverProvider;
 use ssi_core::JsonPointerBuf;
 use ssi_data_integrity_core::{
-    suite::{CryptographicSuiteSelect, SelectionError, SelectiveCryptographicSuite},
+    suite::{
+        standard::EmptyProofOptions, CryptographicSuiteSelect, SelectionError,
+        SelectiveCryptographicSuite,
+    },
     DataIntegrity, ProofRef,
 };
 use ssi_json_ld::{Expandable, ExpandedDocument, JsonLdLoaderProvider, JsonLdNodeObject};
@@ -86,7 +89,7 @@ where
                             p.map_type(
                                 |_| Self::EcdsaSd2023,
                                 crate::AnySuiteVerificationMethod::EcdsaSd2023,
-                                |_| crate::AnyProofOptions::EcdsaSd2023(()),
+                                |_| crate::AnyProofOptions::EcdsaSd2023(EmptyProofOptions {}),
                                 crate::AnySignature::EcdsaSd2023,
                             )
                         })

--- a/crates/claims/crates/data-integrity/suites/src/suites/dif/ecdsa_secp256k1_recovery_signature_2020.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/dif/ecdsa_secp256k1_recovery_signature_2020.rs
@@ -34,7 +34,7 @@ impl StandardCryptographicSuite for EcdsaSecp256k1RecoverySignature2020 {
 
     type SignatureAlgorithm = DetachedJwsSigning<ssi_crypto::algorithm::ES256KR>;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/aleo_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/aleo_signature_2021.rs
@@ -81,7 +81,7 @@ impl StandardCryptographicSuite for AleoSignature2021 {
 
     type SignatureAlgorithm = AleoSignatureAlgorithm;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/eip712_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/eip712_signature_2021.rs
@@ -93,7 +93,7 @@ impl StandardCryptographicSuite for Eip712Signature2021 {
 
     type SignatureAlgorithm = Eip712SignatureAlgorithm;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/ethereum_personal_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/ethereum_personal_signature_2021.rs
@@ -54,7 +54,7 @@ impl StandardCryptographicSuite for EthereumPersonalSignature2021 {
 
     type SignatureAlgorithm = EthereumWalletSigning;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/ethereum_personal_signature_2021/v0_1.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/ethereum_personal_signature_2021/v0_1.rs
@@ -29,7 +29,7 @@ impl StandardCryptographicSuite for EthereumPersonalSignature2021v0_1 {
 
     type SignatureAlgorithm = EthereumWalletSigning;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/unspecified/solana_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/unspecified/solana_signature_2021.rs
@@ -63,7 +63,7 @@ impl StandardCryptographicSuite for SolanaSignature2021 {
 
     type SignatureAlgorithm = SolanaSignatureAlgorithm;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/bbs_2023/mod.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/bbs_2023/mod.rs
@@ -83,7 +83,7 @@ impl StandardCryptographicSuite for Bbs2023 {
 
     type VerificationMethod = Multikey;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     type SignatureAlgorithm = Bbs2023SignatureAlgorithm;
 

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_rdfc_2019.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_rdfc_2019.rs
@@ -9,7 +9,7 @@ use ssi_data_integrity_core::{
     },
     signing::{Base58Btc, MultibaseSigning},
     suite::{
-        standard::{HashingAlgorithm, HashingError},
+        standard::{EmptyProofOptions, HashingAlgorithm, HashingError},
         NoConfiguration,
     },
     CryptosuiteStr, ProofConfigurationRef, StandardCryptographicSuite, TypeRef,
@@ -42,7 +42,7 @@ impl StandardCryptographicSuite for EcdsaRdfc2019 {
 
     type SignatureAlgorithm = MultibaseSigning<ES256OrES384, Base58Btc>;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::DataIntegrityProof(CryptosuiteStr::new("ecdsa-rdfc-2019").unwrap())

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_sd_2023/configuration.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_sd_2023/configuration.rs
@@ -1,6 +1,9 @@
 use ssi_core::JsonPointerBuf;
 use ssi_data_integrity_core::{
-    suite::{ConfigurationError, InputSignatureOptions, InputVerificationOptions},
+    suite::{
+        standard::EmptyProofOptions, ConfigurationError, InputSignatureOptions,
+        InputVerificationOptions,
+    },
     ProofConfiguration, ProofOptions,
 };
 use ssi_di_sd_primitives::HmacShaAnyKey;
@@ -26,7 +29,7 @@ impl ssi_data_integrity_core::suite::ConfigurationAlgorithm<EcdsaSd2023>
 {
     type InputVerificationMethod = Multikey;
 
-    type InputSuiteOptions = ();
+    type InputSuiteOptions = EmptyProofOptions;
 
     type InputSignatureOptions = SignatureOptions;
 

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_sd_2023/derive.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_sd_2023/derive.rs
@@ -79,7 +79,7 @@ where
         domains: base_proof.domains.to_vec(),
         challenge: base_proof.challenge.map(ToOwned::to_owned),
         nonce: base_proof.nonce.map(ToOwned::to_owned),
-        options: *base_proof.options,
+        options: base_proof.options.clone(),
         signature: Signature::encode_derived(
             &data.base_signature,
             &data.public_key,

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_sd_2023/mod.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_sd_2023/mod.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 use ssi_data_integrity_core::{
-    suite::{CryptographicSuiteSelect, SelectionError, SelectiveCryptographicSuite},
+    suite::{
+        standard::EmptyProofOptions, CryptographicSuiteSelect, SelectionError,
+        SelectiveCryptographicSuite,
+    },
     CryptosuiteStr, DataIntegrity, ProofRef, StandardCryptographicSuite, TypeRef,
 };
 
@@ -41,7 +44,7 @@ impl StandardCryptographicSuite for EcdsaSd2023 {
 
     type VerificationMethod = Multikey;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     type SignatureAlgorithm = SignatureAlgorithm;
 

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_secp256k1_signature_2019.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_secp256k1_signature_2019.rs
@@ -2,7 +2,7 @@ use k256::sha2::Sha256;
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     signing::DetachedJwsSigning,
-    suite::NoConfiguration,
+    suite::{standard::EmptyProofOptions, NoConfiguration},
     StandardCryptographicSuite, TypeRef,
 };
 use ssi_verification_methods::EcdsaSecp256k1VerificationKey2019;
@@ -34,7 +34,7 @@ impl StandardCryptographicSuite for EcdsaSecp256k1Signature2019 {
 
     type SignatureAlgorithm = DetachedJwsSigning<ssi_crypto::algorithm::ES256K>;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_secp256r1_signature_2019.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_secp256r1_signature_2019.rs
@@ -2,7 +2,7 @@ use k256::sha2::Sha256;
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     signing::DetachedJwsSigning,
-    suite::NoConfiguration,
+    suite::{standard::EmptyProofOptions, NoConfiguration},
     StandardCryptographicSuite, TypeRef,
 };
 use ssi_verification_methods::EcdsaSecp256r1VerificationKey2019;
@@ -34,7 +34,7 @@ impl StandardCryptographicSuite for EcdsaSecp256r1Signature2019 {
 
     type SignatureAlgorithm = DetachedJwsSigning<ssi_crypto::algorithm::ES256>;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2018.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2018.rs
@@ -2,7 +2,7 @@ use k256::sha2::Sha256;
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     signing::DetachedJwsSigning,
-    suite::NoConfiguration,
+    suite::{standard::EmptyProofOptions, NoConfiguration},
     StandardCryptographicSuite, TypeRef,
 };
 use ssi_verification_methods::Ed25519VerificationKey2018;
@@ -33,7 +33,7 @@ impl StandardCryptographicSuite for Ed25519Signature2018 {
 
     type SignatureAlgorithm = DetachedJwsSigning<ssi_crypto::algorithm::EdDSA>;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2020.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2020.rs
@@ -9,7 +9,7 @@ use lazy_static::lazy_static;
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     signing::{Base58Btc, MultibaseSigning},
-    suite::AddProofContext,
+    suite::{standard::EmptyProofOptions, AddProofContext},
     StandardCryptographicSuite, TypeRef,
 };
 use ssi_verification_methods::Ed25519VerificationKey2020;
@@ -60,7 +60,7 @@ impl StandardCryptographicSuite for Ed25519Signature2020 {
 
     type SignatureAlgorithm = MultibaseSigning<ssi_crypto::algorithm::EdDSA, Base58Btc>;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/eddsa_2022.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/eddsa_2022.rs
@@ -2,7 +2,7 @@ use k256::sha2::Sha256;
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     signing::{Base58Btc, MultibaseSigning},
-    suite::NoConfiguration,
+    suite::{standard::EmptyProofOptions, NoConfiguration},
     CryptosuiteStr, StandardCryptographicSuite, TypeRef,
 };
 use ssi_verification_methods::Multikey;
@@ -37,7 +37,7 @@ impl StandardCryptographicSuite for EdDsa2022 {
 
     type SignatureAlgorithm = MultibaseSigning<ssi_crypto::algorithm::EdDSA, Base58Btc>;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::DataIntegrityProof(CryptosuiteStr::new("eddsa-2022").unwrap())

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/eddsa_rdfc_2022.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/eddsa_rdfc_2022.rs
@@ -2,7 +2,7 @@ use k256::sha2::Sha256;
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     signing::{Base58Btc, MultibaseSigning},
-    suite::NoConfiguration,
+    suite::{standard::EmptyProofOptions, NoConfiguration},
     CryptosuiteStr, StandardCryptographicSuite, TypeRef,
 };
 use ssi_verification_methods::Multikey;
@@ -33,7 +33,7 @@ impl StandardCryptographicSuite for EdDsaRdfc2022 {
 
     type SignatureAlgorithm = MultibaseSigning<ssi_crypto::algorithm::EdDSA, Base58Btc>;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::DataIntegrityProof(CryptosuiteStr::new("eddsa-rdfc-2022").unwrap())

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/json_web_signature_2020.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/json_web_signature_2020.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     signing::DetachedJwsSigning,
-    suite::AddProofContext,
+    suite::{standard::EmptyProofOptions, AddProofContext},
     StandardCryptographicSuite, TypeRef,
 };
 use ssi_verification_methods::JsonWebKey2020;
@@ -51,7 +51,7 @@ impl StandardCryptographicSuite for JsonWebSignature2020 {
 
     type SignatureAlgorithm = DetachedJwsSigning<ssi_jwk::Algorithm>; // TODO make sure to include the key id
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/rsa_signature_2018.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/rsa_signature_2018.rs
@@ -5,7 +5,10 @@ use ssi_claims_core::{ProofValidationError, ProofValidity, SignatureError};
 use ssi_data_integrity_core::{
     canonicalization::{CanonicalizeClaimsAndConfiguration, HashCanonicalClaimsAndConfiguration},
     suite::{
-        standard::{SignatureAlgorithm, SignatureAndVerificationAlgorithm, VerificationAlgorithm},
+        standard::{
+            EmptyProofOptions, SignatureAlgorithm, SignatureAndVerificationAlgorithm,
+            VerificationAlgorithm,
+        },
         NoConfiguration,
     },
     ProofConfigurationRef, ProofRef, StandardCryptographicSuite, TypeRef,
@@ -38,7 +41,7 @@ impl StandardCryptographicSuite for RsaSignature2018 {
 
     type SignatureAlgorithm = RsaSignatureAlgorithm;
 
-    type ProofOptions = ();
+    type ProofOptions = EmptyProofOptions;
 
     fn type_(&self) -> TypeRef {
         TypeRef::Other(Self::NAME)


### PR DESCRIPTION
We were using private APIs from serde, which they have now protected.

I tried to copy the serde code that we were using, but it did not work as it required redefining `Content`, which is explicitly used by traits like with the `__deserialize_content_v1` method.

The existing code is quite complex (I intend to add some comments in this PR), so I thought it would be good to rely on serde in a more common way. An earlier version of this PR didn't have the `DeserializeCryptographicSuiteMultiplexing` trait which resulted in `AnySuite` deserialization having mismatched signatures and options. Which is obviously what the existing code tries to avoid! So I tried to solve the issue using this awkward back and forth between the cryptosuite's associated types and the deserialization process, which means many places (and more are needed) to be patched with a constraint on the trait.

I also replaced the use of `Content` with a JSON "data model". I know the specs don't explicitly say so, but in practice we're only dealing with data that can be represented with JSON types.

We're definitely losing in performance and in cleanliness but what do you think? Do you have a better idea?

Close #681
Close #682
