### PR TITLE
Upgrade `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ contextual = "0.1.6"
 lazy_static = "1.4.0"
 indexmap = "2.0.0"
 uuid = "1.9"
+reqwest = { version = "0.13", default-features = false }
 
 [features]
 default = [

--- a/crates/claims/crates/vc/Cargo.toml
+++ b/crates/claims/crates/vc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-vc"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"
@@ -33,16 +33,13 @@ educe.workspace = true
 base64.workspace = true
 bitvec = "0.20"
 flate2 = "1.0"
-reqwest = { version = "0.11", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
+reqwest = { workspace = true, features = ["json", "rustls"] }
 ssi-verification-methods.workspace = true
 ssi-dids-core.workspace = true
 ssi-data-integrity.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+workspace = true
 features = ["json", "native-tls-vendored"]
 
 [dev-dependencies]

--- a/crates/dids/core/Cargo.toml
+++ b/crates/dids/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-dids-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"
@@ -32,14 +32,11 @@ pin-project.workspace = true
 ssi-jwk.workspace = true
 
 # for the `http` feature.
-reqwest = { version = "0.11", default-features = false, features = [
-    "json",
-    "rustls-tls",
-], optional = true }
+reqwest = { workspace = true, features = ["json", "rustls"], optional = true }
 percent-encoding = { version = "2.1", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+workspace = true
 features = ["json", "native-tls-vendored"]
 
 [dev-dependencies]

--- a/crates/dids/methods/ion/Cargo.toml
+++ b/crates/dids/methods/ion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-ion"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
@@ -26,13 +26,10 @@ thiserror.workspace = true
 base64.workspace = true
 sha2 = "0.10"
 json-patch = "0.2.6"
-reqwest = { version = "0.11", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
+reqwest = { workspace = true, features = ["json", "rustls"] }
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+workspace = true
 features = ["json", "native-tls-vendored"]
 
 # [target.'cfg(target_arch = "wasm32", target_arch = "wasm64")'.dependencies]

--- a/crates/dids/methods/tz/Cargo.toml
+++ b/crates/dids/methods/tz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-tz"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,10 +17,7 @@ ssi-dids-core.workspace = true
 ssi-jwk = { workspace = true, default-features = false, features = ["tezos"] }
 ssi-jws = { workspace = true, default-features = false }
 ssi-core.workspace = true
-reqwest = { version = "0.11", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
+reqwest = { workspace = true, features = ["json", "query", "rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
@@ -38,8 +35,8 @@ chrono = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, features = ["serde", "wasmbind"] }
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
-features = ["json", "native-tls-vendored"]
+workspace = true
+features = ["json", "query", "native-tls-vendored"]
 
 [dev-dependencies]
 ssi-tzkey.workspace = true

--- a/crates/dids/methods/web/Cargo.toml
+++ b/crates/dids/methods/web/Cargo.toml
@@ -35,4 +35,11 @@ static-iref.workspace = true
 xsd-types.workspace = true
 tokio = { version = "1.0", features = ["macros"] }
 futures = "0.3"
-hyper = { version = "0.14", features = ["server", "client", "http1", "stream"] }
+hyper = { version = "0.14", features = [
+    "server",
+    "client",
+    "http1",
+    "stream",
+    "tcp",
+    "runtime",
+] }

--- a/crates/dids/methods/web/Cargo.toml
+++ b/crates/dids/methods/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-web"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
@@ -14,14 +14,12 @@ documentation = "https://docs.rs/did-web/"
 [dependencies]
 ssi-dids-core.workspace = true
 thiserror.workspace = true
-reqwest = { version = "0.11", default-features = false, features = [
-    "rustls-tls",
-] }
-http = "0.2"
+reqwest = { workspace = true, features = ["rustls"] }
+http = "1"
 iref.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies.reqwest]
-version = "0.11"
+workspace = true
 features = ["native-tls-vendored"]
 
 [dev-dependencies]

--- a/crates/dids/methods/web/src/lib.rs
+++ b/crates/dids/methods/web/src/lib.rs
@@ -244,7 +244,7 @@ mod tests {
     // localhost web server for serving did:web DID documents.
     // TODO: pass arguments here instead of using const
     fn web_server() -> Result<(String, impl FnOnce() -> Result<(), ()>), hyper::Error> {
-        use http::header::{HeaderValue, CONTENT_TYPE};
+        use hyper::header::{HeaderValue, CONTENT_TYPE};
         use hyper::service::{make_service_fn, service_fn};
         use hyper::{Body, Response, Server};
         let addr = ([127, 0, 0, 1], 0).into();

--- a/crates/status/Cargo.toml
+++ b/crates/status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-status"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ serde_json.workspace = true
 rdf-types.workspace = true
 xsd-types.workspace = true
 log.workspace = true
-reqwest = "0.12.3"
+reqwest = { workspace = true, features = ["rustls"] }
 parking_lot = "0.12.1"
 flate2 = "1.0.28"
 

--- a/crates/status/examples/status_list_client.rs
+++ b/crates/status/examples/status_list_client.rs
@@ -22,6 +22,11 @@
 //! $ cargo run --example status_list_server -- -t application/vc+ld+json examples/files/local-status-list-credential.jsonld
 //! serving /#statusList at 127.0.0.1:3000...
 //! ```
+
+// `reqwest` 0.13 nests its response futures more deeply, pushing the layout of
+// this example's async `main` past the default recursion limit.
+#![recursion_limit = "256"]
+
 use clap::Parser;
 use core::fmt;
 use ssi_claims_core::VerificationParameters;

--- a/deny.toml
+++ b/deny.toml
@@ -97,6 +97,7 @@ allow = [
     "MIT",
     "MPL-2.0",
     "Unicode-3.0",
+    "CDLA-Permissive-2.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
Mainly to upgrade the `rustls-webpki` dep which has a vulnerability. But this also moves every crate to `http` v1.

Along with the upgrade, `reqwest` is moved to a workspace dependency to be consistent with the rest of the dependencies. The current features have been preserved.

`reqwest::Error` is sometimes exposed publicly, but the type hasn't changed between 0.11 -> 0.13 so it is not a breaking change and allows us to simply bump the patch version of the affected ssi crates.
