### PR TITLE
ssi-jwt: remove unused serde_with dependency

### DIFF
--- a/crates/claims/crates/jwt/Cargo.toml
+++ b/crates/claims/crates/jwt/Cargo.toml
@@ -20,7 +20,6 @@ ssi-jwk.workspace = true
 ssi-jws.workspace = true
 ssi-claims-core.workspace = true
 iref = { workspace = true, features = ["serde"] }
-serde_with = "2.3.2"
 hashbrown = "0.14.3"
 slab = "0.4.9"
 ordered-float = { version = "4.2.0", features = ["serde"] }


### PR DESCRIPTION
The ssi-jwt crate declares serde_with 2.3.2 but does not use it in production, tests, examples, or generated code. Removing the unused declaration eliminates GHSA-7gcf-g7xr-8hxj from downstream dependency graphs without changing the public API or enabled features.\n\nValidated with cargo check -p ssi-jwt and cargo tree -p ssi-jwt.