### PR TITLE
`serde_json` based `FlatMapDeserializer` implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Core library for Verifiable Credentials and Decentralized Identif
 repository = "https://github.com/spruceid/ssi/"
 documentation = "https://docs.rs/ssi/"
 keywords = ["ssi", "did", "vc", "vp", "jsonld"]
-rust-version = "1.85"
+rust-version = "1.87"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Core library for Verifiable Credentials and Decentralized Identif
 repository = "https://github.com/spruceid/ssi/"
 documentation = "https://docs.rs/ssi/"
 keywords = ["ssi", "did", "vc", "vp", "jsonld"]
-rust-version = "1.82"
+rust-version = "1.85"
 
 [workspace]
 members = [

--- a/crates/caips/src/caip10.rs
+++ b/crates/caips/src/caip10.rs
@@ -95,10 +95,10 @@ impl<V: Vocabulary, I: Interpretation> linked_data::LinkedDataResource<I, V>
     for BlockchainAccountId
 {
     fn interpretation(
-        &self,
+        &'_ self,
         _vocabulary: &mut V,
         _interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         use linked_data::{rdf_types::Term, CowRdfTerm, RdfLiteral, ResourceInterpretation};
         ResourceInterpretation::Uninterpreted(Some(CowRdfTerm::Owned(Term::Literal(
             RdfLiteral::Xsd(xsd_types::Value::String(self.to_string())),
@@ -406,10 +406,10 @@ impl<V: Vocabulary, I: Interpretation, T> linked_data::LinkedDataResource<I, V>
     for TypedBlockchainAccountId<T>
 {
     fn interpretation(
-        &self,
+        &'_ self,
         _vocabulary: &mut V,
         _interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         use linked_data::{rdf_types::Term, CowRdfTerm, RdfLiteral, ResourceInterpretation};
         ResourceInterpretation::Uninterpreted(Some(CowRdfTerm::Owned(Term::Literal(
             RdfLiteral::Xsd(xsd_types::Value::String(self.to_string())),

--- a/crates/claims/crates/cose/src/algorithm.rs
+++ b/crates/claims/crates/cose/src/algorithm.rs
@@ -39,7 +39,7 @@ pub fn algorithm_name(algorithm: &Algorithm) -> String {
 }
 
 /// Returns the preferred signature algorithm for the give COSE key.
-pub fn preferred_algorithm(key: &CoseKey) -> Option<Cow<Algorithm>> {
+pub fn preferred_algorithm(key: &'_ CoseKey) -> Option<Cow<'_, Algorithm>> {
     key.alg
         .as_ref()
         .map(Cow::Borrowed)

--- a/crates/claims/crates/cose/src/key.rs
+++ b/crates/claims/crates/cose/src/key.rs
@@ -19,25 +19,25 @@ pub trait CoseKeyResolver {
     /// Fetches the COSE key associated to the give identifier.
     #[allow(async_fn_in_trait)]
     async fn fetch_public_cose_key(
-        &self,
+        &'_ self,
         id: Option<&[u8]>,
-    ) -> Result<Cow<CoseKey>, ProofValidationError>;
+    ) -> Result<Cow<'_, CoseKey>, ProofValidationError>;
 }
 
 impl<T: CoseKeyResolver> CoseKeyResolver for &T {
     async fn fetch_public_cose_key(
-        &self,
+        &'_ self,
         id: Option<&[u8]>,
-    ) -> Result<Cow<CoseKey>, ProofValidationError> {
+    ) -> Result<Cow<'_, CoseKey>, ProofValidationError> {
         T::fetch_public_cose_key(*self, id).await
     }
 }
 
 impl CoseKeyResolver for CoseKey {
     async fn fetch_public_cose_key(
-        &self,
+        &'_ self,
         _id: Option<&[u8]>,
-    ) -> Result<Cow<CoseKey>, ProofValidationError> {
+    ) -> Result<Cow<'_, CoseKey>, ProofValidationError> {
         Ok(Cow::Borrowed(self))
     }
 }

--- a/crates/claims/crates/cose/src/lib.rs
+++ b/crates/claims/crates/cose/src/lib.rs
@@ -109,7 +109,7 @@ pub use sign1::*;
 ///       "application/json+cose".to_owned(),
 ///     ))
 ///   }
-///   
+///
 ///   fn content_type(&self) -> Option<ContentType> {
 ///     Some(ContentType::Text("application/json".to_owned()))
 ///   }
@@ -136,7 +136,7 @@ pub trait CosePayload {
     /// Payload bytes.
     ///
     /// Returns the payload bytes representing this value.
-    fn payload_bytes(&self) -> Cow<[u8]>;
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]>;
 
     /// Sign the payload to produce a serialized `COSE_Sign1` object.
     ///
@@ -153,7 +153,7 @@ pub trait CosePayload {
 }
 
 impl CosePayload for [u8] {
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self)
     }
 }

--- a/crates/claims/crates/data-integrity/core/Cargo.toml
+++ b/crates/claims/crates/data-integrity/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-data-integrity-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/claims/crates/data-integrity/core/src/document.rs
+++ b/crates/claims/crates/data-integrity/core/src/document.rs
@@ -62,13 +62,13 @@ impl ssi_json_ld::Expandable for DataIntegrityDocument {
 }
 
 impl JsonLdObject for DataIntegrityDocument {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         self.context.as_ref().map(Cow::Borrowed)
     }
 }
 
 impl JsonLdNodeObject for DataIntegrityDocument {
-    fn json_ld_type(&self) -> ssi_json_ld::JsonLdTypes {
+    fn json_ld_type(&'_ self) -> ssi_json_ld::JsonLdTypes<'_> {
         ssi_json_ld::JsonLdTypes::new(&[], Cow::Borrowed(self.types.as_slice()))
     }
 }

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/expansion.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/expansion.rs
@@ -81,13 +81,13 @@ pub struct EmbeddedProofConfigurationRef<'d, 'a, S: CryptographicSuite> {
 }
 
 impl<S: CryptographicSuite> JsonLdObject for EmbeddedProofConfigurationRef<'_, '_, S> {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         self.context.as_deref().map(Cow::Borrowed)
     }
 }
 
 impl<S: CryptographicSuite> JsonLdNodeObject for EmbeddedProofConfigurationRef<'_, '_, S> {
-    fn json_ld_type(&self) -> JsonLdTypes {
+    fn json_ld_type(&'_ self) -> JsonLdTypes<'_> {
         self.type_.reborrow()
     }
 }

--- a/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/configuration/mod.rs
@@ -218,7 +218,7 @@ impl<S: CryptographicSuite> ProofConfiguration<S> {
         }
     }
 
-    pub fn borrowed(&self) -> ProofConfigurationRef<S> {
+    pub fn borrowed(&'_ self) -> ProofConfigurationRef<'_, S> {
         ProofConfigurationRef {
             context: self.context.as_ref(),
             type_: &self.type_,

--- a/crates/claims/crates/data-integrity/core/src/proof/de/configuration.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/configuration.rs
@@ -9,7 +9,7 @@ use serde::{
 use ssi_core::de::WithType;
 use std::{collections::BTreeMap, marker::PhantomData};
 
-use super::{Field, RefOrValue, ReplayMap, TypeField};
+use super::{Field, FlatMapDeserializer, RefOrValue, ReplayMap, TypeField};
 
 impl<'de, T: DeserializeCryptographicSuite<'de>> ProofConfiguration<T> {
     fn deserialize_with_type<S>(type_: Type, mut deserializer: S) -> Result<Self, S::Error>
@@ -53,10 +53,7 @@ impl<'de, T: DeserializeCryptographicSuite<'de>> ProofConfiguration<T> {
         }
 
         let options = WithType::<T, OptionsOf<T>>::new(&suite)
-            .deserialize(serde::__private::de::FlatMapDeserializer(
-                &mut other,
-                PhantomData,
-            ))?
+            .deserialize(FlatMapDeserializer::new(&mut other))?
             .0;
 
         Ok(Self {
@@ -73,10 +70,7 @@ impl<'de, T: DeserializeCryptographicSuite<'de>> ProofConfiguration<T> {
             challenge,
             nonce,
             options,
-            extra_properties: BTreeMap::deserialize(serde::__private::de::FlatMapDeserializer(
-                &mut other,
-                PhantomData,
-            ))?,
+            extra_properties: BTreeMap::deserialize(FlatMapDeserializer::new(&mut other))?,
         })
     }
 }

--- a/crates/claims/crates/data-integrity/core/src/proof/de/field.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/field.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use serde::Deserialize;
 
 pub enum TypeField {
@@ -23,14 +25,11 @@ struct TypeFieldVisitor;
 impl<'de> serde::de::Visitor<'de> for TypeFieldVisitor {
     type Value = TypeField;
 
-    fn expecting(
-        &self,
-        __formatter: &mut serde::__private::Formatter,
-    ) -> serde::__private::fmt::Result {
-        serde::__private::Formatter::write_str(__formatter, "field identifier")
+    fn expecting(&self, __formatter: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Formatter::write_str(__formatter, "field identifier")
     }
 
-    fn visit_str<__E>(self, __value: &str) -> serde::__private::Result<Self::Value, __E>
+    fn visit_str<__E>(self, __value: &str) -> Result<Self::Value, __E>
     where
         __E: serde::de::Error,
     {
@@ -41,10 +40,7 @@ impl<'de> serde::de::Visitor<'de> for TypeFieldVisitor {
         }
     }
 
-    fn visit_borrowed_str<__E>(
-        self,
-        __value: &'de str,
-    ) -> serde::__private::Result<Self::Value, __E>
+    fn visit_borrowed_str<__E>(self, __value: &'de str) -> Result<Self::Value, __E>
     where
         __E: serde::de::Error,
     {
@@ -70,14 +66,11 @@ struct FieldVisitor;
 impl<'de> serde::de::Visitor<'de> for FieldVisitor {
     type Value = Field;
 
-    fn expecting(
-        &self,
-        __formatter: &mut serde::__private::Formatter,
-    ) -> serde::__private::fmt::Result {
-        serde::__private::Formatter::write_str(__formatter, "field identifier")
+    fn expecting(&self, __formatter: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Formatter::write_str(__formatter, "field identifier")
     }
 
-    fn visit_str<__E>(self, __value: &str) -> serde::__private::Result<Self::Value, __E>
+    fn visit_str<__E>(self, __value: &str) -> Result<Self::Value, __E>
     where
         __E: serde::de::Error,
     {
@@ -94,10 +87,7 @@ impl<'de> serde::de::Visitor<'de> for FieldVisitor {
         }
     }
 
-    fn visit_borrowed_str<__E>(
-        self,
-        __value: &'de str,
-    ) -> serde::__private::Result<Self::Value, __E>
+    fn visit_borrowed_str<__E>(self, __value: &'de str) -> Result<Self::Value, __E>
     where
         __E: serde::de::Error,
     {

--- a/crates/claims/crates/data-integrity/core/src/proof/de/field.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/field.rs
@@ -1,12 +1,12 @@
 use serde::Deserialize;
 
-pub enum TypeField<'de> {
+pub enum TypeField {
     Type,
     Cryptosuite,
-    Other(serde::__private::de::Content<'de>),
+    Other(String),
 }
 
-pub enum Field<'de> {
+pub enum Field {
     Context,
     Created,
     VerificationMethod,
@@ -15,117 +15,21 @@ pub enum Field<'de> {
     Domains,
     Challenge,
     Nonce,
-    Other(serde::__private::de::Content<'de>),
+    Other(String),
 }
 
 struct TypeFieldVisitor;
 
 impl<'de> serde::de::Visitor<'de> for TypeFieldVisitor {
-    type Value = TypeField<'de>;
+    type Value = TypeField;
+
     fn expecting(
         &self,
         __formatter: &mut serde::__private::Formatter,
     ) -> serde::__private::fmt::Result {
         serde::__private::Formatter::write_str(__formatter, "field identifier")
     }
-    fn visit_bool<__E>(self, __value: bool) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::Bool(
-            __value,
-        )))
-    }
-    fn visit_i8<__E>(self, __value: i8) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::I8(__value)))
-    }
-    fn visit_i16<__E>(self, __value: i16) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::I16(
-            __value,
-        )))
-    }
-    fn visit_i32<__E>(self, __value: i32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::I32(
-            __value,
-        )))
-    }
-    fn visit_i64<__E>(self, __value: i64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::I64(
-            __value,
-        )))
-    }
-    fn visit_u8<__E>(self, __value: u8) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::U8(__value)))
-    }
-    fn visit_u16<__E>(self, __value: u16) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::U16(
-            __value,
-        )))
-    }
-    fn visit_u32<__E>(self, __value: u32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::U32(
-            __value,
-        )))
-    }
-    fn visit_u64<__E>(self, __value: u64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::U64(
-            __value,
-        )))
-    }
-    fn visit_f32<__E>(self, __value: f32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::F32(
-            __value,
-        )))
-    }
-    fn visit_f64<__E>(self, __value: f64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::F64(
-            __value,
-        )))
-    }
-    fn visit_char<__E>(self, __value: char) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::Char(
-            __value,
-        )))
-    }
-    fn visit_unit<__E>(self) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(TypeField::Other(serde::__private::de::Content::Unit))
-    }
+
     fn visit_str<__E>(self, __value: &str) -> serde::__private::Result<Self::Value, __E>
     where
         __E: serde::de::Error,
@@ -133,27 +37,10 @@ impl<'de> serde::de::Visitor<'de> for TypeFieldVisitor {
         match __value {
             "type" => Ok(TypeField::Type),
             "cryptosuite" => Ok(TypeField::Cryptosuite),
-            _ => {
-                let __value = serde::__private::de::Content::String(
-                    serde::__private::ToString::to_string(__value),
-                );
-                serde::__private::Ok(TypeField::Other(__value))
-            }
+            _ => Ok(TypeField::Other(__value.to_owned())),
         }
     }
-    fn visit_bytes<__E>(self, __value: &[u8]) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            b"type" => Ok(TypeField::Type),
-            b"cryptosuite" => Ok(TypeField::Cryptosuite),
-            _ => {
-                let __value = serde::__private::de::Content::ByteBuf(__value.to_vec());
-                serde::__private::Ok(TypeField::Other(__value))
-            }
-        }
-    }
+
     fn visit_borrowed_str<__E>(
         self,
         __value: &'de str,
@@ -164,31 +51,12 @@ impl<'de> serde::de::Visitor<'de> for TypeFieldVisitor {
         match __value {
             "type" => Ok(TypeField::Type),
             "cryptosuite" => Ok(TypeField::Cryptosuite),
-            _ => {
-                let __value = serde::__private::de::Content::Str(__value);
-                serde::__private::Ok(TypeField::Other(__value))
-            }
-        }
-    }
-    fn visit_borrowed_bytes<__E>(
-        self,
-        __value: &'de [u8],
-    ) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            b"type" => Ok(TypeField::Type),
-            b"cryptosuite" => Ok(TypeField::Cryptosuite),
-            _ => {
-                let __value = serde::__private::de::Content::Bytes(__value);
-                serde::__private::Ok(TypeField::Other(__value))
-            }
+            _ => Ok(TypeField::Other(__value.to_owned())),
         }
     }
 }
 
-impl<'de> Deserialize<'de> for TypeField<'de> {
+impl<'de> Deserialize<'de> for TypeField {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -200,91 +68,15 @@ impl<'de> Deserialize<'de> for TypeField<'de> {
 struct FieldVisitor;
 
 impl<'de> serde::de::Visitor<'de> for FieldVisitor {
-    type Value = Field<'de>;
+    type Value = Field;
+
     fn expecting(
         &self,
         __formatter: &mut serde::__private::Formatter,
     ) -> serde::__private::fmt::Result {
         serde::__private::Formatter::write_str(__formatter, "field identifier")
     }
-    fn visit_bool<__E>(self, __value: bool) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::Bool(__value)))
-    }
-    fn visit_i8<__E>(self, __value: i8) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::I8(__value)))
-    }
-    fn visit_i16<__E>(self, __value: i16) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::I16(__value)))
-    }
-    fn visit_i32<__E>(self, __value: i32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::I32(__value)))
-    }
-    fn visit_i64<__E>(self, __value: i64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::I64(__value)))
-    }
-    fn visit_u8<__E>(self, __value: u8) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::U8(__value)))
-    }
-    fn visit_u16<__E>(self, __value: u16) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::U16(__value)))
-    }
-    fn visit_u32<__E>(self, __value: u32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::U32(__value)))
-    }
-    fn visit_u64<__E>(self, __value: u64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::U64(__value)))
-    }
-    fn visit_f32<__E>(self, __value: f32) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::F32(__value)))
-    }
-    fn visit_f64<__E>(self, __value: f64) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::F64(__value)))
-    }
-    fn visit_char<__E>(self, __value: char) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::Char(__value)))
-    }
-    fn visit_unit<__E>(self) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        serde::__private::Ok(Field::Other(serde::__private::de::Content::Unit))
-    }
+
     fn visit_str<__E>(self, __value: &str) -> serde::__private::Result<Self::Value, __E>
     where
         __E: serde::de::Error,
@@ -298,33 +90,10 @@ impl<'de> serde::de::Visitor<'de> for FieldVisitor {
             "domain" => Ok(Field::Domains),
             "challenge" => Ok(Field::Challenge),
             "nonce" => Ok(Field::Nonce),
-            _ => {
-                let __value = serde::__private::de::Content::String(
-                    serde::__private::ToString::to_string(__value),
-                );
-                serde::__private::Ok(Field::Other(__value))
-            }
+            _ => Ok(Field::Other(__value.to_owned())),
         }
     }
-    fn visit_bytes<__E>(self, __value: &[u8]) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            b"@context" => Ok(Field::Context),
-            b"created" => Ok(Field::Created),
-            b"verificationMethod" => Ok(Field::VerificationMethod),
-            b"proofPurpose" => Ok(Field::ProofPurpose),
-            b"expires" => Ok(Field::Expires),
-            b"domain" => Ok(Field::Domains),
-            b"challenge" => Ok(Field::Challenge),
-            b"nonce" => Ok(Field::Nonce),
-            _ => {
-                let __value = serde::__private::de::Content::ByteBuf(__value.to_vec());
-                serde::__private::Ok(Field::Other(__value))
-            }
-        }
-    }
+
     fn visit_borrowed_str<__E>(
         self,
         __value: &'de str,
@@ -341,37 +110,12 @@ impl<'de> serde::de::Visitor<'de> for FieldVisitor {
             "domain" => Ok(Field::Domains),
             "challenge" => Ok(Field::Challenge),
             "nonce" => Ok(Field::Nonce),
-            _ => {
-                let __value = serde::__private::de::Content::Str(__value);
-                serde::__private::Ok(Field::Other(__value))
-            }
-        }
-    }
-    fn visit_borrowed_bytes<__E>(
-        self,
-        __value: &'de [u8],
-    ) -> serde::__private::Result<Self::Value, __E>
-    where
-        __E: serde::de::Error,
-    {
-        match __value {
-            b"@context" => Ok(Field::Context),
-            b"created" => Ok(Field::Created),
-            b"verificationMethod" => Ok(Field::VerificationMethod),
-            b"proofPurpose" => Ok(Field::ProofPurpose),
-            b"expires" => Ok(Field::Expires),
-            b"domain" => Ok(Field::Domains),
-            b"challenge" => Ok(Field::Challenge),
-            b"nonce" => Ok(Field::Nonce),
-            _ => {
-                let __value = serde::__private::de::Content::Bytes(__value);
-                serde::__private::Ok(Field::Other(__value))
-            }
+            _ => Ok(Field::Other(__value.to_owned())),
         }
     }
 }
 
-impl<'de> Deserialize<'de> for Field<'de> {
+impl<'de> Deserialize<'de> for Field {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/crates/claims/crates/data-integrity/core/src/proof/de/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/mod.rs
@@ -23,8 +23,8 @@ pub use field::*;
 mod ref_or_value;
 pub use ref_or_value::*;
 
-mod replay_map;
-pub use replay_map::*;
+mod utils;
+use utils::{FlatMapDeserializer, ReplayMap};
 
 mod configuration;
 
@@ -97,17 +97,11 @@ impl<'de, T: DeserializeCryptographicSuite<'de>> Proof<T> {
         }
 
         let options = WithType::<T, OptionsOf<T>>::new(&suite)
-            .deserialize(serde::__private::de::FlatMapDeserializer(
-                &mut other,
-                PhantomData,
-            ))?
+            .deserialize(FlatMapDeserializer::new(&mut other))?
             .0;
 
         let signature = WithType::<T, SignatureOf<T>>::new(&suite)
-            .deserialize(serde::__private::de::FlatMapDeserializer(
-                &mut other,
-                PhantomData,
-            ))?
+            .deserialize(FlatMapDeserializer::new(&mut other))?
             .0;
 
         Ok(Self {
@@ -125,10 +119,7 @@ impl<'de, T: DeserializeCryptographicSuite<'de>> Proof<T> {
             nonce,
             options,
             signature,
-            extra_properties: BTreeMap::deserialize(serde::__private::de::FlatMapDeserializer(
-                &mut other,
-                PhantomData,
-            ))?,
+            extra_properties: BTreeMap::deserialize(FlatMapDeserializer::new(&mut other))?,
         })
     }
 }

--- a/crates/claims/crates/data-integrity/core/src/proof/de/utils/flat_map.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/utils/flat_map.rs
@@ -157,7 +157,7 @@ where
 
 /// Claims one key-value pair from a FlatMapDeserializer's field buffer if the
 /// field name matches any of the recognized ones.
-fn flat_map_take_entry<'de>(
+fn flat_map_take_entry(
     entry: &mut Option<(String, serde_json::Value)>,
     recognized: &[&str],
 ) -> Option<(String, serde_json::Value)> {
@@ -378,7 +378,7 @@ where
     }
 }
 
-fn content_unexpected<'a>(content: &'a serde_json::Value) -> de::Unexpected<'a> {
+fn content_unexpected(content: &serde_json::Value) -> de::Unexpected<'_> {
     match content {
         serde_json::Value::Null => de::Unexpected::Unit,
         serde_json::Value::Bool(b) => de::Unexpected::Bool(*b),

--- a/crates/claims/crates/data-integrity/core/src/proof/de/utils/flat_map.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/utils/flat_map.rs
@@ -1,0 +1,390 @@
+use std::marker::PhantomData;
+
+use serde::{
+    de::{
+        self,
+        value::{MapDeserializer, SeqDeserializer, StringDeserializer},
+    },
+    Deserializer,
+};
+
+pub struct FlatMapDeserializer<'a, E> {
+    entries: &'a mut Vec<Option<(String, serde_json::Value)>>,
+    error: PhantomData<E>,
+}
+
+impl<'a, E> FlatMapDeserializer<'a, E> {
+    pub fn new(entries: &'a mut Vec<Option<(String, serde_json::Value)>>) -> Self {
+        Self {
+            entries,
+            error: PhantomData,
+        }
+    }
+}
+
+macro_rules! unsupported {
+    ($($func:ident ($($arg:ty),*))*) => {
+        $(
+            fn $func<V>(self, $(_: $arg,)* _visitor: V) -> Result<V::Value, Self::Error>
+            where
+                V: serde::de::Visitor<'de>,
+            {
+                Err(serde::de::Error::custom("can only flatten structs and maps"))
+            }
+        )*
+    }
+}
+
+impl<'a, 'de, E> Deserializer<'de> for FlatMapDeserializer<'a, E>
+where
+    E: serde::de::Error,
+    'de: 'a,
+{
+    type Error = E;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        for entry in self.entries {
+            if let Some((key, value)) = flat_map_take_entry(entry, variants) {
+                return visitor.visit_enum(EnumDeserializer::new(key, Some(value)));
+            }
+        }
+
+        Err(de::Error::custom(format_args!(
+            "no variant of enum {} found in flattened data",
+            name
+        )))
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_map(FlatMapAccess {
+            iter: self.entries.iter_mut(),
+            pending_content: None,
+            _marker: PhantomData,
+        })
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_map(FlatStructAccess {
+            iter: self.entries.iter_mut(),
+            pending_content: None,
+            fields,
+            _marker: PhantomData,
+        })
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &str, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    unsupported! {
+        deserialize_option()
+        deserialize_bool()
+        deserialize_i8()
+        deserialize_i16()
+        deserialize_i32()
+        deserialize_i64()
+        deserialize_u8()
+        deserialize_u16()
+        deserialize_u32()
+        deserialize_u64()
+        deserialize_f32()
+        deserialize_f64()
+        deserialize_char()
+        deserialize_str()
+        deserialize_string()
+        deserialize_bytes()
+        deserialize_byte_buf()
+        deserialize_seq()
+        deserialize_tuple(usize)
+        deserialize_tuple_struct(&'static str, usize)
+        deserialize_identifier()
+    }
+}
+
+/// Claims one key-value pair from a FlatMapDeserializer's field buffer if the
+/// field name matches any of the recognized ones.
+fn flat_map_take_entry<'de>(
+    entry: &mut Option<(String, serde_json::Value)>,
+    recognized: &[&str],
+) -> Option<(String, serde_json::Value)> {
+    // Entries in the FlatMapDeserializer buffer are nulled out as they get
+    // claimed for deserialization. We only use an entry if it is still present
+    // and if the field is one recognized by the current data structure.
+    let is_recognized = match entry {
+        None => false,
+        Some((k, _v)) => recognized.contains(&k.as_str()),
+    };
+
+    if is_recognized {
+        entry.take()
+    } else {
+        None
+    }
+}
+
+struct FlatMapAccess<'a, E> {
+    iter: std::slice::IterMut<'a, Option<(String, serde_json::Value)>>,
+    pending_content: Option<serde_json::Value>,
+    _marker: PhantomData<E>,
+}
+
+impl<'a, 'de, E> de::MapAccess<'de> for FlatMapAccess<'a, E>
+where
+    E: de::Error,
+    'de: 'a,
+{
+    type Error = E;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        for entry in self.iter.by_ref() {
+            if let Some((key, content)) = entry.take() {
+                self.pending_content = Some(content);
+                return seed.deserialize(StringDeserializer::new(key)).map(Some);
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.pending_content.take() {
+            Some(value) => seed.deserialize(value).map_err(de::Error::custom),
+            None => Err(de::Error::custom("value is missing")),
+        }
+    }
+}
+
+struct FlatStructAccess<'a, E> {
+    iter: std::slice::IterMut<'a, Option<(String, serde_json::Value)>>,
+    pending_content: Option<serde_json::Value>,
+    fields: &'static [&'static str],
+    _marker: PhantomData<E>,
+}
+
+impl<'a, 'de, E> de::MapAccess<'de> for FlatStructAccess<'a, E>
+where
+    E: de::Error,
+    'de: 'a,
+{
+    type Error = E;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        for entry in self.iter.by_ref() {
+            if let Some((key, content)) = flat_map_take_entry(entry, self.fields) {
+                self.pending_content = Some(content);
+                return seed.deserialize(StringDeserializer::new(key)).map(Some);
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.pending_content.take() {
+            Some(value) => seed.deserialize(value).map_err(de::Error::custom),
+            None => Err(de::Error::custom("value is missing")),
+        }
+    }
+}
+
+pub struct EnumDeserializer<E>
+where
+    E: de::Error,
+{
+    variant: String,
+    value: Option<serde_json::Value>,
+    err: PhantomData<E>,
+}
+
+impl<E> EnumDeserializer<E>
+where
+    E: serde::de::Error,
+{
+    pub fn new(variant: String, value: Option<serde_json::Value>) -> Self {
+        Self {
+            variant,
+            value,
+            err: PhantomData,
+        }
+    }
+}
+
+impl<'de, E> de::EnumAccess<'de> for EnumDeserializer<E>
+where
+    E: de::Error,
+{
+    type Error = E;
+    type Variant = VariantDeserializer<Self::Error>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), E>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let visitor = VariantDeserializer {
+            value: self.value,
+            err: PhantomData,
+        };
+        seed.deserialize(StringDeserializer::new(self.variant))
+            .map(|v| (v, visitor))
+    }
+}
+
+pub struct VariantDeserializer<E>
+where
+    E: de::Error,
+{
+    value: Option<serde_json::Value>,
+    err: PhantomData<E>,
+}
+
+impl<'de, E> de::VariantAccess<'de> for VariantDeserializer<E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    fn unit_variant(self) -> Result<(), E> {
+        match self.value {
+            Some(value) => de::Deserialize::deserialize(value).map_err(de::Error::custom),
+            None => Ok(()),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, E>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(value) => seed.deserialize(value).map_err(de::Error::custom),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Some(serde_json::Value::Array(v)) => {
+                de::Deserializer::deserialize_any(SeqDeserializer::new(v.into_iter()), visitor)
+                    .map_err(de::Error::custom)
+            }
+            Some(other) => Err(de::Error::invalid_type(
+                content_unexpected(&other),
+                &"tuple variant",
+            )),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Some(serde_json::Value::Object(v)) => {
+                de::Deserializer::deserialize_any(MapDeserializer::new(v.into_iter()), visitor)
+                    .map_err(de::Error::custom)
+            }
+            Some(serde_json::Value::Array(v)) => {
+                de::Deserializer::deserialize_any(SeqDeserializer::new(v.into_iter()), visitor)
+                    .map_err(de::Error::custom)
+            }
+            Some(other) => Err(de::Error::invalid_type(
+                content_unexpected(&other),
+                &"struct variant",
+            )),
+            None => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+        }
+    }
+}
+
+fn content_unexpected<'a>(content: &'a serde_json::Value) -> de::Unexpected<'a> {
+    match content {
+        serde_json::Value::Null => de::Unexpected::Unit,
+        serde_json::Value::Bool(b) => de::Unexpected::Bool(*b),
+        serde_json::Value::Number(_) => de::Unexpected::Other("number"),
+        serde_json::Value::String(s) => de::Unexpected::Str(s.as_str()),
+        serde_json::Value::Array(_) => de::Unexpected::Seq,
+        serde_json::Value::Object(_) => de::Unexpected::Map,
+    }
+}

--- a/crates/claims/crates/data-integrity/core/src/proof/de/utils/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/utils/mod.rs
@@ -1,0 +1,5 @@
+mod flat_map;
+mod replay_map;
+
+pub use flat_map::FlatMapDeserializer;
+pub use replay_map::ReplayMap;

--- a/crates/claims/crates/data-integrity/core/src/proof/de/utils/replay_map.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/utils/replay_map.rs
@@ -1,20 +1,13 @@
-pub struct ReplayMap<'de, M> {
-    past: std::vec::IntoIter<(
-        serde::__private::de::Content<'de>,
-        serde::__private::de::Content<'de>,
-    )>,
-    past_value: Option<serde::__private::de::Content<'de>>,
+use serde::de::value::StringDeserializer;
+
+pub struct ReplayMap<M> {
+    past: std::vec::IntoIter<(String, serde_json::Value)>,
+    past_value: Option<serde_json::Value>,
     future: M,
 }
 
-impl<'de, M> ReplayMap<'de, M> {
-    pub fn new(
-        past: Vec<(
-            serde::__private::de::Content<'de>,
-            serde::__private::de::Content<'de>,
-        )>,
-        future: M,
-    ) -> Self {
+impl<M> ReplayMap<M> {
+    pub fn new(past: Vec<(String, serde_json::Value)>, future: M) -> Self {
         Self {
             past: past.into_iter(),
             past_value: None,
@@ -23,7 +16,7 @@ impl<'de, M> ReplayMap<'de, M> {
     }
 }
 
-impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<'de, M> {
+impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<M> {
     type Error = M::Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -33,8 +26,7 @@ impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<
         match self.past.next() {
             Some((key, value)) => {
                 self.past_value = Some(value);
-                seed.deserialize(serde::__private::de::ContentDeserializer::new(key))
-                    .map(Some)
+                seed.deserialize(StringDeserializer::new(key)).map(Some)
             }
             None => self.future.next_key_seed(seed),
         }
@@ -45,7 +37,9 @@ impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<
         V: serde::de::DeserializeSeed<'de>,
     {
         match self.past_value.take() {
-            Some(value) => seed.deserialize(serde::__private::de::ContentDeserializer::new(value)),
+            Some(value) => seed
+                .deserialize(value)
+                .map_err(|e| serde::de::Error::custom(e)),
             None => self.future.next_value_seed(seed),
         }
     }

--- a/crates/claims/crates/data-integrity/core/src/proof/de/utils/replay_map.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/de/utils/replay_map.rs
@@ -37,9 +37,7 @@ impl<'de, M: serde::de::MapAccess<'de>> serde::de::MapAccess<'de> for ReplayMap<
         V: serde::de::DeserializeSeed<'de>,
     {
         match self.past_value.take() {
-            Some(value) => seed
-                .deserialize(value)
-                .map_err(|e| serde::de::Error::custom(e)),
+            Some(value) => seed.deserialize(value).map_err(serde::de::Error::custom),
             None => self.future.next_value_seed(seed),
         }
     }

--- a/crates/claims/crates/data-integrity/core/src/proof/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/mod.rs
@@ -140,7 +140,7 @@ impl<T: CryptographicSuite> Proof<T> {
         }
     }
 
-    pub fn borrowed(&self) -> ProofRef<T> {
+    pub fn borrowed(&'_ self) -> ProofRef<'_, T> {
         ProofRef {
             context: self.context.as_ref(),
             type_: &self.type_,
@@ -168,7 +168,7 @@ impl<T: CryptographicSuite> Proof<T> {
         &self.type_
     }
 
-    pub fn configuration(&self) -> ProofConfigurationRef<T> {
+    pub fn configuration(&'_ self) -> ProofConfigurationRef<'_, T> {
         ProofConfigurationRef {
             context: self.context.as_ref(),
             type_: &self.type_,
@@ -300,11 +300,11 @@ impl<S: CryptographicSuite> Proofs<S> {
         &mut self.0
     }
 
-    pub fn iter(&self) -> std::slice::Iter<Proof<S>> {
+    pub fn iter(&'_ self) -> std::slice::Iter<'_, Proof<S>> {
         self.0.iter()
     }
 
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<Proof<S>> {
+    pub fn iter_mut(&'_ mut self) -> std::slice::IterMut<'_, Proof<S>> {
         self.0.iter_mut()
     }
 }

--- a/crates/claims/crates/data-integrity/core/src/proof/type.rs
+++ b/crates/claims/crates/data-integrity/core/src/proof/type.rs
@@ -39,7 +39,7 @@ impl Type {
         }
     }
 
-    pub fn as_ref(&self) -> TypeRef {
+    pub fn as_ref(&'_ self) -> TypeRef<'_> {
         match self {
             Self::DataIntegrityProof(c) => TypeRef::DataIntegrityProof(c),
             Self::Other(t) => TypeRef::Other(t),
@@ -354,10 +354,10 @@ where
     V: IriVocabularyMut,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         _interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         use linked_data::{rdf_types::Term, CowRdfTerm, ResourceInterpretation};
         ResourceInterpretation::Uninterpreted(Some(CowRdfTerm::Owned(Term::Literal(
             RdfLiteral::Any(

--- a/crates/claims/crates/data-integrity/core/src/signing/jws.rs
+++ b/crates/claims/crates/data-integrity/core/src/signing/jws.rs
@@ -220,5 +220,5 @@ where
 }
 
 pub trait RecoverPublicJwk {
-    fn public_jwk(&self) -> Cow<JWK>;
+    fn public_jwk(&'_ self) -> Cow<'_, JWK>;
 }

--- a/crates/claims/crates/data-integrity/core/src/suite/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/suite/mod.rs
@@ -58,7 +58,7 @@ pub trait CryptographicSuite: Clone {
     type Signature: AsRef<str>;
 
     /// Returns the cryptographic suite type.
-    fn type_(&self) -> TypeRef;
+    fn type_(&'_ self) -> TypeRef<'_>;
 
     /// Generates a proof configuration from input options.
     fn configure_signature(

--- a/crates/claims/crates/data-integrity/core/src/suite/standard/mod.rs
+++ b/crates/claims/crates/data-integrity/core/src/suite/standard/mod.rs
@@ -53,7 +53,7 @@ pub trait StandardCryptographicSuite: Clone {
     type ProofOptions;
 
     /// Returns the cryptographic suite type.
-    fn type_(&self) -> TypeRef;
+    fn type_(&'_ self) -> TypeRef<'_>;
 
     #[allow(async_fn_in_trait)]
     async fn transform<T, C>(
@@ -112,7 +112,7 @@ impl<S: StandardCryptographicSuite> CryptographicSuite for S {
     type Signature = <S::SignatureAlgorithm as SignatureAndVerificationAlgorithm>::Signature;
 
     /// Returns the cryptographic suite type.
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         StandardCryptographicSuite::type_(self)
     }
 }

--- a/crates/claims/crates/data-integrity/src/any/macros.rs
+++ b/crates/claims/crates/data-integrity/src/any/macros.rs
@@ -35,7 +35,7 @@ macro_rules! crypto_suites {
 
             type ProofOptions = AnyProofOptions;
 
-            fn type_(&self) -> ssi_data_integrity_core::TypeRef {
+            fn type_(&'_ self) -> ssi_data_integrity_core::TypeRef<'_> {
                 match self {
                     $(
                         $(#[cfg($($t)*)])?

--- a/crates/claims/crates/data-integrity/src/any/resolution.rs
+++ b/crates/claims/crates/data-integrity/src/any/resolution.rs
@@ -22,11 +22,11 @@ where
     type Method = M;
 
     async fn resolve_verification_method_with(
-        &self,
+        &'_ self,
         issuer: Option<&iref::Iri>,
         method: Option<ssi_verification_methods::ReferenceOrOwnedRef<'_, Self::Method>>,
         options: ssi_verification_methods::ResolutionOptions,
-    ) -> Result<Cow<Self::Method>, ssi_verification_methods::VerificationMethodResolutionError>
+    ) -> Result<Cow<'_, Self::Method>, ssi_verification_methods::VerificationMethodResolutionError>
     {
         let method = method.map(|m| match m {
             ssi_verification_methods::ReferenceOrOwnedRef::Reference(uri) => {

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_rdfc_2019.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_rdfc_2019.rs
@@ -44,7 +44,7 @@ impl StandardCryptographicSuite for EcdsaRdfc2019 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::DataIntegrityProof(CryptosuiteStr::new("ecdsa-rdfc-2019").unwrap())
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_sd_2023/mod.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_sd_2023/mod.rs
@@ -45,7 +45,7 @@ impl StandardCryptographicSuite for EcdsaSd2023 {
 
     type SignatureAlgorithm = SignatureAlgorithm;
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::DataIntegrityProof(CryptosuiteStr::new("ecdsa-sd-2023").unwrap())
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_secp256k1_signature_2019.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_secp256k1_signature_2019.rs
@@ -36,7 +36,7 @@ impl StandardCryptographicSuite for EcdsaSecp256k1Signature2019 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::Other(Self::NAME)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_secp256r1_signature_2019.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ecdsa_secp256r1_signature_2019.rs
@@ -36,7 +36,7 @@ impl StandardCryptographicSuite for EcdsaSecp256r1Signature2019 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::Other(Self::NAME)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2018.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2018.rs
@@ -35,7 +35,7 @@ impl StandardCryptographicSuite for Ed25519Signature2018 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::Other(Self::NAME)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2020.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ed25519_signature_2020.rs
@@ -62,7 +62,7 @@ impl StandardCryptographicSuite for Ed25519Signature2020 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::Other(Self::NAME)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/eddsa_2022.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/eddsa_2022.rs
@@ -39,7 +39,7 @@ impl StandardCryptographicSuite for EdDsa2022 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::DataIntegrityProof(CryptosuiteStr::new("eddsa-2022").unwrap())
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/eddsa_rdfc_2022.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/eddsa_rdfc_2022.rs
@@ -35,7 +35,7 @@ impl StandardCryptographicSuite for EdDsaRdfc2022 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::DataIntegrityProof(CryptosuiteStr::new("eddsa-rdfc-2022").unwrap())
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ethereum_eip712_signature_2021.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ethereum_eip712_signature_2021.rs
@@ -111,7 +111,7 @@ impl StandardCryptographicSuite for EthereumEip712Signature2021 {
 
     type ProofOptions = Options;
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::Other(Self::NAME)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/ethereum_eip712_signature_2021/v0_1.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/ethereum_eip712_signature_2021/v0_1.rs
@@ -131,7 +131,7 @@ impl StandardCryptographicSuite for EthereumEip712Signature2021v0_1 {
 
     type ProofOptions = Options;
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::Other(Self::NAME)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/json_web_signature_2020.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/json_web_signature_2020.rs
@@ -53,7 +53,7 @@ impl StandardCryptographicSuite for JsonWebSignature2020 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::Other(Self::NAME)
     }
 }

--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/rsa_signature_2018.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/rsa_signature_2018.rs
@@ -40,7 +40,7 @@ impl StandardCryptographicSuite for RsaSignature2018 {
 
     type ProofOptions = ();
 
-    fn type_(&self) -> TypeRef {
+    fn type_(&'_ self) -> TypeRef<'_> {
         TypeRef::Other(Self::NAME)
     }
 }

--- a/crates/claims/crates/jws/src/compact/bytes.rs
+++ b/crates/claims/crates/jws/src/compact/bytes.rs
@@ -155,7 +155,7 @@ impl JwsSlice {
     /// Decode the payload bytes.
     ///
     /// The header is necessary to know how the payload is encoded.
-    pub fn decode_payload(&self, header: &Header) -> Result<Cow<[u8]>, Base64DecodeError> {
+    pub fn decode_payload(&'_ self, header: &Header) -> Result<Cow<'_, [u8]>, Base64DecodeError> {
         if header.base64urlencode_payload.unwrap_or(true) {
             Ok(Cow::Owned(
                 base64::prelude::BASE64_URL_SAFE_NO_PAD.decode(self.payload())?,
@@ -177,7 +177,7 @@ impl JwsSlice {
     }
 
     /// Decodes the entire JWS.
-    pub fn decode(&self) -> Result<DecodedJws<Cow<[u8]>>, DecodeError> {
+    pub fn decode(&'_ self) -> Result<DecodedJws<'_, Cow<'_, [u8]>>, DecodeError> {
         let header = self.decode_header().map_err(DecodeError::Header)?;
         let payload = self.decode_payload(&header).map_err(DecodeError::Payload)?;
         let signature = self.decode_signature().map_err(DecodeError::Signature)?;

--- a/crates/claims/crates/jws/src/signature.rs
+++ b/crates/claims/crates/jws/src/signature.rs
@@ -20,7 +20,7 @@ pub trait JwsPayload {
         None
     }
 
-    fn payload_bytes(&self) -> Cow<[u8]>;
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]>;
 
     /// Signs the payload and returns a compact JWS.
     #[allow(async_fn_in_trait)]
@@ -38,7 +38,7 @@ impl<P: ?Sized + JwsPayload> JwsPayload for &P {
         P::cty(*self)
     }
 
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         P::payload_bytes(*self)
     }
 
@@ -48,31 +48,31 @@ impl<P: ?Sized + JwsPayload> JwsPayload for &P {
 }
 
 impl JwsPayload for [u8] {
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self)
     }
 }
 
 impl JwsPayload for Vec<u8> {
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self)
     }
 }
 
 impl JwsPayload for str {
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self.as_bytes())
     }
 }
 
 impl JwsPayload for String {
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self.as_bytes())
     }
 }
 
 impl JwsPayload for serde_json::Value {
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_json::to_vec(self).unwrap())
     }
 }

--- a/crates/claims/crates/jwt/src/claims/any.rs
+++ b/crates/claims/crates/jwt/src/claims/any.rs
@@ -26,7 +26,7 @@ impl AnyClaims {
         self.0.remove(key)
     }
 
-    pub fn iter(&self) -> std::collections::btree_map::Iter<String, serde_json::Value> {
+    pub fn iter(&'_ self) -> std::collections::btree_map::Iter<'_, String, serde_json::Value> {
         self.0.iter()
     }
 }
@@ -60,7 +60,7 @@ impl ClaimSet for AnyClaims {
         self.contains(C::JWT_CLAIM_NAME)
     }
 
-    fn try_get<C: Claim>(&self) -> Result<Option<Cow<C>>, InvalidClaimValue> {
+    fn try_get<C: Claim>(&'_ self) -> Result<Option<Cow<'_, C>>, InvalidClaimValue> {
         self.get(C::JWT_CLAIM_NAME)
             .cloned()
             .map(serde_json::from_value)

--- a/crates/claims/crates/jwt/src/claims/mixed/mod.rs
+++ b/crates/claims/crates/jwt/src/claims/mixed/mod.rs
@@ -50,7 +50,7 @@ impl<T: ClaimSet> ClaimSet for JWTClaims<T> {
         ClaimSet::contains::<C>(&self.registered) || self.private.contains::<C>()
     }
 
-    fn try_get<C: Claim>(&self) -> Result<Option<Cow<C>>, InvalidClaimValue> {
+    fn try_get<C: Claim>(&'_ self) -> Result<Option<Cow<'_, C>>, InvalidClaimValue> {
         match InfallibleClaimSet::get(&self.registered) {
             Some(claim) => Ok(Some(claim)),
             None => self.private.try_get(),
@@ -77,7 +77,7 @@ impl<T: Serialize> JwsPayload for JWTClaims<T> {
         Some("JWT")
     }
 
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_json::to_vec(self).unwrap())
     }
 }

--- a/crates/claims/crates/jwt/src/claims/mod.rs
+++ b/crates/claims/crates/jwt/src/claims/mod.rs
@@ -39,7 +39,7 @@ pub trait ClaimSet {
         false
     }
 
-    fn try_get<C: Claim>(&self) -> Result<Option<Cow<C>>, InvalidClaimValue> {
+    fn try_get<C: Claim>(&'_ self) -> Result<Option<Cow<'_, C>>, InvalidClaimValue> {
         Ok(None)
     }
 
@@ -87,7 +87,7 @@ pub trait ClaimSet {
 
 /// Set of JWT claims.
 pub trait InfallibleClaimSet: ClaimSet {
-    fn get<C: Claim>(&self) -> Option<Cow<C>> {
+    fn get<C: Claim>(&'_ self) -> Option<Cow<'_, C>> {
         Self::try_get(self).unwrap()
     }
 

--- a/crates/claims/crates/jwt/src/claims/registered.rs
+++ b/crates/claims/crates/jwt/src/claims/registered.rs
@@ -31,7 +31,7 @@ impl RegisteredClaims {
         self.0.len()
     }
 
-    pub fn iter(&self) -> RegisteredClaimsIter {
+    pub fn iter(&'_ self) -> RegisteredClaimsIter<'_> {
         self.0.values()
     }
 
@@ -82,7 +82,7 @@ impl JwsPayload for RegisteredClaims {
         Some("JWT")
     }
 
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_json::to_vec(self).unwrap())
     }
 }
@@ -222,7 +222,7 @@ macro_rules! registered_claims {
                 false
             }
 
-            fn try_get<C: Claim>(&self) -> Result<Option<Cow<C>>, InvalidClaimValue> {
+            fn try_get<C: Claim>(&'_ self) -> Result<Option<Cow<'_, C>>, InvalidClaimValue> {
                 $(
                     if std::any::TypeId::of::<C>() == std::any::TypeId::of::<$variant>() {
                         return Ok(unsafe { CastClaim::cast_claim(self.get::<$variant>()) }.map(Cow::Borrowed));

--- a/crates/claims/crates/jwt/src/decoding.rs
+++ b/crates/claims/crates/jwt/src/decoding.rs
@@ -28,10 +28,12 @@ pub type DecodedJwt<'a, T = AnyClaims> = DecodedJws<'a, JWTClaims<T>>;
 /// JWT borrowing decoding.
 pub trait ToDecodedJwt {
     /// Decodes a JWT with custom claims.
-    fn to_decoded_custom_jwt<C: DeserializeOwned>(&self) -> Result<DecodedJwt<C>, DecodeError>;
+    fn to_decoded_custom_jwt<C: DeserializeOwned>(
+        &'_ self,
+    ) -> Result<DecodedJwt<'_, C>, DecodeError>;
 
     /// Decodes a JWT.
-    fn to_decoded_jwt(&self) -> Result<DecodedJwt, DecodeError> {
+    fn to_decoded_jwt(&'_ self) -> Result<DecodedJwt<'_>, DecodeError> {
         self.to_decoded_custom_jwt::<AnyClaims>()
     }
 
@@ -61,20 +63,26 @@ pub trait IntoDecodedJwt: Sized {
 }
 
 impl ToDecodedJwt for JwsSlice {
-    fn to_decoded_custom_jwt<C: DeserializeOwned>(&self) -> Result<DecodedJwt<C>, DecodeError> {
+    fn to_decoded_custom_jwt<C: DeserializeOwned>(
+        &'_ self,
+    ) -> Result<DecodedJwt<'_, C>, DecodeError> {
         self.decode()?
             .try_map(|bytes| serde_json::from_slice(&bytes).map_err(Into::into))
     }
 }
 
 impl ToDecodedJwt for JwsStr {
-    fn to_decoded_custom_jwt<C: DeserializeOwned>(&self) -> Result<DecodedJwt<C>, DecodeError> {
+    fn to_decoded_custom_jwt<C: DeserializeOwned>(
+        &'_ self,
+    ) -> Result<DecodedJwt<'_, C>, DecodeError> {
         JwsSlice::to_decoded_custom_jwt(self)
     }
 }
 
 impl ToDecodedJwt for JwsVec {
-    fn to_decoded_custom_jwt<C: DeserializeOwned>(&self) -> Result<DecodedJwt<C>, DecodeError> {
+    fn to_decoded_custom_jwt<C: DeserializeOwned>(
+        &'_ self,
+    ) -> Result<DecodedJwt<'_, C>, DecodeError> {
         JwsSlice::to_decoded_custom_jwt(self)
     }
 }
@@ -89,7 +97,9 @@ impl IntoDecodedJwt for JwsVec {
 }
 
 impl ToDecodedJwt for JwsString {
-    fn to_decoded_custom_jwt<C: DeserializeOwned>(&self) -> Result<DecodedJwt<C>, DecodeError> {
+    fn to_decoded_custom_jwt<C: DeserializeOwned>(
+        &'_ self,
+    ) -> Result<DecodedJwt<'_, C>, DecodeError> {
         JwsSlice::to_decoded_custom_jwt(self)
     }
 }

--- a/crates/claims/crates/sd-jwt/src/decode.rs
+++ b/crates/claims/crates/sd-jwt/src/decode.rs
@@ -91,7 +91,7 @@ impl<'a> PartsRef<'a> {
 
 impl Disclosure {
     /// Decode this disclosure.
-    pub fn decode(&self) -> Result<DecodedDisclosure, DecodeError> {
+    pub fn decode(&'_ self) -> Result<DecodedDisclosure<'_>, DecodeError> {
         DecodedDisclosure::new(self)
     }
 }

--- a/crates/claims/crates/sd-jwt/src/lib.rs
+++ b/crates/claims/crates/sd-jwt/src/lib.rs
@@ -226,7 +226,7 @@ impl SdJwt {
     }
 
     /// Returns an iterator over the disclosures of the SD-JWT.
-    pub fn disclosures(&self) -> Disclosures {
+    pub fn disclosures(&'_ self) -> Disclosures<'_> {
         Disclosures {
             bytes: &self.0,
             offset: self.jwt_end() + 1,
@@ -234,7 +234,7 @@ impl SdJwt {
     }
 
     /// Returns references to each part of this SD-JWT.
-    pub fn parts(&self) -> PartsRef {
+    pub fn parts(&'_ self) -> PartsRef<'_> {
         PartsRef {
             jwt: self.jwt(),
             disclosures: self.disclosures().collect(),
@@ -242,25 +242,27 @@ impl SdJwt {
     }
 
     /// Decode a compact SD-JWT.
-    pub fn decode(&self) -> Result<DecodedSdJwt, DecodeError> {
+    pub fn decode(&'_ self) -> Result<DecodedSdJwt<'_>, DecodeError> {
         self.parts().decode()
     }
 
     /// Decodes and reveals the SD-JWT.
-    pub fn decode_reveal<T: DeserializeOwned>(&self) -> Result<RevealedSdJwt<T>, RevealError> {
+    pub fn decode_reveal<T: DeserializeOwned>(
+        &'_ self,
+    ) -> Result<RevealedSdJwt<'_, T>, RevealError> {
         self.parts().decode_reveal()
     }
 
     /// Decodes and reveals the SD-JWT.
-    pub fn decode_reveal_any(&self) -> Result<RevealedSdJwt, RevealError> {
+    pub fn decode_reveal_any(&'_ self) -> Result<RevealedSdJwt<'_>, RevealError> {
         self.parts().decode_reveal_any()
     }
 
     /// Decode a compact SD-JWT.
     pub async fn decode_verify_concealed<P>(
-        &self,
+        &'_ self,
         params: P,
-    ) -> Result<(DecodedSdJwt, Verification), ProofValidationError>
+    ) -> Result<(DecodedSdJwt<'_>, Verification), ProofValidationError>
     where
         P: ResolverProvider<Resolver: JWKResolver>,
     {
@@ -276,9 +278,9 @@ impl SdJwt {
     ///
     /// Returns the decoded JWT with the verification status.
     pub async fn decode_reveal_verify_any<P>(
-        &self,
+        &'_ self,
         params: P,
-    ) -> Result<(RevealedSdJwt, Verification), ProofValidationError>
+    ) -> Result<(RevealedSdJwt<'_>, Verification), ProofValidationError>
     where
         P: ResolverProvider<Resolver: JWKResolver> + DateTimeProvider,
     {
@@ -294,9 +296,9 @@ impl SdJwt {
     ///
     /// Returns the decoded JWT with the verification status.
     pub async fn decode_reveal_verify<T, P>(
-        &self,
+        &'_ self,
         params: P,
-    ) -> Result<(RevealedSdJwt<T>, Verification), ProofValidationError>
+    ) -> Result<(RevealedSdJwt<'_, T>, Verification), ProofValidationError>
     where
         T: ClaimSet + DeserializeOwned + ValidateClaims<P, JwsSignature>,
         P: ResolverProvider<Resolver: JWKResolver> + DateTimeProvider,
@@ -629,7 +631,7 @@ pub struct SdJwtPayload {
 }
 
 impl JwsPayload for SdJwtPayload {
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_json::to_vec(self).unwrap())
     }
 }

--- a/crates/claims/crates/vc-jose-cose/src/cose/credential.rs
+++ b/crates/claims/crates/vc-jose-cose/src/cose/credential.rs
@@ -67,7 +67,7 @@ impl<T: Serialize> CosePayload for CoseVc<T> {
         Some(ssi_cose::ContentType::Text("application/vc".to_owned()))
     }
 
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_json::to_vec(&self.0).unwrap())
     }
 }
@@ -107,7 +107,7 @@ impl<T: Credential> Credential for CoseVc<T> {
         self.0.additional_types()
     }
 
-    fn types(&self) -> CredentialTypes {
+    fn types(&'_ self) -> CredentialTypes<'_> {
         self.0.types()
     }
 

--- a/crates/claims/crates/vc-jose-cose/src/cose/presentation.rs
+++ b/crates/claims/crates/vc-jose-cose/src/cose/presentation.rs
@@ -26,7 +26,7 @@ impl<T: Serialize> CosePayload for CoseVp<T> {
         Some(ssi_cose::ContentType::Text("application/vp".to_owned()))
     }
 
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_json::to_vec(&self.0).unwrap())
     }
 }
@@ -99,7 +99,7 @@ impl<T: Presentation> Presentation for CoseVp<T> {
         self.0.additional_types()
     }
 
-    fn types(&self) -> PresentationTypes {
+    fn types(&'_ self) -> PresentationTypes<'_> {
         self.0.types()
     }
 

--- a/crates/claims/crates/vc-jose-cose/src/jose/credential.rs
+++ b/crates/claims/crates/vc-jose-cose/src/jose/credential.rs
@@ -31,7 +31,7 @@ impl<T: Serialize> JoseVc<T> {
 
 impl<T: DeserializeOwned> JoseVc<T> {
     /// Decode a JOSE VC.
-    pub fn decode(jws: &JwsSlice) -> Result<DecodedJws<Self>, JoseDecodeError> {
+    pub fn decode(jws: &'_ JwsSlice) -> Result<DecodedJws<'_, Self>, JoseDecodeError> {
         jws.decode()?
             .try_map(|payload| serde_json::from_slice(&payload).map(Self))
             .map_err(Into::into)
@@ -40,7 +40,7 @@ impl<T: DeserializeOwned> JoseVc<T> {
 
 impl JoseVc {
     /// Decode a JOSE VC with an arbitrary credential type.
-    pub fn decode_any(jws: &JwsSlice) -> Result<DecodedJws<Self>, JoseDecodeError> {
+    pub fn decode_any(jws: &'_ JwsSlice) -> Result<DecodedJws<'_, Self>, JoseDecodeError> {
         Self::decode(jws)
     }
 }
@@ -54,7 +54,7 @@ impl<T: Serialize> JwsPayload for JoseVc<T> {
         Some("vc")
     }
 
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_json::to_vec(&self.0).unwrap())
     }
 }
@@ -91,7 +91,7 @@ impl<T: Credential> Credential for JoseVc<T> {
         self.0.additional_types()
     }
 
-    fn types(&self) -> CredentialTypes {
+    fn types(&'_ self) -> CredentialTypes<'_> {
         self.0.types()
     }
 

--- a/crates/claims/crates/vc-jose-cose/src/jose/presentation.rs
+++ b/crates/claims/crates/vc-jose-cose/src/jose/presentation.rs
@@ -23,7 +23,7 @@ impl<T: Serialize> JwsPayload for JoseVp<T> {
         Some("vp")
     }
 
-    fn payload_bytes(&self) -> Cow<[u8]> {
+    fn payload_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_json::to_vec(&self.0).unwrap())
     }
 }
@@ -52,7 +52,7 @@ impl<T: Serialize> JoseVp<T> {
 
 impl<T: DeserializeOwned> JoseVp<T> {
     /// Decode a JOSE VP.
-    pub fn decode(jws: &JwsSlice) -> Result<DecodedJws<Self>, JoseDecodeError> {
+    pub fn decode(jws: &'_ JwsSlice) -> Result<DecodedJws<'_, Self>, JoseDecodeError> {
         jws.decode()?
             .try_map(|payload| serde_json::from_slice(&payload).map(Self))
             .map_err(Into::into)
@@ -61,7 +61,7 @@ impl<T: DeserializeOwned> JoseVp<T> {
 
 impl JoseVp {
     /// Decode a JOSE VP with an arbitrary presentation type.
-    pub fn decode_any(jws: &JwsSlice) -> Result<DecodedJws<Self>, JoseDecodeError> {
+    pub fn decode_any(jws: &'_ JwsSlice) -> Result<DecodedJws<'_, Self>, JoseDecodeError> {
         Self::decode(jws)
     }
 }
@@ -84,7 +84,7 @@ impl<T: Presentation> Presentation for JoseVp<T> {
         self.0.additional_types()
     }
 
-    fn types(&self) -> PresentationTypes {
+    fn types(&'_ self) -> PresentationTypes<'_> {
         self.0.types()
     }
 

--- a/crates/claims/crates/vc-jose-cose/src/sd_jwt/credential.rs
+++ b/crates/claims/crates/vc-jose-cose/src/sd_jwt/credential.rs
@@ -116,7 +116,7 @@ impl<T: DeserializeOwned> SdJwtVc<T> {
     /// This function requires the `T` parameter, representing the credential
     /// type, to be known. If you don't know what `T` you should use, use the
     /// [`Self::decode_reveal_any`].
-    pub fn decode_reveal(sd_jwt: &SdJwt) -> Result<RevealedSdJwt<Self>, RevealError> {
+    pub fn decode_reveal(sd_jwt: &'_ SdJwt) -> Result<RevealedSdJwt<'_, Self>, RevealError> {
         sd_jwt.decode_reveal()
     }
 }
@@ -127,7 +127,7 @@ impl SdJwtVc {
     /// This function uses [`JsonCredential`] as credential type. If you need
     /// to use a custom credential type, use the [`Self::decode_reveal`]
     /// function.
-    pub fn decode_reveal_any(sd_jwt: &SdJwt) -> Result<RevealedSdJwt<Self>, RevealError> {
+    pub fn decode_reveal_any(sd_jwt: &'_ SdJwt) -> Result<RevealedSdJwt<'_, Self>, RevealError> {
         sd_jwt.decode_reveal()
     }
 }
@@ -156,7 +156,7 @@ impl<T: Credential> Credential for SdJwtVc<T> {
         self.0.additional_types()
     }
 
-    fn types(&self) -> CredentialTypes {
+    fn types(&'_ self) -> CredentialTypes<'_> {
         self.0.types()
     }
 

--- a/crates/claims/crates/vc-jose-cose/src/sd_jwt/presentation.rs
+++ b/crates/claims/crates/vc-jose-cose/src/sd_jwt/presentation.rs
@@ -113,7 +113,7 @@ impl<T: DeserializeOwned> SdJwtVp<T> {
     /// This function requires the `T` parameter, representing the presentation
     /// type, to be known. If you don't know what `T` you should use, use the
     /// [`Self::decode_reveal_any`].
-    pub fn decode_reveal(sd_jwt: &SdJwt) -> Result<RevealedSdJwt<Self>, RevealError> {
+    pub fn decode_reveal(sd_jwt: &'_ SdJwt) -> Result<RevealedSdJwt<'_, Self>, RevealError> {
         sd_jwt.decode_reveal()
     }
 }
@@ -124,7 +124,7 @@ impl SdJwtVp {
     /// This function uses [`JsonPresentation<EnvelopedVerifiableCredential>`]
     /// as presentation type. If you need to use a custom presentation type, use
     /// the [`Self::decode_reveal`] function.
-    pub fn decode_reveal_any(sd_jwt: &SdJwt) -> Result<RevealedSdJwt<Self>, RevealError> {
+    pub fn decode_reveal_any(sd_jwt: &'_ SdJwt) -> Result<RevealedSdJwt<'_, Self>, RevealError> {
         sd_jwt.decode_reveal()
     }
 }
@@ -147,7 +147,7 @@ impl<T: Presentation> Presentation for SdJwtVp<T> {
         self.0.additional_types()
     }
 
-    fn types(&self) -> PresentationTypes {
+    fn types(&'_ self) -> PresentationTypes<'_> {
         self.0.types()
     }
 

--- a/crates/claims/crates/vc/src/syntax/context.rs
+++ b/crates/claims/crates/vc/src/syntax/context.rs
@@ -61,7 +61,7 @@ impl<V, T> Context<V, T> {
     }
 
     /// Returns an iterator over the context entries.
-    pub fn iter(&self) -> std::slice::Iter<ContextEntry> {
+    pub fn iter(&'_ self) -> std::slice::Iter<'_, ContextEntry> {
         self.0.iter()
     }
 

--- a/crates/claims/crates/vc/src/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/syntax/credential.rs
@@ -35,7 +35,7 @@ pub enum AnySpecializedJsonCredential<S = json_syntax::Object, C = (), T = ()> {
 }
 
 impl<S, C, T> JsonLdObject for AnySpecializedJsonCredential<S, C, T> {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         match self {
             Self::V1(c) => c.json_ld_context(),
             Self::V2(c) => c.json_ld_context(),
@@ -44,7 +44,7 @@ impl<S, C, T> JsonLdObject for AnySpecializedJsonCredential<S, C, T> {
 }
 
 impl<S, C, T> JsonLdNodeObject for AnySpecializedJsonCredential<S, C, T> {
-    fn json_ld_type(&self) -> JsonLdTypes {
+    fn json_ld_type(&'_ self) -> JsonLdTypes<'_> {
         match self {
             Self::V1(c) => c.json_ld_type(),
             Self::V2(c) => c.json_ld_type(),

--- a/crates/claims/crates/vc/src/syntax/non_empty_object.rs
+++ b/crates/claims/crates/vc/src/syntax/non_empty_object.rs
@@ -30,14 +30,14 @@ impl NonEmptyObject {
         self.0
     }
 
-    pub fn iter_mut(&mut self) -> IterMut {
+    pub fn iter_mut(&'_ mut self) -> IterMut<'_> {
         self.0.iter_mut()
     }
 
     /// Returns an iterator over the values matching the given key.
     ///
     /// Runs in `O(1)` (average).
-    pub fn get_mut<Q>(&mut self, key: &Q) -> ValuesMut
+    pub fn get_mut<Q>(&'_ mut self, key: &Q) -> ValuesMut<'_>
     where
         Q: ?Sized + Hash + Equivalent<Key>,
     {
@@ -114,7 +114,7 @@ impl NonEmptyObject {
     /// If one or more entries are already matching the given key,
     /// all of them are removed and returned in the resulting iterator.
     /// Otherwise, `None` is returned.
-    pub fn insert(&mut self, key: Key, value: Value) -> Option<RemovedByInsertion> {
+    pub fn insert(&'_ mut self, key: Key, value: Value) -> Option<RemovedByInsertion<'_>> {
         self.0.insert(key, value)
     }
 
@@ -122,7 +122,7 @@ impl NonEmptyObject {
     ///
     /// If one or more entries are already matching the given key,
     /// all of them are removed and returned in the resulting iterator.
-    pub fn insert_front(&mut self, key: Key, value: Value) -> RemovedByInsertFront {
+    pub fn insert_front(&'_ mut self, key: Key, value: Value) -> RemovedByInsertFront<'_> {
         self.0.insert_front(key, value)
     }
 

--- a/crates/claims/crates/vc/src/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/syntax/presentation.rs
@@ -17,7 +17,7 @@ pub enum AnyJsonPresentation<C1 = v1::syntax::JsonCredential, C2 = v2::syntax::J
 }
 
 impl<C1, C2> JsonLdObject for AnyJsonPresentation<C1, C2> {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         match self {
             Self::V1(p) => p.json_ld_context(),
             Self::V2(p) => p.json_ld_context(),
@@ -26,7 +26,7 @@ impl<C1, C2> JsonLdObject for AnyJsonPresentation<C1, C2> {
 }
 
 impl<C1, C2> JsonLdNodeObject for AnyJsonPresentation<C1, C2> {
-    fn json_ld_type(&self) -> JsonLdTypes {
+    fn json_ld_type(&'_ self) -> JsonLdTypes<'_> {
         match self {
             Self::V1(p) => p.json_ld_type(),
             Self::V2(p) => p.json_ld_type(),

--- a/crates/claims/crates/vc/src/syntax/types.rs
+++ b/crates/claims/crates/vc/src/syntax/types.rs
@@ -52,7 +52,7 @@ impl<B, T> Types<B, T> {
 }
 
 impl<B: RequiredType, T> Types<B, T> {
-    pub fn to_json_ld_types(&self) -> JsonLdTypes {
+    pub fn to_json_ld_types(&'_ self) -> JsonLdTypes<'_> {
         JsonLdTypes::new(&[B::REQUIRED_TYPE], Cow::Borrowed(&self.0))
     }
 }

--- a/crates/claims/crates/vc/src/v1/data_model/credential.rs
+++ b/crates/claims/crates/vc/src/v1/data_model/credential.rs
@@ -58,7 +58,7 @@ pub trait Credential {
         &[]
     }
 
-    fn types(&self) -> CredentialTypes {
+    fn types(&'_ self) -> CredentialTypes<'_> {
         CredentialTypes::from_additional_types(self.additional_types())
     }
 

--- a/crates/claims/crates/vc/src/v1/data_model/presentation.rs
+++ b/crates/claims/crates/vc/src/v1/data_model/presentation.rs
@@ -20,7 +20,7 @@ pub trait Presentation {
         &[]
     }
 
-    fn types(&self) -> PresentationTypes {
+    fn types(&'_ self) -> PresentationTypes<'_> {
         PresentationTypes {
             base_type: true,
             additional_types: self.additional_types().iter(),

--- a/crates/claims/crates/vc/src/v1/revocation/mod.rs
+++ b/crates/claims/crates/vc/src/v1/revocation/mod.rs
@@ -85,8 +85,8 @@ pub enum ListIterDecodeError {
 impl List {
     /// Get an array of indices in the revocation list for credentials that are revoked.
     pub fn iter_revoked_indexes(
-        &self,
-    ) -> Result<bitvec::slice::IterOnes<Lsb0, u8>, ListIterDecodeError> {
+        &'_ self,
+    ) -> Result<bitvec::slice::IterOnes<'_, Lsb0, u8>, ListIterDecodeError> {
         let bitstring = BitSlice::<Lsb0, u8>::from_slice(&self.0[..])?;
         if bitstring.len() < MIN_BITSTRING_LENGTH {
             return Err(ListIterDecodeError::ListTooSmall(
@@ -133,7 +133,7 @@ impl EncodedList {
     ///
     /// Given length must be a multiple of 8.
     pub fn new(bit_len: usize) -> Result<Self, NewEncodedListError> {
-        if bit_len % 8 != 0 {
+        if !bit_len.is_multiple_of(8) {
             return Err(NewEncodedListError::LengthMultiple8(bit_len));
         }
         let byte_len = bit_len / 8;

--- a/crates/claims/crates/vc/src/v1/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/credential.rs
@@ -222,7 +222,7 @@ impl<
         ExtraProperties,
     >
 {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
@@ -252,7 +252,7 @@ impl<
         ExtraProperties,
     >
 {
-    fn json_ld_type(&self) -> JsonLdTypes {
+    fn json_ld_type(&'_ self) -> JsonLdTypes<'_> {
         self.types.to_json_ld_types()
     }
 }

--- a/crates/claims/crates/vc/src/v1/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/v1/syntax/presentation.rs
@@ -94,13 +94,13 @@ impl<C> JsonPresentation<C> {
 }
 
 impl<C> JsonLdObject for JsonPresentation<C> {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
 
 impl<C> JsonLdNodeObject for JsonPresentation<C> {
-    fn json_ld_type(&self) -> JsonLdTypes {
+    fn json_ld_type(&'_ self) -> JsonLdTypes<'_> {
         self.types.to_json_ld_types()
     }
 }

--- a/crates/claims/crates/vc/src/v2/data_model/credential.rs
+++ b/crates/claims/crates/vc/src/v2/data_model/credential.rs
@@ -58,7 +58,7 @@ pub trait Credential: MaybeIdentified {
         &[]
     }
 
-    fn types(&self) -> CredentialTypes {
+    fn types(&'_ self) -> CredentialTypes<'_> {
         CredentialTypes::from_additional_types(self.additional_types())
     }
 

--- a/crates/claims/crates/vc/src/v2/data_model/language.rs
+++ b/crates/claims/crates/vc/src/v2/data_model/language.rs
@@ -17,25 +17,25 @@ impl<'a> From<&'a LangString> for LanguageValueRef<'a> {
 }
 
 pub trait AnyInternationalString {
-    fn default_value(&self) -> Option<LanguageValueRef>;
+    fn default_value(&'_ self) -> Option<LanguageValueRef<'_>>;
 
-    fn get_language(&self, _lang: &LangTag) -> Option<LanguageValueRef> {
+    fn get_language(&'_ self, _lang: &LangTag) -> Option<LanguageValueRef<'_>> {
         None
     }
 
-    fn get_language_or_default(&self, lang: &LangTag) -> Option<LanguageValueRef> {
+    fn get_language_or_default(&'_ self, lang: &LangTag) -> Option<LanguageValueRef<'_>> {
         self.get_language(lang).or_else(|| self.default_value())
     }
 }
 
 impl<T: ?Sized + AnyInternationalString> AnyInternationalString for &T {
-    fn default_value(&self) -> Option<LanguageValueRef> {
+    fn default_value(&'_ self) -> Option<LanguageValueRef<'_>> {
         T::default_value(*self)
     }
 }
 
 impl AnyInternationalString for str {
-    fn default_value(&self) -> Option<LanguageValueRef> {
+    fn default_value(&'_ self) -> Option<LanguageValueRef<'_>> {
         Some(LanguageValueRef {
             value: self,
             language: None,
@@ -45,13 +45,13 @@ impl AnyInternationalString for str {
 }
 
 impl AnyInternationalString for String {
-    fn default_value(&self) -> Option<LanguageValueRef> {
+    fn default_value(&'_ self) -> Option<LanguageValueRef<'_>> {
         self.as_str().default_value()
     }
 }
 
 impl AnyInternationalString for LangString {
-    fn default_value(&self) -> Option<LanguageValueRef> {
+    fn default_value(&'_ self) -> Option<LanguageValueRef<'_>> {
         Some(LanguageValueRef::from(self))
     }
 }

--- a/crates/claims/crates/vc/src/v2/data_model/presentation.rs
+++ b/crates/claims/crates/vc/src/v2/data_model/presentation.rs
@@ -23,7 +23,7 @@ pub trait Presentation: MaybeIdentified {
         &[]
     }
 
-    fn types(&self) -> PresentationTypes {
+    fn types(&'_ self) -> PresentationTypes<'_> {
         PresentationTypes::from_additional_types(self.additional_types())
     }
 

--- a/crates/claims/crates/vc/src/v2/syntax/credential.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/credential.rs
@@ -217,7 +217,7 @@ impl<
         ExtraProperties,
     >
 {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
@@ -247,7 +247,7 @@ impl<
         ExtraProperties,
     >
 {
-    fn json_ld_type(&self) -> JsonLdTypes {
+    fn json_ld_type(&'_ self) -> JsonLdTypes<'_> {
         self.types.to_json_ld_types()
     }
 }

--- a/crates/claims/crates/vc/src/v2/syntax/language.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/language.rs
@@ -13,7 +13,7 @@ pub enum InternationalString {
 }
 
 impl data_model::AnyInternationalString for InternationalString {
-    fn default_value(&self) -> Option<data_model::LanguageValueRef> {
+    fn default_value(&'_ self) -> Option<data_model::LanguageValueRef<'_>> {
         match self {
             Self::String(s) => s.default_value(),
             Self::LanguageValue(v) => v.default_value(),
@@ -22,9 +22,9 @@ impl data_model::AnyInternationalString for InternationalString {
     }
 
     fn get_language(
-        &self,
+        &'_ self,
         lang: &ssi_json_ld::syntax::LangTag,
-    ) -> Option<data_model::LanguageValueRef> {
+    ) -> Option<data_model::LanguageValueRef<'_>> {
         match self {
             Self::String(_) => None,
             Self::LanguageValue(v) => {

--- a/crates/claims/crates/vc/src/v2/syntax/presentation.rs
+++ b/crates/claims/crates/vc/src/v2/syntax/presentation.rs
@@ -91,13 +91,13 @@ impl<C> JsonPresentation<C> {
 }
 
 impl<C> JsonLdObject for JsonPresentation<C> {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
 
 impl<C> JsonLdNodeObject for JsonPresentation<C> {
-    fn json_ld_type(&self) -> JsonLdTypes {
+    fn json_ld_type(&'_ self) -> JsonLdTypes<'_> {
         self.types.to_json_ld_types()
     }
 }

--- a/crates/claims/src/lib.rs
+++ b/crates/claims/src/lib.rs
@@ -59,7 +59,7 @@ pub use ssi_data_integrity as data_integrity;
 #[educe(Debug(bound("S: DebugCryptographicSuite")))]
 pub enum JsonCredentialOrJws<S: CryptographicSuite = data_integrity::AnySuite> {
     /// JSON-like verifiable credential.
-    Credential(DataIntegrity<vc::AnyJsonCredential, S>),
+    Credential(Box<DataIntegrity<vc::AnyJsonCredential, S>>),
 
     /// JSON Web Signature.
     Jws(jws::JwsString),
@@ -78,7 +78,7 @@ pub enum JsonCredentialOrJws<S: CryptographicSuite = data_integrity::AnySuite> {
 #[educe(Debug(bound("S: DebugCryptographicSuite")))]
 pub enum JsonPresentationOrJws<S: CryptographicSuite = data_integrity::AnySuite> {
     /// JSON-like verifiable presentation.
-    Presentation(DataIntegrity<vc::AnyJsonPresentation, S>),
+    Presentation(Box<DataIntegrity<vc::AnyJsonPresentation, S>>),
 
     /// JSON Web Signature.
     Jws(jws::JwsString),

--- a/crates/core/src/json_pointer.rs
+++ b/crates/core/src/json_pointer.rs
@@ -131,7 +131,7 @@ impl JsonPointer {
         })
     }
 
-    pub fn iter(&self) -> JsonPointerIter {
+    pub fn iter(&'_ self) -> JsonPointerIter<'_> {
         let mut tokens = self.0.split('/');
         tokens.next();
         JsonPointerIter(tokens)
@@ -322,7 +322,7 @@ impl ReferenceToken {
         &self.0
     }
 
-    pub fn to_decoded(&self) -> Cow<str> {
+    pub fn to_decoded(&'_ self) -> Cow<'_, str> {
         if self.is_escaped() {
             Cow::Owned(self.decode())
         } else {

--- a/crates/dids/core/src/did/url/reference.rs
+++ b/crates/dids/core/src/did/url/reference.rs
@@ -12,7 +12,7 @@ pub enum DIDURLReference<'a> {
 }
 
 impl DIDURLReference<'_> {
-    pub fn resolve(&self, base_id: &DID) -> Cow<DIDURL> {
+    pub fn resolve(&'_ self, base_id: &DID) -> Cow<'_, DIDURL> {
         match self {
             Self::Absolute(a) => Cow::Borrowed(a),
             Self::Relative(r) => Cow::Owned(r.resolve(base_id)),
@@ -28,14 +28,14 @@ pub enum DIDURLReferenceBuf {
 }
 
 impl DIDURLReferenceBuf {
-    pub fn as_did_reference(&self) -> DIDURLReference {
+    pub fn as_did_reference(&'_ self) -> DIDURLReference<'_> {
         match self {
             Self::Absolute(a) => DIDURLReference::Absolute(a),
             Self::Relative(r) => DIDURLReference::Relative(r),
         }
     }
 
-    pub fn resolve(&self, base_id: &DID) -> Cow<DIDURL> {
+    pub fn resolve(&'_ self, base_id: &DID) -> Cow<'_, DIDURL> {
         match self {
             Self::Absolute(a) => Cow::Borrowed(a.as_did_url()),
             Self::Relative(r) => Cow::Owned(r.resolve(base_id)),

--- a/crates/dids/core/src/document.rs
+++ b/crates/dids/core/src/document.rs
@@ -115,7 +115,7 @@ impl Document {
     /// Select an object in the DID document.
     ///
     /// See: <https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm-secondary>
-    pub fn find_resource(&self, id: &DIDURL) -> Option<ResourceRef> {
+    pub fn find_resource(&'_ self, id: &DIDURL) -> Option<ResourceRef<'_>> {
         if self.id == *id {
             Some(ResourceRef::Document(self))
         } else {
@@ -130,7 +130,7 @@ impl Document {
     /// See: <https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm-secondary>
     pub fn into_resource(self, id: &DIDURL) -> Option<Resource> {
         if self.id == *id {
-            Some(Resource::Document(self))
+            Some(Resource::Document(Box::new(self)))
         } else {
             self.verification_method
                 .extract_resource(&self.id, id)
@@ -278,7 +278,7 @@ impl VerificationRelationships {
 }
 
 impl FindResource for VerificationRelationships {
-    fn find_resource(&self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef> {
+    fn find_resource(&'_ self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef<'_>> {
         self.authentication
             .find_resource(base_did, id)
             .or_else(|| self.assertion_method.find_resource(base_did, id))

--- a/crates/dids/core/src/document/resource.rs
+++ b/crates/dids/core/src/document/resource.rs
@@ -9,7 +9,7 @@ use super::DIDVerificationMethod;
 #[serde(untagged)]
 pub enum Resource {
     /// DID document.
-    Document(Document),
+    Document(Box<Document>),
 
     /// Verification method.
     VerificationMethod(DIDVerificationMethod),

--- a/crates/dids/core/src/document/resource.rs
+++ b/crates/dids/core/src/document/resource.rs
@@ -59,17 +59,17 @@ impl<T: UsesResource> UsesResource for Vec<T> {
 
 /// Find a resource definition.
 pub trait FindResource {
-    fn find_resource(&self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef>;
+    fn find_resource(&'_ self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef<'_>>;
 }
 
 impl<T: FindResource> FindResource for Option<T> {
-    fn find_resource(&self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef> {
+    fn find_resource(&'_ self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef<'_>> {
         self.as_ref().and_then(|t| t.find_resource(base_did, id))
     }
 }
 
 impl<T: FindResource> FindResource for Vec<T> {
-    fn find_resource(&self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef> {
+    fn find_resource(&'_ self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef<'_>> {
         self.iter().find_map(|t| t.find_resource(base_did, id))
     }
 }

--- a/crates/dids/core/src/document/verification_method.rs
+++ b/crates/dids/core/src/document/verification_method.rs
@@ -22,7 +22,7 @@ pub enum ValueOrReference {
 }
 
 impl ValueOrReference {
-    pub fn id(&self) -> DIDURLReference {
+    pub fn id(&'_ self) -> DIDURLReference<'_> {
         match self {
             Self::Reference(r) => r.as_did_reference(),
             Self::Value(v) => DIDURLReference::Absolute(&v.id),
@@ -65,7 +65,7 @@ impl UsesResource for ValueOrReference {
 }
 
 impl FindResource for ValueOrReference {
-    fn find_resource(&self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef> {
+    fn find_resource(&'_ self, base_did: &DID, id: &DIDURL) -> Option<ResourceRef<'_>> {
         match self {
             Self::Reference(_) => None,
             Self::Value(m) => m.find_resource(base_did, id),
@@ -141,7 +141,7 @@ impl UsesResource for DIDVerificationMethod {
 }
 
 impl FindResource for DIDVerificationMethod {
-    fn find_resource(&self, _base_did: &DID, id: &DIDURL) -> Option<ResourceRef> {
+    fn find_resource(&'_ self, _base_did: &DID, id: &DIDURL) -> Option<ResourceRef<'_>> {
         if self.id == *id {
             Some(ResourceRef::VerificationMethod(self))
         } else {

--- a/crates/dids/core/src/method_resolver.rs
+++ b/crates/dids/core/src/method_resolver.rs
@@ -101,11 +101,11 @@ where
     type Method = M;
 
     async fn resolve_verification_method_with(
-        &self,
+        &'_ self,
         _issuer: Option<&iref::Iri>,
         method: Option<ReferenceOrOwnedRef<'_, M>>,
         options: ssi_verification_methods_core::ResolutionOptions,
-    ) -> Result<Cow<M>, VerificationMethodResolutionError> {
+    ) -> Result<Cow<'_, M>, VerificationMethodResolutionError> {
         let mut deref_options = self.options.clone();
 
         if let Some(set) = options.accept {
@@ -166,9 +166,9 @@ where
         + TryFrom<GenericVerificationMethod, Error = InvalidVerificationMethod>,
 {
     async fn fetch_public_jwk(
-        &self,
+        &'_ self,
         key_id: Option<&str>,
-    ) -> Result<Cow<JWK>, ProofValidationError> {
+    ) -> Result<Cow<'_, JWK>, ProofValidationError> {
         let vm = match key_id {
             Some(id) => match Iri::new(id) {
                 Ok(iri) => Some(ReferenceOrOwnedRef::Reference(iri)),

--- a/crates/dids/core/src/resolution/dereference.rs
+++ b/crates/dids/core/src/resolution/dereference.rs
@@ -94,7 +94,7 @@ impl DerefOutput<PrimaryContent> {
 pub enum PrimaryContent {
     Null,
     Url(IriBuf), // TODO must be an URL
-    Document(document::Represented),
+    Document(Box<document::Represented>),
 }
 
 impl From<IriBuf> for PrimaryContent {
@@ -132,7 +132,7 @@ impl From<PrimaryContent> for Content {
             PrimaryContent::Null => Self::Null,
             PrimaryContent::Url(url) => Self::Url(url),
             PrimaryContent::Document(doc) => {
-                Self::Resource(Resource::Document(doc.into_document()))
+                Self::Resource(Resource::Document(Box::new(doc.into_document())))
             }
         }
     }
@@ -187,7 +187,7 @@ pub(crate) async fn dereference_primary_resource<'a, R: ?Sized + DIDResolver>(
             if primary_did_url.path().is_empty() && primary_did_url.query().is_none() {
                 // 2.1
                 return Ok(DerefOutput::new(
-                    PrimaryContent::Document(resolution_output.document),
+                    PrimaryContent::Document(Box::new(resolution_output.document)),
                     document::Metadata::default(),
                     resolution_output.metadata,
                 ));

--- a/crates/dids/methods/tz/src/lib.rs
+++ b/crates/dids/methods/tz/src/lib.rs
@@ -544,7 +544,7 @@ impl DIDTz {
                                 .await
                                 .map_err(UpdateError::DereferenceFailed)?;
                             match deref.content {
-                                Content::Resource(Resource::Document(d)) => d,
+                                Content::Resource(Resource::Document(d)) => *d,
                                 _ => {
                                     // Dereferenced content not a DID document.
                                     return Err(UpdateError::NotADocument);

--- a/crates/dids/src/lib.rs
+++ b/crates/dids/src/lib.rs
@@ -256,8 +256,8 @@ impl AnyDidMethod {
     /// - `jwk` to generate a `did:jwk` DID,
     /// - `ethr` to generate a `did:ethr` DID,
     /// - `pkh:{pkh_name}` to generate a `did:pkh` DID, where `{pkh_name}`
-    ///    should be replaced by the network id as specified by the
-    ///    [`DIDPKH::generate`] function.
+    ///   should be replaced by the network id as specified by the
+    ///   [`DIDPKH::generate`] function.
     /// - `tz` to generate a `did:tz` DID.
     ///
     /// # Example

--- a/crates/eip712/src/value.rs
+++ b/crates/eip712/src/value.rs
@@ -45,11 +45,11 @@ impl Struct {
         self.0.get_mut(key)
     }
 
-    pub fn iter(&self) -> indexmap::map::Iter<String, Value> {
+    pub fn iter(&'_ self) -> indexmap::map::Iter<'_, String, Value> {
         self.0.iter()
     }
 
-    pub fn keys(&self) -> indexmap::map::Keys<String, Value> {
+    pub fn keys(&'_ self) -> indexmap::map::Keys<'_, String, Value> {
         self.0.keys()
     }
 

--- a/crates/json-ld/src/lib.rs
+++ b/crates/json-ld/src/lib.rs
@@ -130,13 +130,13 @@ impl Expandable for CompactJsonLd {
 /// Any type representing a JSON-LD object.
 pub trait JsonLdObject {
     /// Returns the JSON-LD context attached to `self`.
-    fn json_ld_context(&self) -> Option<Cow<json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, json_ld::syntax::Context>> {
         None
     }
 }
 
 impl JsonLdObject for CompactJsonLd {
-    fn json_ld_context(&self) -> Option<Cow<json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, json_ld::syntax::Context>> {
         json_syntax::from_value(self.0.as_object()?.get("@context").next()?.clone())
             .map(Cow::Owned)
             .ok()
@@ -144,7 +144,7 @@ impl JsonLdObject for CompactJsonLd {
 }
 
 pub trait JsonLdNodeObject: JsonLdObject {
-    fn json_ld_type(&self) -> JsonLdTypes {
+    fn json_ld_type(&'_ self) -> JsonLdTypes<'_> {
         JsonLdTypes::default()
     }
 }
@@ -177,7 +177,7 @@ impl<'a> JsonLdTypes<'a> {
         self.static_.is_empty() && self.non_static.is_empty()
     }
 
-    pub fn reborrow(&self) -> JsonLdTypes {
+    pub fn reborrow(&'_ self) -> JsonLdTypes<'_> {
         JsonLdTypes {
             static_: self.static_,
             non_static: Cow::Borrowed(&self.non_static),

--- a/crates/jwk/src/multicodec.rs
+++ b/crates/jwk/src/multicodec.rs
@@ -130,7 +130,7 @@ impl JWK {
 impl Codec for JWK {
     const CODEC: u64 = ssi_multicodec::JWK_JCS_PUB;
 
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(serde_jcs::to_vec(self).unwrap())
     }
 

--- a/crates/jwk/src/resolver.rs
+++ b/crates/jwk/src/resolver.rs
@@ -15,25 +15,25 @@ pub trait JWKResolver {
     /// The key identifier is optional since the key may be known in advance.
     #[allow(async_fn_in_trait)]
     async fn fetch_public_jwk(
-        &self,
+        &'_ self,
         key_id: Option<&str>,
-    ) -> Result<Cow<JWK>, ProofValidationError>;
+    ) -> Result<Cow<'_, JWK>, ProofValidationError>;
 }
 
 impl<T: JWKResolver> JWKResolver for &T {
     async fn fetch_public_jwk(
-        &self,
+        &'_ self,
         key_id: Option<&str>,
-    ) -> Result<Cow<JWK>, ProofValidationError> {
+    ) -> Result<Cow<'_, JWK>, ProofValidationError> {
         T::fetch_public_jwk(*self, key_id).await
     }
 }
 
 impl JWKResolver for JWK {
     async fn fetch_public_jwk(
-        &self,
+        &'_ self,
         _key_id: Option<&str>,
-    ) -> Result<Cow<JWK>, ProofValidationError> {
+    ) -> Result<Cow<'_, JWK>, ProofValidationError> {
         Ok(Cow::Borrowed(self))
     }
 }

--- a/crates/multicodec/src/codec/ed25519.rs
+++ b/crates/multicodec/src/codec/ed25519.rs
@@ -10,7 +10,7 @@ impl Codec for VerifyingKey {
         Self::try_from(bytes).map_err(|_| Error::InvalidData)
     }
 
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self.as_bytes().as_slice())
     }
 }

--- a/crates/multicodec/src/codec/k256.rs
+++ b/crates/multicodec/src/codec/k256.rs
@@ -9,7 +9,7 @@ impl Codec for k256::PublicKey {
         Self::from_sec1_bytes(bytes).map_err(|_| Error::InvalidData)
     }
 
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(self.to_sec1_bytes().into_vec())
     }
 }

--- a/crates/multicodec/src/codec/mod.rs
+++ b/crates/multicodec/src/codec/mod.rs
@@ -5,19 +5,19 @@ use crate::Error;
 pub trait Codec: Sized {
     const CODEC: u64;
 
-    fn to_bytes(&self) -> Cow<[u8]>;
+    fn to_bytes(&'_ self) -> Cow<'_, [u8]>;
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error>;
 }
 
 pub trait MultiCodec: Sized {
-    fn to_codec_and_bytes(&self) -> (u64, Cow<[u8]>);
+    fn to_codec_and_bytes(&'_ self) -> (u64, Cow<'_, [u8]>);
 
     fn from_codec_and_bytes(codec: u64, bytes: &[u8]) -> Result<Self, Error>;
 }
 
 impl<C: Codec> MultiCodec for C {
-    fn to_codec_and_bytes(&self) -> (u64, Cow<[u8]>) {
+    fn to_codec_and_bytes(&'_ self) -> (u64, Cow<'_, [u8]>) {
         (Self::CODEC, self.to_bytes())
     }
 

--- a/crates/multicodec/src/codec/p256.rs
+++ b/crates/multicodec/src/codec/p256.rs
@@ -9,7 +9,7 @@ impl Codec for p256::PublicKey {
         Self::from_sec1_bytes(bytes).map_err(|_| Error::InvalidData)
     }
 
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&'_ self) -> Cow<'_, [u8]> {
         use p256::elliptic_curve::sec1::ToEncodedPoint;
         Cow::Owned(self.to_encoded_point(true).as_bytes().to_vec())
     }
@@ -22,7 +22,7 @@ impl Codec for p256::SecretKey {
         Self::from_slice(bytes).map_err(|_| Error::InvalidData)
     }
 
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&'_ self) -> Cow<'_, [u8]> {
         Cow::Owned(self.to_bytes().to_vec())
     }
 }

--- a/crates/multicodec/src/codec/p384.rs
+++ b/crates/multicodec/src/codec/p384.rs
@@ -9,7 +9,7 @@ impl Codec for p384::PublicKey {
         Self::from_sec1_bytes(bytes).map_err(|_| Error::InvalidData)
     }
 
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&'_ self) -> Cow<'_, [u8]> {
         use p384::elliptic_curve::sec1::ToEncodedPoint;
         Cow::Owned(self.to_encoded_point(true).as_bytes().to_vec())
     }

--- a/crates/security/src/ethereum_adress.rs
+++ b/crates/security/src/ethereum_adress.rs
@@ -61,10 +61,10 @@ impl<V: Vocabulary, I: Interpretation> linked_data::LinkedDataResource<I, V>
     for EthereumAddressBuf
 {
     fn interpretation(
-        &self,
+        &'_ self,
         _vocabulary: &mut V,
         _interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         use linked_data::{rdf_types::Term, CowRdfTerm, RdfLiteral, ResourceInterpretation};
         ResourceInterpretation::Uninterpreted(Some(CowRdfTerm::Owned(Term::Literal(
             RdfLiteral::Xsd(xsd_types::Value::String(self.to_string())),
@@ -116,10 +116,10 @@ impl EthereumAddress {
 
 impl<V: Vocabulary, I: Interpretation> linked_data::LinkedDataResource<I, V> for EthereumAddress {
     fn interpretation(
-        &self,
+        &'_ self,
         _vocabulary: &mut V,
         _interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         use linked_data::{rdf_types::Term, CowRdfTerm, RdfLiteralRef, ResourceInterpretation};
         ResourceInterpretation::Uninterpreted(Some(CowRdfTerm::Borrowed(Term::Literal(
             RdfLiteralRef::Xsd(xsd_types::ValueRef::String(&self.0)),

--- a/crates/security/src/multibase.rs
+++ b/crates/security/src/multibase.rs
@@ -52,10 +52,10 @@ where
     V: IriVocabularyMut,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         _interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         use linked_data::{rdf_types::Term, CowRdfTerm, ResourceInterpretation};
         ResourceInterpretation::Uninterpreted(Some(CowRdfTerm::Owned(Term::Literal(
             RdfLiteral::Any(
@@ -152,10 +152,10 @@ where
     V: IriVocabularyMut,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         _interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         use linked_data::{rdf_types::Term, CowRdfTerm, ResourceInterpretation};
         ResourceInterpretation::Uninterpreted(Some(CowRdfTerm::Owned(Term::Literal(
             RdfLiteral::Any(

--- a/crates/status/src/impl/any.rs
+++ b/crates/status/src/impl/any.rs
@@ -111,9 +111,9 @@ pub enum AnyDecodedStatusMap {
 
 impl AnyDecodedStatusMap {
     pub fn iter(
-        &self,
+        &'_ self,
         status_size: Option<u8>,
-    ) -> Result<AnyDecodedStatusMapIter, StatusSizeError> {
+    ) -> Result<AnyDecodedStatusMapIter<'_>, StatusSizeError> {
         match self {
             Self::BitstringStatusList(m) => Ok(AnyDecodedStatusMapIter::BitstringStatusList(
                 m.iter(status_size.ok_or(StatusSizeError::Missing)?.try_into()?),

--- a/crates/status/src/impl/bitstring_status_list/mod.rs
+++ b/crates/status/src/impl/bitstring_status_list/mod.rs
@@ -402,7 +402,7 @@ impl SizedBitString {
     }
 
     /// Returns an iterator over all the statuses stored in this bit-string.
-    pub fn iter(&self) -> BitStringIter {
+    pub fn iter(&'_ self) -> BitStringIter<'_> {
         self.inner.iter(self.status_size)
     }
 
@@ -567,7 +567,7 @@ impl BitString {
     }
 
     /// Returns an iterator over all the statuses stored in this bit-string.
-    pub fn iter(&self, status_size: StatusSize) -> BitStringIter {
+    pub fn iter(&'_ self, status_size: StatusSize) -> BitStringIter<'_> {
         BitStringIter {
             bit_string: self,
             status_size,
@@ -655,7 +655,7 @@ impl StatusList {
         self.bit_string.set(status_size, index, value)
     }
 
-    pub fn iter(&self, status_size: StatusSize) -> BitStringIter {
+    pub fn iter(&'_ self, status_size: StatusSize) -> BitStringIter<'_> {
         self.bit_string.iter(status_size)
     }
 
@@ -707,7 +707,7 @@ impl SizedStatusList {
         self.bit_string.push(value)
     }
 
-    pub fn iter(&self) -> BitStringIter {
+    pub fn iter(&'_ self) -> BitStringIter<'_> {
         self.bit_string.iter()
     }
 

--- a/crates/status/src/impl/bitstring_status_list/syntax/entry_set/credential.rs
+++ b/crates/status/src/impl/bitstring_status_list/syntax/entry_set/credential.rs
@@ -65,13 +65,13 @@ impl StatusMapEntrySet for BitstringStatusListEntrySetCredential {
 }
 
 impl JsonLdObject for BitstringStatusListEntrySetCredential {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
 
 impl JsonLdNodeObject for BitstringStatusListEntrySetCredential {
-    fn json_ld_type(&self) -> ssi_json_ld::JsonLdTypes {
+    fn json_ld_type(&'_ self) -> ssi_json_ld::JsonLdTypes<'_> {
         self.types.to_json_ld_types()
     }
 }

--- a/crates/status/src/impl/bitstring_status_list/syntax/status_list/credential.rs
+++ b/crates/status/src/impl/bitstring_status_list/syntax/status_list/credential.rs
@@ -89,13 +89,13 @@ impl BitstringStatusListCredential {
 }
 
 impl JsonLdObject for BitstringStatusListCredential {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
 
 impl JsonLdNodeObject for BitstringStatusListCredential {
-    fn json_ld_type(&self) -> ssi_json_ld::JsonLdTypes {
+    fn json_ld_type(&'_ self) -> ssi_json_ld::JsonLdTypes<'_> {
         self.types.to_json_ld_types()
     }
 }

--- a/crates/status/src/impl/bitstring_status_list_20240406/mod.rs
+++ b/crates/status/src/impl/bitstring_status_list_20240406/mod.rs
@@ -424,7 +424,7 @@ impl BitString {
     }
 
     /// Returns an iterator over all the statuses stored in this bit-string.
-    pub fn iter(&self) -> BitStringIter {
+    pub fn iter(&'_ self) -> BitStringIter<'_> {
         BitStringIter {
             bit_string: self,
             index: 0,
@@ -502,7 +502,7 @@ impl StatusList {
         self.bit_string.push(value)
     }
 
-    pub fn iter(&self) -> BitStringIter {
+    pub fn iter(&'_ self) -> BitStringIter<'_> {
         self.bit_string.iter()
     }
 

--- a/crates/status/src/impl/bitstring_status_list_20240406/syntax/entry_set/credential.rs
+++ b/crates/status/src/impl/bitstring_status_list_20240406/syntax/entry_set/credential.rs
@@ -60,13 +60,13 @@ impl StatusMapEntrySet for BitstringStatusListEntrySetCredential {
 }
 
 impl JsonLdObject for BitstringStatusListEntrySetCredential {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
 
 impl JsonLdNodeObject for BitstringStatusListEntrySetCredential {
-    fn json_ld_type(&self) -> ssi_json_ld::JsonLdTypes {
+    fn json_ld_type(&'_ self) -> ssi_json_ld::JsonLdTypes<'_> {
         self.types.to_json_ld_types()
     }
 }

--- a/crates/status/src/impl/bitstring_status_list_20240406/syntax/status_list/credential.rs
+++ b/crates/status/src/impl/bitstring_status_list_20240406/syntax/status_list/credential.rs
@@ -86,13 +86,13 @@ impl BitstringStatusListCredential {
 }
 
 impl JsonLdObject for BitstringStatusListCredential {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
 
 impl JsonLdNodeObject for BitstringStatusListCredential {
-    fn json_ld_type(&self) -> ssi_json_ld::JsonLdTypes {
+    fn json_ld_type(&'_ self) -> ssi_json_ld::JsonLdTypes<'_> {
         self.types.to_json_ld_types()
     }
 }

--- a/crates/status/src/impl/token_status_list/json.rs
+++ b/crates/status/src/impl/token_status_list/json.rs
@@ -88,7 +88,7 @@ impl ClaimSet for StatusListJwtPrivateClaims {
         }
     }
 
-    fn try_get<C: Claim>(&self) -> Result<Option<Cow<C>>, InvalidClaimValue> {
+    fn try_get<C: Claim>(&'_ self) -> Result<Option<Cow<'_, C>>, InvalidClaimValue> {
         match_claim_type! {
             match C {
                 TimeToLiveClaim => {

--- a/crates/status/src/impl/token_status_list/mod.rs
+++ b/crates/status/src/impl/token_status_list/mod.rs
@@ -250,7 +250,7 @@ impl StatusList {
         Self { bit_string, ttl }
     }
 
-    pub fn iter(&self) -> BitStringIter {
+    pub fn iter(&'_ self) -> BitStringIter<'_> {
         self.bit_string.iter()
     }
 }
@@ -484,7 +484,7 @@ impl BitString {
     }
 
     /// Returns an iterator over all the statuses stored in this bit-string.
-    pub fn iter(&self) -> BitStringIter {
+    pub fn iter(&'_ self) -> BitStringIter<'_> {
         BitStringIter {
             bit_string: self,
             index: 0,

--- a/crates/verification-methods/core/src/reference.rs
+++ b/crates/verification-methods/core/src/reference.rs
@@ -34,7 +34,7 @@ impl<M> ReferenceOrOwned<M> {
         }
     }
 
-    pub fn borrowed(&self) -> ReferenceOrOwnedRef<M> {
+    pub fn borrowed(&'_ self) -> ReferenceOrOwnedRef<'_, M> {
         match self {
             Self::Reference(r) => ReferenceOrOwnedRef::Reference(r.as_iri()),
             Self::Owned(m) => ReferenceOrOwnedRef::Owned(m),

--- a/crates/verification-methods/src/methods.rs
+++ b/crates/verification-methods/src/methods.rs
@@ -66,7 +66,7 @@ impl AnyMethod {
     /// Returns the public key of the verification method as a JWK.
     ///
     /// Some methods don't have any the public key embedded.
-    pub fn public_key_jwk(&self) -> Option<Cow<JWK>> {
+    pub fn public_key_jwk(&'_ self) -> Option<Cow<'_, JWK>> {
         match self {
             #[cfg(feature = "rsa")]
             Self::RsaVerificationKey2018(m) => Some(Cow::Borrowed(m.public_key_jwk())),
@@ -109,7 +109,7 @@ impl From<AnyMethod> for GenericVerificationMethod {
 }
 
 impl MaybeJwkVerificationMethod for AnyMethod {
-    fn try_to_jwk(&self) -> Option<Cow<JWK>> {
+    fn try_to_jwk(&'_ self) -> Option<Cow<'_, JWK>> {
         self.public_key_jwk()
     }
 }
@@ -259,7 +259,7 @@ impl AnyJwkMethod {
     /// Returns the public key of the verification method as a JWK.
     ///
     /// Some methods don't have any the public key embedded.
-    pub fn public_key_jwk(&self) -> Cow<JWK> {
+    pub fn public_key_jwk(&'_ self) -> Cow<'_, JWK> {
         match self {
             Self::JsonWebKey2020(m) => Cow::Borrowed(m.public_key_jwk()),
             #[cfg(feature = "rsa")]
@@ -279,7 +279,7 @@ impl AnyJwkMethod {
 }
 
 impl JwkVerificationMethod for AnyJwkMethod {
-    fn to_jwk(&self) -> Cow<JWK> {
+    fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         self.public_key_jwk()
     }
 }

--- a/crates/verification-methods/src/methods/unspecified/solana_method_2021.rs
+++ b/crates/verification-methods/src/methods/unspecified/solana_method_2021.rs
@@ -116,7 +116,7 @@ impl TypedVerificationMethod for SolanaMethod2021 {
 }
 
 impl JwkVerificationMethod for SolanaMethod2021 {
-    fn to_jwk(&self) -> Cow<JWK> {
+    fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         Cow::Borrowed(self.public_key_jwk())
     }
 }

--- a/crates/verification-methods/src/methods/w3c/ecdsa_secp_256k1_recovery_method_2020.rs
+++ b/crates/verification-methods/src/methods/w3c/ecdsa_secp_256k1_recovery_method_2020.rs
@@ -113,7 +113,7 @@ impl EcdsaSecp256k1RecoveryMethod2020 {
     pub const IRI: &'static Iri =
         iri!("https://w3id.org/security#EcdsaSecp256k1RecoveryMethod2020");
 
-    pub fn public_key_jwk(&self) -> Option<Cow<JWK>> {
+    pub fn public_key_jwk(&'_ self) -> Option<Cow<'_, JWK>> {
         self.public_key.to_jwk()
     }
 
@@ -227,7 +227,7 @@ impl From<InvalidPublicKey> for ProofValidationError {
 }
 
 impl PublicKey {
-    pub fn to_jwk(&self) -> Option<Cow<JWK>> {
+    pub fn to_jwk(&'_ self) -> Option<Cow<'_, JWK>> {
         match self {
             Self::Jwk(jwk) => Some(Cow::Borrowed(jwk)),
             Self::Hex(hex) => Some(Cow::Owned(hex.to_jwk())),
@@ -333,10 +333,10 @@ where
     String: linked_data::LinkedDataResource<I, V>,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         self.encoded.interpretation(vocabulary, interpretation)
     }
 }

--- a/crates/verification-methods/src/methods/w3c/ecdsa_secp_256k1_verification_key_2019.rs
+++ b/crates/verification-methods/src/methods/w3c/ecdsa_secp_256k1_verification_key_2019.rs
@@ -70,7 +70,7 @@ impl EcdsaSecp256k1VerificationKey2019 {
     pub const IRI: &'static Iri =
         iri!("https://w3id.org/security#EcdsaSecp256k1VerificationKey2019");
 
-    pub fn public_key_jwk(&self) -> Cow<JWK> {
+    pub fn public_key_jwk(&'_ self) -> Cow<'_, JWK> {
         self.public_key.to_jwk()
     }
 
@@ -152,7 +152,7 @@ impl TypedVerificationMethod for EcdsaSecp256k1VerificationKey2019 {
 }
 
 impl JwkVerificationMethod for EcdsaSecp256k1VerificationKey2019 {
-    fn to_jwk(&self) -> Cow<JWK> {
+    fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         self.public_key_jwk()
     }
 }
@@ -223,7 +223,7 @@ pub enum PublicKey {
 }
 
 impl PublicKey {
-    pub fn to_jwk(&self) -> Cow<JWK> {
+    pub fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         match self {
             Self::Jwk(jwk) => Cow::Borrowed(jwk),
             Self::Hex(hex) => Cow::Owned(hex.to_jwk()),
@@ -297,10 +297,10 @@ where
     String: linked_data::LinkedDataResource<I, V>,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         self.encoded.interpretation(vocabulary, interpretation)
     }
 }

--- a/crates/verification-methods/src/methods/w3c/ecdsa_secp_256r1_verification_key_2019.rs
+++ b/crates/verification-methods/src/methods/w3c/ecdsa_secp_256r1_verification_key_2019.rs
@@ -181,7 +181,7 @@ impl TypedVerificationMethod for EcdsaSecp256r1VerificationKey2019 {
 }
 
 impl JwkVerificationMethod for EcdsaSecp256r1VerificationKey2019 {
-    fn to_jwk(&self) -> Cow<JWK> {
+    fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         Cow::Owned(self.public_key_jwk())
     }
 }
@@ -330,10 +330,10 @@ where
     MultibaseBuf: linked_data::LinkedDataResource<I, V>,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         self.encoded.interpretation(vocabulary, interpretation)
     }
 }

--- a/crates/verification-methods/src/methods/w3c/ed25519_verification_key_2018.rs
+++ b/crates/verification-methods/src/methods/w3c/ed25519_verification_key_2018.rs
@@ -122,7 +122,7 @@ impl TypedVerificationMethod for Ed25519VerificationKey2018 {
 }
 
 impl JwkVerificationMethod for Ed25519VerificationKey2018 {
-    fn to_jwk(&self) -> Cow<JWK> {
+    fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         Cow::Owned(self.public_key_jwk())
     }
 }
@@ -252,10 +252,10 @@ where
     String: linked_data::LinkedDataResource<I, V>,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         self.encoded.interpretation(vocabulary, interpretation)
     }
 }

--- a/crates/verification-methods/src/methods/w3c/ed25519_verification_key_2020.rs
+++ b/crates/verification-methods/src/methods/w3c/ed25519_verification_key_2020.rs
@@ -182,7 +182,7 @@ impl TypedVerificationMethod for Ed25519VerificationKey2020 {
 }
 
 impl JwkVerificationMethod for Ed25519VerificationKey2020 {
-    fn to_jwk(&self) -> Cow<JWK> {
+    fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         Cow::Owned(self.public_key_jwk())
     }
 }
@@ -353,10 +353,10 @@ where
     MultibaseBuf: linked_data::LinkedDataResource<I, V>,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         self.encoded.interpretation(vocabulary, interpretation)
     }
 }

--- a/crates/verification-methods/src/methods/w3c/json_web_key_2020.rs
+++ b/crates/verification-methods/src/methods/w3c/json_web_key_2020.rs
@@ -138,7 +138,7 @@ impl TypedVerificationMethod for JsonWebKey2020 {
 }
 
 impl JwkVerificationMethod for JsonWebKey2020 {
-    fn to_jwk(&self) -> Cow<JWK> {
+    fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         Cow::Borrowed(self.public_key_jwk())
     }
 }

--- a/crates/verification-methods/src/methods/w3c/multikey.rs
+++ b/crates/verification-methods/src/methods/w3c/multikey.rs
@@ -267,7 +267,7 @@ impl TypedVerificationMethod for Multikey {
 }
 
 impl MaybeJwkVerificationMethod for Multikey {
-    fn try_to_jwk(&self) -> Option<Cow<JWK>> {
+    fn try_to_jwk(&'_ self) -> Option<Cow<'_, JWK>> {
         self.public_key_jwk().map(Cow::Owned)
     }
 }
@@ -379,10 +379,10 @@ where
     V: IriVocabularyMut,
 {
     fn interpretation(
-        &self,
+        &'_ self,
         vocabulary: &mut V,
         interpretation: &mut I,
-    ) -> linked_data::ResourceInterpretation<I, V> {
+    ) -> linked_data::ResourceInterpretation<'_, I, V> {
         self.encoded.interpretation(vocabulary, interpretation)
     }
 }
@@ -497,7 +497,7 @@ impl MultiCodec for DecodedMultikey {
         }
     }
 
-    fn to_codec_and_bytes(&self) -> (u64, Cow<[u8]>) {
+    fn to_codec_and_bytes(&'_ self) -> (u64, Cow<'_, [u8]>) {
         match self {
             #[cfg(feature = "ed25519")]
             Self::Ed25519(k) => k.to_codec_and_bytes(),

--- a/crates/verification-methods/src/methods/w3c/rsa_verification_key_2018.rs
+++ b/crates/verification-methods/src/methods/w3c/rsa_verification_key_2018.rs
@@ -121,7 +121,7 @@ impl TypedVerificationMethod for RsaVerificationKey2018 {
 }
 
 impl JwkVerificationMethod for RsaVerificationKey2018 {
-    fn to_jwk(&self) -> Cow<JWK> {
+    fn to_jwk(&'_ self) -> Cow<'_, JWK> {
         Cow::Borrowed(self.public_key_jwk())
     }
 }

--- a/crates/zcap-ld/src/lib.rs
+++ b/crates/zcap-ld/src/lib.rs
@@ -297,7 +297,7 @@ impl<C, S, R, L1, L2> TargetCapabilityProvider for InvocationVerifier<'_, C, S, 
 }
 
 impl<C, P> JsonLdObject for Delegation<C, P> {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }
@@ -431,7 +431,7 @@ impl<P> Invocation<P> {
 }
 
 impl<P> JsonLdObject for Invocation<P> {
-    fn json_ld_context(&self) -> Option<Cow<ssi_json_ld::syntax::Context>> {
+    fn json_ld_context(&'_ self) -> Option<Cow<'_, ssi_json_ld::syntax::Context>> {
         Some(Cow::Borrowed(self.context.as_ref()))
     }
 }

--- a/examples/present.rs
+++ b/examples/present.rs
@@ -29,7 +29,7 @@ async fn verify(proof_format_in: &str, proof_format_out: &str, input_vc: &str) {
         "ldp" => {
             let vc_ldp: AnyDataIntegrity<AnyJsonCredential> =
                 serde_json::from_str(input_vc).unwrap();
-            ssi::claims::JsonCredentialOrJws::Credential(vc_ldp)
+            ssi::claims::JsonCredentialOrJws::Credential(Box::new(vc_ldp))
         }
         "jwt" => match JwsString::from_string(input_vc.to_string()) {
             Ok(vc_jwt) => ssi::claims::JsonCredentialOrJws::Jws(vc_jwt),


### PR DESCRIPTION
## Description

In the `data-integrity` library we currently use a `FlatMapDeserializer` to deserialize proof/configuration types that is part of `serde` private API. That type is used by `serde`'s derive macro to implement `#[derive(flatten)]`. However because Data Integrity proofs/configurations are so hard to deserialize, we can't use `serde`'s derive macro, we have to implement `flatten` "by hand". That's because the deserialization behavior depends on the crypto suite type, which is unknown when the deserialization starts. The result is a fairly complex deserialization function that requires a `FlatMapDeserializer` implementation. Unfortunately `serde` recently made it impossible to use their private API, and provides no public equivalent to `FlatMapDeserializer`. This PR implements a weaker but simpler version of `FlatMapDeserializer` based on `serde_json::Value` (to store arbitrary values deserialized during flattening).

Close https://github.com/spruceid/ssi/issues/681
Close https://github.com/spruceid/ssi/pull/682
Close #683 

### Other changes

I moved all the deserialization utility types in a dedicated `de::utils` module.

## Tested

- [x] Test suite still passes.