### PR TITLE
Add `caip2` and `caip10` features to `ssi-caips`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ssi-rdf = { path = "./crates/rdf", version = "0.1", default-features = false }
 ssi-contexts = { path = "./crates/contexts", version = "0.1.10", default-features = false }
 ssi-json-ld = { path = "./crates/json-ld", version = "0.3.3", default-features = false }
 ssi-security = { path = "./crates/security", version = "0.1", default-features = false }
-ssi-caips = { path = "./crates/caips", version = "0.3", default-features = false }
+ssi-caips = { path = "./crates/caips", version = "0.4", default-features = false }
 ssi-ucan = { path = "./crates/ucan", version = "0.5", default-features = false }
 ssi-zcap-ld = { path = "./crates/zcap-ld", version = "0.8", default-features = false }
 ssi-ssh = { path = "./crates/ssh", version = "0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ ssi-status.workspace = true
 ssi-verification-methods.workspace = true
 ssi-dids.workspace = true
 ssi-eip712.workspace = true
-ssi-caips.workspace = true
+ssi-caips = { workspace = true, features = ["caip10"] }
 ssi-ucan.workspace = true
 ssi-zcap-ld.workspace = true
 ssi-multicodec.workspace = true

--- a/crates/caips/Cargo.toml
+++ b/crates/caips/Cargo.toml
@@ -9,24 +9,48 @@ repository = "https://github.com/spruceid/ssi/"
 documentation = "https://docs.rs/ssi-caips/"
 
 [features]
-default = ["eip", "ripemd-160", "ssi-jwk/secp256k1"]
-eip = ["ssi-jwk/eip"]
-ripemd-160 = ["ssi-jwk/ripemd-160"]
+default = ["caip10", "eip", "ripemd-160", "ssi-jwk/secp256k1"]
+
+## Enable the `caip2` module, providing CAIP-2 blockchain ids.
+##
+## `thiserror` is the only dependency required by this feature.
+caip2 = []
+
+## Enable the `caip10` module, providing CAIP-10 blockchain account ids.
+##
+## This requires a public key implementation (`ssi-jwk`) and RDF/serde support,
+## which is most of the weight of this crate. Implies `caip2`.
+caip10 = [
+  "caip2",
+  "dep:ssi-jwk",
+  "dep:bs58",
+  "dep:serde",
+  "dep:linked-data",
+  "dep:xsd-types",
+]
+
+## Enable the verification of `eip155` accounts.
+eip = ["caip10", "ssi-jwk/eip"]
+
+## Enable the verification of `bip122` (Bitcoin, Dogecoin) accounts.
+ripemd-160 = ["caip10", "ssi-jwk/ripemd-160"]
 
 ## Enable aleo accounts.
 ##
 ## Not compatible with WASM targets.
-aleo = ["ssi-jwk/aleo", "bech32"]
-tezos = ["ssi-jwk/tezos"]
+aleo = ["caip10", "ssi-jwk/aleo", "bech32"]
+
+## Enable the verification of `tezos` accounts.
+tezos = ["caip10", "ssi-jwk/tezos"]
 
 [dependencies]
 thiserror = "1"
-ssi-jwk.workspace = true
-bs58 = { workspace = true, features = ["check"] }
+ssi-jwk = { workspace = true, optional = true }
+bs58 = { workspace = true, features = ["check"], optional = true }
 bech32 = { version = "0.8", optional = true }
-serde.workspace = true
-linked-data.workspace = true
-xsd-types.workspace = true
+serde = { workspace = true, optional = true }
+linked-data = { workspace = true, optional = true }
+xsd-types = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/caips/Cargo.toml
+++ b/crates/caips/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssi-caips"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Spruce Systems, Inc."]
 license = "Apache-2.0"

--- a/crates/caips/src/lib.rs
+++ b/crates/caips/src/lib.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[cfg(feature = "caip10")]
 pub mod caip10;
+
+#[cfg(feature = "caip2")]
 pub mod caip2;

--- a/crates/claims/crates/data-integrity/suites/Cargo.toml
+++ b/crates/claims/crates/data-integrity/suites/Cargo.toml
@@ -86,7 +86,7 @@ tezos = [
 ]
 
 ## Enables `AleoSignature2021`.
-aleo = ["ssi-jwk/aleo", "ssi-verification-methods/aleo", "k256"]
+aleo = ["ssi-jwk/aleo", "ssi-verification-methods/aleo", "ssi-caips/aleo", "k256"]
 
 ## Signature suites based on Ethereum EIP-712.
 ##

--- a/crates/dids/methods/ethr/Cargo.toml
+++ b/crates/dids/methods/ethr/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/did-ethr/"
 
 [dependencies]
 ssi-dids-core.workspace = true
-ssi-caips = { workspace = true, features = ["eip"] }
+ssi-caips = { workspace = true, features = ["caip10", "eip"] }
 ssi-jwk.workspace = true
 iref.workspace = true
 static-iref.workspace = true

--- a/crates/dids/methods/pkh/Cargo.toml
+++ b/crates/dids/methods/pkh/Cargo.toml
@@ -21,7 +21,7 @@ solana = []
 
 [dependencies]
 ssi-crypto.workspace = true
-ssi-caips.workspace = true
+ssi-caips = { workspace = true, features = ["caip10"] }
 ssi-dids-core.workspace = true
 ssi-jwk.workspace = true
 iref.workspace = true
@@ -53,7 +53,7 @@ ssi-claims = { workspace = true, features = [
 ] }
 ssi-tzkey.workspace = true
 ssi-eip712.workspace = true
-ssi-caips = { workspace = true, features = ["eip"] }
+ssi-caips = { workspace = true, features = ["caip10", "eip"] }
 ssi-jws.workspace = true
 rdf-types.workspace = true
 xsd-types.workspace = true

--- a/crates/ucan/Cargo.toml
+++ b/crates/ucan/Cargo.toml
@@ -24,7 +24,7 @@ ssi-jwt.workspace = true
 ssi-dids-core.workspace = true
 ssi-core.workspace = true
 ssi-verification-methods.workspace = true
-ssi-caips.workspace = true
+ssi-caips = { workspace = true, features = ["caip10"] }
 chrono = { workspace = true, features = ["serde"] }
 serde_ipld_dagjson = "0.2.0"
 cid = "0.11.1"

--- a/crates/verification-methods/Cargo.toml
+++ b/crates/verification-methods/Cargo.toml
@@ -64,7 +64,7 @@ ssi-crypto.workspace = true
 ssi-jwk.workspace = true
 ssi-jws.workspace = true
 ssi-security.workspace = true
-ssi-caips.workspace = true
+ssi-caips = { workspace = true, features = ["caip10"] }
 ssi-claims-core.workspace = true
 ssi-verification-methods-core.workspace = true
 ssi-tzkey = { workspace = true, optional = true }


### PR DESCRIPTION
## Description

Users that only need CAIP-2 blockchain ids had to pull in the whole crate, including `ssi-jwk`, `linked-data` and `xsd-types`. The `caip2` module only ever needed `thiserror`.

Every dependency besides `thiserror` is now optional and gated behind the new `caip10` feature, which implies `caip2`. The existing account verification features (`eip`, `ripemd-160`, `aleo`, `tezos`) imply `caip10`, and `default` now includes it, so the default build is unchanged.

This is a breaking change for dependents using `default-features = false`, which previously still got both modules.

## Breaking change

`ssi-caips` is bumped to **0.4.0**

Affected: crates depending on `ssi-caips` directly and with `default-features = false`. They previously got both modules regardless of features; they now get an empty crate unless they opt in.

Migration:
```toml
ssi-caips = { version = "0.4", default-features = false, features = ["caip10"] }
```