### PR TITLE
Turn `StringOrURI` into a newtype

### DIFF
--- a/crates/claims/crates/jwt/src/datatype/string_or_uri.rs
+++ b/crates/claims/crates/jwt/src/datatype/string_or_uri.rs
@@ -1,23 +1,56 @@
 use std::str::FromStr;
 
-use iref::UriBuf;
+use iref::{InvalidUri, Uri, UriBuf};
 use serde::{Deserialize, Serialize};
 
 /// `StringOrURI` datatype defined in [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-2)
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[serde(untagged)]
+///
+/// Any string is a valid value, except that a string containing a `:`
+/// character MUST be a valid URI.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(try_from = "String")]
-pub enum StringOrURI {
-    String(String),
-    URI(UriBuf),
+pub struct StringOrURI(String);
+
+impl Serialize for StringOrURI {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
 }
 
 impl StringOrURI {
-    pub fn into_string(self) -> String {
-        match self {
-            Self::String(s) => s,
-            Self::URI(s) => s.into_string(),
+    /// Creates a new `StringOrURI` value, failing if `string` contains a `:`
+    /// character but is not a valid URI.
+    pub fn new(string: impl Into<String>) -> Result<Self, InvalidUri<String>> {
+        let string = string.into();
+
+        if string.contains(':') {
+            UriBuf::try_from(string).map(|uri| Self(uri.into_string()))
+        } else {
+            Ok(Self(string))
         }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Checks if this value is a URI.
+    pub fn is_uri(&self) -> bool {
+        self.0.contains(':')
+    }
+
+    /// Returns this value as a URI, if it is one.
+    pub fn as_uri(&self) -> Option<&Uri> {
+        Uri::new(self.0.as_bytes()).ok()
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    /// Turns this value into a URI, if it is one.
+    pub fn into_uri(self) -> Option<UriBuf> {
+        UriBuf::try_from(self.0).ok()
     }
 }
 
@@ -27,45 +60,85 @@ impl From<StringOrURI> for String {
     }
 }
 
-impl StringOrURI {
-    pub fn as_str(&self) -> &str {
-        match self {
-            StringOrURI::URI(uri) => uri.as_str(),
-            StringOrURI::String(string) => string.as_str(),
-        }
+impl From<UriBuf> for StringOrURI {
+    fn from(uri: UriBuf) -> Self {
+        Self(uri.into_string())
     }
 }
 
 impl TryFrom<String> for StringOrURI {
-    type Error = iref::InvalidUri<String>;
+    type Error = InvalidUri<String>;
 
     fn try_from(string: String) -> Result<Self, Self::Error> {
-        if string.contains(':') {
-            UriBuf::try_from(string).map(Self::URI)
-        } else {
-            Ok(Self::String(string))
-        }
+        Self::new(string)
     }
 }
 
 impl TryFrom<&str> for StringOrURI {
-    type Error = iref::InvalidUri<String>;
+    type Error = InvalidUri<String>;
 
     fn try_from(string: &str) -> Result<Self, Self::Error> {
-        string.to_string().try_into()
-    }
-}
-
-impl From<UriBuf> for StringOrURI {
-    fn from(uri: UriBuf) -> Self {
-        StringOrURI::URI(uri)
+        Self::new(string)
     }
 }
 
 impl FromStr for StringOrURI {
-    type Err = iref::InvalidUri<String>;
+    type Err = InvalidUri<String>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.try_into()
+        Self::new(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StringOrURI, UriBuf};
+
+    #[test]
+    fn accept_string() {
+        let value = StringOrURI::new("foo").unwrap();
+        assert_eq!(value.as_str(), "foo");
+        assert!(!value.is_uri());
+        assert!(value.as_uri().is_none());
+        assert!(value.into_uri().is_none());
+    }
+
+    #[test]
+    fn accept_uri() {
+        let value = StringOrURI::new("http://example.org/#foo").unwrap();
+        assert_eq!(value.as_str(), "http://example.org/#foo");
+        assert!(value.is_uri());
+        assert_eq!(value.as_uri().unwrap().as_str(), "http://example.org/#foo");
+        assert_eq!(
+            value.into_uri().unwrap().as_str(),
+            "http://example.org/#foo"
+        );
+    }
+
+    #[test]
+    fn from_uri() {
+        let uri = UriBuf::try_from("http://example.org/#foo".to_string()).unwrap();
+        let value = StringOrURI::from(uri);
+        assert_eq!(value.as_str(), "http://example.org/#foo");
+        assert!(value.is_uri());
+    }
+
+    #[test]
+    fn reject_invalid_uri() {
+        assert!(StringOrURI::new(":bar").is_err());
+    }
+
+    #[test]
+    fn deserialize_reject_invalid_uri() {
+        assert!(serde_json::from_str::<StringOrURI>("\":bar\"").is_err());
+    }
+
+    #[test]
+    fn serialize() {
+        let value = StringOrURI::new("http://example.org/#foo").unwrap();
+        assert_eq!(
+            serde_json::to_string(&value).unwrap(),
+            "\"http://example.org/#foo\""
+        );
     }
 }


### PR DESCRIPTION
## Description

`StringOrURI` was an enum with public variants, making it possible to build values that violate the RFC 7519 requirement that a value containing a `:` be a valid URI (e.g. `StringOrURI::String(":bar")`).

Replace it with a newtype around `String` with a private field, so every construction path goes through the validating constructor. Variant matching is replaced by `is_uri`, `as_uri`, `into_uri`; the existing conversions (`TryFrom<String>`, `TryFrom<&str>`, `FromStr`, `From<UriBuf>`) and serialization behaviour are unchanged.

Closes #652

