### PR TITLE
Fix BBS derived proof message ordering

### DIFF
--- a/crates/claims/crates/data-integrity/suites/src/suites/w3c/bbs_2023/derive.rs
+++ b/crates/claims/crates/data-integrity/suites/src/suites/w3c/bbs_2023/derive.rs
@@ -8,7 +8,7 @@ use ssi_di_sd_primitives::{
     HmacShaAnyKey, JsonPointerBuf,
 };
 use ssi_json_ld::{Expandable, ExpandedDocument, JsonLdNodeObject};
-use ssi_rdf::LexicalInterpretation;
+use ssi_rdf::{IntoNQuads, LexicalInterpretation};
 use ssi_verification_methods::{
     multikey::{self, DecodedMultikey},
     Multikey,
@@ -212,28 +212,26 @@ where
     let mandatory_group = canonical.groups.get(&Group::Mandatory).unwrap();
     let selective_group = canonical.groups.get(&Group::Selective).unwrap();
 
-    let mandatory_match = &mandatory_group.matching;
-    let combined_match = &combined_group.matching;
-    let combined_indexes: Vec<_> = combined_match.keys().copied().collect();
-    let mut mandatory_indexes = Vec::with_capacity(mandatory_match.len());
-    for i in mandatory_match.keys() {
-        let offset = combined_indexes.binary_search(i).unwrap();
+    let combined_lines = combined_group.matching.values().into_nquads_lines();
+    let mandatory_lines = mandatory_group.matching.values().into_nquads_lines();
+    let mut mandatory_indexes = Vec::with_capacity(mandatory_lines.len());
+    for line in mandatory_lines {
+        let offset = combined_lines.binary_search(&line).unwrap();
         mandatory_indexes.push(offset);
     }
 
-    let selective_match = &selective_group.matching;
-    let mandatory_non_match = &mandatory_group.non_matching;
-    let non_mandatory_indexes: Vec<_> = mandatory_non_match.keys().copied().collect();
-    let mut selective_indexes = Vec::with_capacity(mandatory_non_match.len());
-    for i in selective_match.keys() {
-        if let Ok(offset) = non_mandatory_indexes.binary_search(i) {
+    let bbs_message_lines = mandatory_group.non_matching.values().into_nquads_lines();
+    let selective_lines = selective_group.matching.values().into_nquads_lines();
+    let mut selective_indexes = Vec::with_capacity(selective_lines.len());
+    for line in selective_lines {
+        if let Ok(offset) = bbs_message_lines.binary_search(&line) {
             selective_indexes.push(offset);
         }
     }
 
-    let bbs_messages: Vec<_> = mandatory_non_match
-        .values()
-        .map(|quad| format!("{quad} .\n").into_bytes())
+    let bbs_messages: Vec<_> = bbs_message_lines
+        .into_iter()
+        .map(String::into_bytes)
         .collect();
 
     let DecodedMultikey::Bls12_381(pk) = verification_method.public_key.decode()? else {


### PR DESCRIPTION
## Description

This PR fixes BBS-2023 derived proof creation for credentials whose canonicalized RDF dataset order differs from the internal canonicalization map/index order.

The issue shows up in the W3C BBS test suite under:

https://w3c.github.io/vc-di-bbs-test-suite/#bbs-2023%20(issuers)%20VC%20Version%202.0

In the published W3C report, SpruceID currently fails this issuer VC 2.0 test:

> A conforming proof is any concrete expression of the data model that complies with the normative statements in this specification. Specifically, all relevant normative statements in Sections 2. Data Model and 3. Algorithms of this document MUST be enforced.

### Root Cause

BBS signs and proves over an ordered list of messages. In the `bbs-2023` cryptosuite, those messages are canonical N-Quads lines.

The base proof signing path already builds BBS messages using sorted N-Quads line order via `into_nquads_lines()`. The derived proof verification path also interprets disclosed messages in that sorted N-Quads line order.

However, the derived proof creation path computed:

- `mandatory_indexes`
- `selective_indexes`
- `bbs_messages`

using the internal canonicalization map/index order.

For simple credentials these orders can happen to match. For credentials with blank nodes or nested JSON-LD structures, such as the W3C license VC fixture, the internal canonicalization order can differ from the sorted N-Quads line order. This causes the generated BBS proof to disclose indexes for the wrong messages, and downstream verification fails with an invalid signature / derived proof verification error.

In short:

```text
base proof signing:      sorted N-Quads message order
derived proof creation:  internal canonicalization index order
derived proof verify:    sorted N-Quads message order
```

This PR makes derived proof creation use the same sorted N-Quads line order as signing and verification.

### Fix

The derive path now computes `mandatory_indexes`, `selective_indexes`, and `bbs_messages` from `into_nquads_lines()` output.

This aligns holder-side proof generation with the message order already used by base proof signing and derived proof verification.

Existing base proofs remain valid; the change only affects newly generated BBS-2023 derived proofs.

### Impact

This primarily affects:

- BBS-2023 selective disclosure
- VC-to-derived-proof / VP generation
- credentials containing blank nodes or nested JSON-LD structures

It should not affect:

- base BBS proof signing
- base proof verification
- non-BBS suites
- JWT / SD-JWT / ECDSA / EdDSA paths


## Tested

```bash
cargo test -p ssi-data-integrity-suites --features 'w3c bbs' w3c::bbs_2023
cargo test -p ssi --features 'w3c bbs'
```

Both passed locally.

I also built a minimal VC API-compatible HTTP service for this branch and ran the W3C `vc-di-bbs-test-suite` against it. The suite completed successfully, including the previously failing `bbs-2023 (issuers) VC Version 2.0` conforming proof test.
